### PR TITLE
When we say we don't want to depend on setuptools, we shouldn't.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - "2.5"
+  - "2.6"
+  - "2.7"
+script: python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -54,3 +54,6 @@ Have a look at ``COPYING`` file for more information.
 .. _`docs/overview.txt`: docs/overview.html
 .. _`docs/contributing.txt`: docs/contributing.html
 .. _`docs/library.txt`: docs/library.html
+
+.. image:: https://secure.travis-ci.org/mcepl/rope.png
+   :alt: Build Status

--- a/ropetest/__init__.py
+++ b/ropetest/__init__.py
@@ -13,6 +13,9 @@ import ropetest.builtinstest
 import ropetest.historytest
 import ropetest.simplifytest
 
+import ropetest.contrib
+import ropetest.refactor
+
 
 def suite():
     result = unittest.TestSuite()
@@ -27,6 +30,10 @@ def suite():
     result.addTests(ropetest.builtinstest.suite())
     result.addTests(ropetest.historytest.suite())
     result.addTests(ropetest.simplifytest.suite())
+
+    result.addTests(ropetest.refactor.suite())
+    result.addTests(ropetest.contrib.suite())
+
     return result
 
 

--- a/ropetest/testutils.py
+++ b/ropetest/testutils.py
@@ -1,6 +1,9 @@
 import os.path
 import shutil
 import sys
+import logging
+logging.basicConfig(format='%(levelname)s:%(funcName)s:%(message)s',
+                    level=logging.INFO)
 
 import rope.base.project
 from rope.contrib import generate
@@ -12,8 +15,12 @@ def sample_project(root=None, foldername=None, **kwds):
         if foldername:
             root = foldername
         # HACK: Using ``/dev/shm/`` for faster tests
-        if os.name == 'posix' and os.path.isdir('/dev/shm'):
-            root = '/dev/shm/' + root
+        if os.name == 'posix':
+            if os.path.isdir('/dev/shm') and os.access('/dev/shm', os.W_OK):
+                    root = '/dev/shm/' + root
+            elif os.path.isdir('/tmp') and os.access('/tmp', os.W_OK):
+                    root = '/tmp/' + root
+    logging.debug("Using %s as root of the project.", root)
     # Using these prefs for faster tests
     prefs = {'save_objectdb': False, 'save_history': False,
              'validate_objectdb': False, 'automatic_soa': False,
@@ -27,6 +34,7 @@ def sample_project(root=None, foldername=None, **kwds):
 create_module = generate.create_module
 create_package = generate.create_package
 
+
 def remove_project(project):
     project.close()
     remove_recursively(project.address)
@@ -36,7 +44,7 @@ def remove_recursively(path):
     import time
     # windows sometimes raises exceptions instead of removing files
     if os.name == 'nt' or sys.platform == 'cygwin':
-          for i in range(12):
+        for i in range(12):
             try:
                 _remove_recursively(path)
             except OSError, e:
@@ -47,6 +55,7 @@ def remove_recursively(path):
                 break
     else:
         _remove_recursively(path)
+
 
 def _remove_recursively(path):
     if not os.path.exists(path):

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,32 @@
-import glob
-import os
-import shutil
-
-extra_kwargs = {}
-try:
-    # we don't want to depend on setuptools
-    # please don't use any setuptools specific API
-    from setuptools import setup
-    extra_kwargs['test_suite'] = 'ropetest'
-except ImportError:
-    from distutils.core import setup
+from distutils.core import setup, Command
+import unittest
 
 import rope
+import ropetest
+import ropetest.contrib
+import ropetest.refactor
 
 
-classifiers=[
+class RunTests(Command):
+    """New setup.py command to run all tests for the package.
+    """
+    description = "run all tests for the package"
+
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        tests = unittest.TestSuite(ropetest.suite())
+        runner = unittest.TextTestRunner(verbosity=2)
+        runner.run(tests)
+
+
+classifiers = [
     'Development Status :: 4 - Beta',
     'Operating System :: OS Independent',
     'Environment :: X11 Applications',
@@ -26,8 +38,9 @@ classifiers=[
     'Programming Language :: Python',
     'Topic :: Software Development']
 
+
 def get_long_description():
-    lines = open('README.txt').read().splitlines(False)
+    lines = open('README.rst').read().splitlines(False)
     end = lines.index('Getting Started')
     return '\n' + '\n'.join(lines[:end]) + '\n'
 
@@ -42,4 +55,6 @@ setup(name='rope',
                 'rope.refactor.importutils', 'rope.contrib'],
       license='GNU GPL',
       classifiers=classifiers,
-      **extra_kwargs)
+      cmdclass={
+          'test': RunTests,
+      })


### PR DESCRIPTION
Also,
- add support for Travis-CI
- rename README to README.rst
- if /dev/shm is not writeable, use /tmp (for Travis-CI, where /dev/shm
  is not accessible)
