### PR TITLE
Make rope work with dynamically loaded modules elsewhere.

### DIFF
--- a/rope/base/stdmods.py
+++ b/rope/base/stdmods.py
@@ -6,11 +6,14 @@ from rope.base import utils
 
 def _stdlib_path():
     import distutils.sysconfig
-    return distutils.sysconfig.get_python_lib(standard_lib=True)
+    return distutils.sysconfig.get_python_lib(standard_lib=True,
+                                              plat_specific=True)
+
 
 @utils.cached(1)
 def standard_modules():
     return python_modules() | dynload_modules()
+
 
 @utils.cached(1)
 def python_modules():
@@ -27,6 +30,7 @@ def python_modules():
                     result.add(name[:-3])
     return result
 
+
 @utils.cached(1)
 def dynload_modules():
     result = set(sys.builtin_module_names)
@@ -35,6 +39,8 @@ def dynload_modules():
         for name in os.listdir(dynload_path):
             path = os.path.join(dynload_path, name)
             if os.path.isfile(path):
-                if name.endswith('.so') or name.endswith('.dll'):
+                if name.endswith('.dll'):
                     result.add(os.path.splitext(name)[0])
+                if name.endswith('.so'):
+                    result.add(os.path.splitext(name)[0].replace('module', ''))
     return result

--- a/ropetest/builtinstest.py
+++ b/ropetest/builtinstest.py
@@ -476,6 +476,10 @@ class BuiltinModulesTest(unittest.TestCase):
         invalid = pymod['invalid'].get_object()
         self.assertTrue('sub' in invalid)
 
+    def test_time_in_std_mods(self):
+        import rope.base.stdmods
+        self.assertTrue('time' in rope.base.stdmods.standard_modules())
+
 
 def suite():
     result = unittest.TestSuite()


### PR DESCRIPTION
E.g., on Fedora-derived Linux distributions `time` (which is not in `sys.builtin_module_names` and it is dynamically loaded from `lib-dynload/timemodule.so`) is not recognized as part of the standard library, which makes ImportUtilsTest.test_sorting_imports_and_standard_modules2 fail (because of superfluous \n included between import of `sys` and `time` modules).

Fixes #38
