### PR TITLE
Travis-CI doesn’t support python 2.5 anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.5"
   - "2.6"
   - "2.7"
 script: python setup.py test


### PR DESCRIPTION
Unfortunately we won't have an automatic testing for < 2.6
