### PR TITLE
Add '.tox' to default ignored_resources

### DIFF
--- a/rope/base/default_config.py
+++ b/rope/base/default_config.py
@@ -14,7 +14,7 @@ def set_prefs(prefs):
     # 'build/*.o': matches 'build/lib.o' but not 'build/sub/lib.o'
     # 'build//*.o': matches 'build/lib.o' and 'build/sub/lib.o'
     prefs['ignored_resources'] = ['*.pyc', '*~', '.ropeproject',
-                                  '.hg', '.svn', '_svn', '.git']
+                                  '.hg', '.svn', '_svn', '.git', '.tox']
 
     # Specifies which files should be considered python files.  It is
     # useful when you have scripts inside your project.  Only files


### PR DESCRIPTION
Under .tox directory there are many Python files which are not
meant to be edited by hand. Also, having 3.x environments causes
errors when doing refactoring etc.
