### PR TITLE
Move 'get_string_module' and 'get_string_scope' into libutils.

### DIFF
--- a/rope/base/libutils.py
+++ b/rope/base/libutils.py
@@ -3,6 +3,7 @@ import os.path
 
 import rope.base.project
 import rope.base.pycore
+from rope.base import pyobjectsdef
 from rope.base import taskhandle
 
 
@@ -66,3 +67,20 @@ def analyze_modules(project, task_handle=taskhandle.NullTaskHandle()):
         job_set.started_job(resource.path)
         project.pycore.analyze_module(resource)
         job_set.finished_job()
+
+
+def get_string_module(project, code, resource=None, force_errors=False):
+    """Returns a `PyObject` object for the given code
+
+    If `force_errors` is `True`, `exceptions.ModuleSyntaxError` is
+    raised if module has syntax errors.  This overrides
+    ``ignore_syntax_errors`` project config.
+
+    """
+    return pyobjectsdef.PyModule(project.pycore, code, resource,
+                                 force_errors=force_errors)
+
+
+def get_string_scope(project, code, resource=None):
+    """Returns a `Scope` object for the given code"""
+    return get_string_module(project, code, resource).get_scope()

--- a/rope/base/pycore.py
+++ b/rope/base/pycore.py
@@ -103,6 +103,7 @@ class PyCore(object):
             raise ModuleNotFoundError('Module %s not found' % name)
         return self.resource_to_pyobject(module)
 
+    @utils.deprecated('Use `libutils.get_string_module` instead')
     def get_string_module(self, code, resource=None, force_errors=False):
         """Returns a `PyObject` object for the given code
 
@@ -113,6 +114,7 @@ class PyCore(object):
         """
         return PyModule(self, code, resource, force_errors=force_errors)
 
+    @utils.deprecated('Use `libutils.get_string_scope` instead')
     def get_string_scope(self, code, resource=None):
         """Returns a `Scope` object for the given code"""
         return self.get_string_module(code, resource).get_scope()
@@ -196,6 +198,7 @@ class PyCore(object):
     def resource_to_pyobject(self, resource, force_errors=False):
         return self.module_cache.get_pymodule(resource, force_errors)
 
+    @utils.deprecated('Use `project.get_python_files` instead')
     def get_python_files(self):
         """Returns all python files available in the project"""
         return [resource for resource in self.project.get_files()

--- a/rope/contrib/autoimport.py
+++ b/rope/contrib/autoimport.py
@@ -1,7 +1,13 @@
 import re
 
-from rope.base import (exceptions, pynames, resourceobserver,
-                       taskhandle, pyobjects, builtins, resources)
+from rope.base import builtins
+from rope.base import exceptions
+from rope.base import libutils
+from rope.base import pynames
+from rope.base import pyobjects
+from rope.base import resources
+from rope.base import resourceobserver
+from rope.base import taskhandle
 from rope.refactor import importutils
 
 
@@ -130,7 +136,7 @@ class AutoImport(object):
         if match is not None:
             code = code[:match.start()]
         try:
-            pymodule = self.project.pycore.get_string_module(code)
+            pymodule = libutils.get_string_module(self.project, code)
         except exceptions.ModuleSyntaxError:
             return 1
         testmodname = '__rope_testmodule_rope'

--- a/rope/contrib/fixsyntax.py
+++ b/rope/contrib/fixsyntax.py
@@ -1,6 +1,9 @@
 import rope.base.codeanalyze
 import rope.base.evaluate
-from rope.base import worder, exceptions, utils
+from rope.base import exceptions
+from rope.base import libutils
+from rope.base import utils
+from rope.base import worder
 from rope.base.codeanalyze import ArrayLinesAdapter, LogicalLineFinder
 
 
@@ -24,8 +27,9 @@ class FixSyntax(object):
                    self.resource.read() == code:
                     return self.pycore.resource_to_pyobject(self.resource,
                                                             force_errors=True)
-                return self.pycore.get_string_module(
-                    code, resource=self.resource, force_errors=True)
+                return libutils.get_string_module(
+                    self.pycore.project, code, resource=self.resource,
+                    force_errors=True)
             except exceptions.ModuleSyntaxError, e:
                 if msg is None:
                     msg = '%s:%s %s' % (e.filename, e.lineno, e.message_)

--- a/rope/refactor/change_signature.py
+++ b/rope/refactor/change_signature.py
@@ -1,8 +1,12 @@
 import copy
 
 import rope.base.exceptions
-from rope.base import (pyobjects, taskhandle, evaluate, worder, codeanalyze,
-                       utils)
+from rope.base import codeanalyze
+from rope.base import evaluate
+from rope.base import pyobjects
+from rope.base import taskhandle
+from rope.base import utils
+from rope.base import worder
 from rope.base.change import ChangeContents, ChangeSet
 from rope.refactor import occurrences, functionutils
 
@@ -11,7 +15,6 @@ class ChangeSignature(object):
 
     def __init__(self, project, resource, offset):
         self.project = project
-        self.pycore = project.pycore
         self.resource = resource
         self.offset = offset
         self._set_name_and_pyname()

--- a/rope/refactor/encapsulate_field.py
+++ b/rope/refactor/encapsulate_field.py
@@ -1,4 +1,10 @@
-from rope.base import pynames, taskhandle, evaluate, exceptions, worder, utils
+from rope.base import evaluate
+from rope.base import exceptions
+from rope.base import libutils
+from rope.base import pynames
+from rope.base import taskhandle
+from rope.base import utils
+from rope.base import worder
 from rope.base.change import ChangeSet, ChangeContents
 from rope.refactor import sourceutils, occurrences
 
@@ -89,7 +95,8 @@ class EncapsulateField(object):
         new_source = renamer.get_changed_module(pymodule=pymodule,
                                                 skip_start=start, skip_end=end)
         if new_source is not None:
-            pymodule = self.pycore.get_string_module(new_source, self.resource)
+            pymodule = libutils.get_string_module(
+                self.project, new_source, self.resource)
             class_scope = pymodule.get_scope().\
                 get_inner_scope_for_line(class_scope.get_start())
         indents = sourceutils.get_indent(self.pycore) * ' '

--- a/rope/refactor/importutils/__init__.py
+++ b/rope/refactor/importutils/__init__.py
@@ -5,6 +5,7 @@ refactorings or as a separate task.
 
 """
 import rope.base.evaluate
+from rope.base import libutils
 from rope.base.change import ChangeSet, ChangeContents
 from rope.refactor import occurrences, rename
 from rope.refactor.importutils import module_imports, actions
@@ -127,7 +128,8 @@ class ImportTools(object):
                 occurrence_finder, module_name + '.' + name,
                 pymodule=pymodule, replace_primary=True)
             if source is not None:
-                pymodule = self.pycore.get_string_module(source, resource)
+                pymodule = libutils.get_string_module(
+                    self.pycore.project, source, resource)
         return pymodule
 
     def _clean_up_imports(self, pymodule, import_filter):
@@ -136,17 +138,20 @@ class ImportTools(object):
         module_with_imports.expand_stars()
         source = module_with_imports.get_changed_source()
         if source is not None:
-            pymodule = self.pycore.get_string_module(source, resource)
+            pymodule = libutils.get_string_module(
+                self.pycore.project, source, resource)
         source = self.relatives_to_absolutes(pymodule)
         if source is not None:
-            pymodule = self.pycore.get_string_module(source, resource)
+            pymodule = libutils.get_string_module(
+                self.pycore.project, source, resource)
 
         module_with_imports = self.module_imports(pymodule, import_filter)
         module_with_imports.remove_duplicates()
         module_with_imports.remove_unused_imports()
         source = module_with_imports.get_changed_source()
         if source is not None:
-            pymodule = self.pycore.get_string_module(source, resource)
+            pymodule = libutils.get_string_module(
+                self.pycore.project, source, resource)
         return pymodule
 
     def relatives_to_absolutes(self, pymodule, import_filter=None):
@@ -177,8 +182,8 @@ class ImportTools(object):
                 module_imports.remove_duplicates()
             source = module_imports.get_changed_source()
             if source is not None:
-                pymodule = self.pycore.get_string_module(
-                    source, pymodule.get_resource())
+                pymodule = libutils.get_string_module(
+                    self.pycore.project, source, pymodule.get_resource())
         if selfs:
             pymodule = self._remove_self_imports(pymodule, import_filter)
         if sort:
@@ -203,8 +208,8 @@ class ImportTools(object):
         module_imports.get_self_import_fix_and_rename_list()
         source = module_imports.get_changed_source()
         if source is not None:
-            pymodule = self.pycore.get_string_module(source,
-                                                     pymodule.get_resource())
+            pymodule = libutils.get_string_module(
+                self.pycore.project, source, pymodule.get_resource())
         return pymodule
 
     def _rename_in_module(self, pymodule, name, new_name, till_dot=False):
@@ -227,8 +232,8 @@ class ImportTools(object):
             changes.add_change(start, end, new_name)
         source = changes.get_changed()
         if source is not None:
-            pymodule = self.pycore.get_string_module(source,
-                                                     pymodule.get_resource())
+            pymodule = libutils.get_string_module(
+                self.pycore.project, source, pymodule.get_resource())
         return pymodule
 
     def sort_imports(self, pymodule, import_filter=None):
@@ -243,8 +248,8 @@ class ImportTools(object):
         module_imports = self.module_imports(pymodule, import_filter)
         to_be_fixed = module_imports.handle_long_imports(maxdots, maxlength)
         # performing the renaming
-        pymodule = self.pycore.get_string_module(
-            module_imports.get_changed_source(),
+        pymodule = libutils.get_string_module(
+            self.pycore.project, module_imports.get_changed_source(),
             resource=pymodule.get_resource())
         for name in to_be_fixed:
             pymodule = self._rename_in_module(pymodule, name,

--- a/rope/refactor/introduce_factory.py
+++ b/rope/refactor/introduce_factory.py
@@ -1,5 +1,6 @@
 import rope.base.exceptions
 import rope.base.pyobjects
+from rope.base import libutils
 from rope.base import taskhandle, evaluate
 from rope.base.change import (ChangeSet, ChangeContents)
 from rope.refactor import rename, occurrences, sourceutils, importutils
@@ -66,8 +67,8 @@ class IntroduceFactory(object):
                                                     global_)
             if changed_code is not None:
                 if global_:
-                    new_pymodule = self.pycore.get_string_module(changed_code,
-                                                                 self.resource)
+                    new_pymodule = libutils.get_string_module(
+                        self.project, changed_code, self.resource)
                     modname = self.pycore.modname(self.resource)
                     changed_code, imported = importutils.add_import(
                         self.pycore, new_pymodule, modname, factory_name)
@@ -83,8 +84,8 @@ class IntroduceFactory(object):
         if source_code is None:
             source_code = self.pymodule.source_code
         else:
-            self.pymodule = self.pycore.get_string_module(
-                source_code, resource=self.resource)
+            self.pymodule = libutils.get_string_module(
+                self.project, source_code, resource=self.resource)
         lines = self.pymodule.lines
         start = self._get_insertion_offset(class_scope, lines)
         result = source_code[:start]

--- a/rope/refactor/method_object.py
+++ b/rope/refactor/method_object.py
@@ -1,5 +1,6 @@
 import warnings
 
+from rope.base import libutils
 from rope.base import pyobjects, exceptions, change, evaluate, codeanalyze
 from rope.refactor import sourceutils, occurrences, rename
 
@@ -60,7 +61,8 @@ class MethodObject(object):
         body = sourceutils.get_body(self.pyfunction)
         for param in self._get_parameter_names():
             body = param + ' = None\n' + body
-            pymod = self.pycore.get_string_module(body, self.resource)
+            pymod = libutils.get_string_module(
+                self.project, body, self.resource)
             pyname = pymod[param]
             finder = occurrences.create_finder(self.pycore, param, pyname)
             result = rename.rename_in_module(finder, 'self.' + param,

--- a/rope/refactor/rename.py
+++ b/rope/refactor/rename.py
@@ -1,7 +1,7 @@
 import warnings
 
 from rope.base import (exceptions, pyobjects, pynames, taskhandle,
-                       evaluate, worder, codeanalyze)
+                       evaluate, worder, codeanalyze, libutils)
 from rope.base.change import ChangeSet, ChangeContents, MoveResource
 from rope.refactor import occurrences
 
@@ -31,7 +31,7 @@ class Rename(object):
         else:
             if not resource.is_folder() and resource.name == '__init__.py':
                 resource = resource.parent
-            dummy_pymodule = self.pycore.get_string_module('')
+            dummy_pymodule = libutils.get_string_module(self.project, '')
             self.old_instance = None
             self.old_pyname = pynames.ImportedModule(dummy_pymodule,
                                                      resource=resource)

--- a/rope/refactor/restructure.py
+++ b/rope/refactor/restructure.py
@@ -1,6 +1,7 @@
 import warnings
 
 from rope.base import change, taskhandle, builtins, ast, codeanalyze
+from rope.base import libutils
 from rope.refactor import patchedast, similarfinder, sourceutils
 from rope.refactor.importutils import module_imports
 
@@ -162,15 +163,15 @@ class Restructure(object):
         if not imports:
             return source
         import_infos = self._get_import_infos(resource, imports)
-        pymodule = self.pycore.get_string_module(source, resource)
+        pymodule = libutils.get_string_module(self.project, source, resource)
         imports = module_imports.ModuleImports(self.pycore, pymodule)
         for import_info in import_infos:
             imports.add_import(import_info)
         return imports.get_changed_source()
 
     def _get_import_infos(self, resource, imports):
-        pymodule = self.pycore.get_string_module('\n'.join(imports),
-                                                 resource)
+        pymodule = libutils.get_string_module(
+            self.project, '\n'.join(imports), resource)
         imports = module_imports.ModuleImports(self.pycore, pymodule)
         return [imports.import_info
                 for imports in imports.imports]

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -1,5 +1,6 @@
 from rope.base import (change, taskhandle, evaluate,
                        exceptions, pyobjects, pynames, ast)
+from rope.base import libutils
 from rope.refactor import restructure, sourceutils, similarfinder
 
 
@@ -122,7 +123,7 @@ class UseFunction(object):
 
 def find_temps(project, code):
     code = 'def f():\n' + sourceutils.indent_lines(code, 4)
-    pymodule = project.pycore.get_string_module(code)
+    pymodule = libutils.get_string_module(project, code)
     result = []
     function_scope = pymodule.get_scope().get_scopes()[0]
     for name, pyname in function_scope.get_names().items():

--- a/ropetest/builtinstest.py
+++ b/ropetest/builtinstest.py
@@ -1,5 +1,6 @@
 import unittest
 
+from rope.base import libutils
 from rope.base import pyobjects, builtins
 from ropetest import testutils
 
@@ -436,7 +437,7 @@ class BuiltinTypesTest(unittest.TestCase):
 
     def test_binary_or_left_value_unknown(self):
         code = 'var = (asdsd or 3)\n'
-        pymod = self.pycore.get_string_module(code)
+        pymod = libutils.get_string_module(self.project, code)
         self.assertEquals(builtins.builtins['int'].get_object(),
                           pymod['var'].get_object().get_type())
 

--- a/ropetest/pyscopestest.py
+++ b/ropetest/pyscopestest.py
@@ -1,5 +1,6 @@
 import unittest
 
+from rope.base import libutils
 from rope.base.pyobjects import get_base_type
 from ropetest import testutils
 
@@ -16,20 +17,22 @@ class PyCoreScopesTest(unittest.TestCase):
         super(PyCoreScopesTest, self).tearDown()
 
     def test_simple_scope(self):
-        scope = self.pycore.get_string_scope('def sample_func():\n    pass\n')
+        scope = libutils.get_string_scope(
+            self.project, 'def sample_func():\n    pass\n')
         sample_func = scope['sample_func'].get_object()
         self.assertEquals(get_base_type('Function'), sample_func.get_type())
 
     def test_simple_function_scope(self):
-        scope = self.pycore.get_string_scope(
-            'def sample_func():\n    a = 10\n')
+        scope = libutils.get_string_scope(
+            self.project, 'def sample_func():\n    a = 10\n')
         self.assertEquals(1, len(scope.get_scopes()))
         sample_func_scope = scope.get_scopes()[0]
         self.assertEquals(1, len(sample_func_scope.get_names()))
         self.assertEquals(0, len(sample_func_scope.get_scopes()))
 
     def test_classes_inside_function_scopes(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'def sample_func():\n'
             '    class SampleClass(object):\n        pass\n')
         self.assertEquals(1, len(scope.get_scopes()))
@@ -39,7 +42,8 @@ class PyCoreScopesTest(unittest.TestCase):
                           get_object().get_type())
 
     def test_simple_class_scope(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'class SampleClass(object):\n'
             '    def f(self):\n        var = 10\n')
         self.assertEquals(1, len(scope.get_scopes()))
@@ -50,15 +54,16 @@ class PyCoreScopesTest(unittest.TestCase):
         self.assertTrue('var' in f_in_class)
 
     def test_get_lineno(self):
-        scope = self.pycore.get_string_scope(
-            '\ndef sample_func():\n    a = 10\n')
+        scope = libutils.get_string_scope(
+            self.project, '\ndef sample_func():\n    a = 10\n')
         self.assertEquals(1, len(scope.get_scopes()))
         sample_func_scope = scope.get_scopes()[0]
         self.assertEquals(1, scope.get_start())
         self.assertEquals(2, sample_func_scope.get_start())
 
     def test_scope_kind(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'class SampleClass(object):\n    pass\n'
             'def sample_func():\n    pass\n')
         sample_class_scope = scope.get_scopes()[0]
@@ -68,19 +73,21 @@ class PyCoreScopesTest(unittest.TestCase):
         self.assertEquals('Function', sample_func_scope.get_kind())
 
     def test_function_parameters_in_scope_names(self):
-        scope = self.pycore.get_string_scope(
-            'def sample_func(param):\n    a = 10\n')
+        scope = libutils.get_string_scope(
+            self.project, 'def sample_func(param):\n    a = 10\n')
         sample_func_scope = scope.get_scopes()[0]
         self.assertTrue('param' in sample_func_scope)
 
     def test_get_names_contains_only_names_defined_in_a_scope(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'var1 = 10\ndef sample_func(param):\n    var2 = 20\n')
         sample_func_scope = scope.get_scopes()[0]
         self.assertTrue('var1' not in sample_func_scope)
 
     def test_scope_lookup(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'var1 = 10\ndef sample_func(param):\n    var2 = 20\n')
         self.assertTrue(scope.lookup('var2') is None)
         self.assertEquals(get_base_type('Function'),
@@ -89,42 +96,47 @@ class PyCoreScopesTest(unittest.TestCase):
         self.assertTrue(sample_func_scope.lookup('var1') is not None)
 
     def test_function_scopes(self):
-        scope = self.pycore.get_string_scope('def func():\n    var = 10\n')
+        scope = libutils.get_string_scope(
+            self.project, 'def func():\n    var = 10\n')
         func_scope = scope.get_scopes()[0]
         self.assertTrue('var' in func_scope)
 
     def test_function_scopes_classes(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'def func():\n    class Sample(object):\n        pass\n')
         func_scope = scope.get_scopes()[0]
         self.assertTrue('Sample' in func_scope)
 
     def test_function_getting_scope(self):
-        mod = self.pycore.get_string_module('def func():    var = 10\n')
+        mod = libutils.get_string_module(
+            self.project, 'def func():    var = 10\n')
         func_scope = mod['func'].get_object().get_scope()
         self.assertTrue('var' in func_scope)
 
     def test_scopes_in_function_scopes(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'def func():\n    def inner():\n        var = 10\n')
         func_scope = scope.get_scopes()[0]
         inner_scope = func_scope.get_scopes()[0]
         self.assertTrue('var' in inner_scope)
 
     def test_for_variables_in_scopes(self):
-        scope = self.pycore.get_string_scope(
-            'for a_var in range(10):\n    pass\n')
+        scope = libutils.get_string_scope(
+            self.project, 'for a_var in range(10):\n    pass\n')
         self.assertTrue('a_var' in scope)
 
     def test_assists_inside_fors(self):
-        scope = self.pycore.get_string_scope(
-            'for i in range(10):\n    a_var = i\n')
+        scope = libutils.get_string_scope(
+            self.project, 'for i in range(10):\n    a_var = i\n')
         self.assertTrue('a_var' in scope)
 
     def test_first_parameter_of_a_method(self):
         code = 'class AClass(object):\n' \
                '    def a_func(self, param):\n        pass\n'
-        a_class = self.pycore.get_string_module(code)['AClass']. get_object()
+        a_class = libutils.get_string_module(self.project, code)['AClass'].\
+            get_object()
         function_scope = a_class['a_func'].get_object().get_scope()
         self.assertEquals(a_class,
                           function_scope['self'].get_object().get_type())
@@ -134,7 +146,8 @@ class PyCoreScopesTest(unittest.TestCase):
     def test_first_parameter_of_static_methods(self):
         code = 'class AClass(object):\n' \
                '    @staticmethod\n    def a_func(param):\n        pass\n'
-        a_class = self.pycore.get_string_module(code)['AClass']. get_object()
+        a_class = libutils.get_string_module(self.project, code)['AClass'].\
+            get_object()
         function_scope = a_class['a_func'].\
             get_object().get_scope()
         self.assertNotEquals(a_class,
@@ -143,7 +156,8 @@ class PyCoreScopesTest(unittest.TestCase):
     def test_first_parameter_of_class_methods(self):
         code = 'class AClass(object):\n' \
             '    @classmethod\n    def a_func(cls):\n        pass\n'
-        a_class = self.pycore.get_string_module(code)['AClass']. get_object()
+        a_class = libutils.get_string_module(self.project, code)['AClass'].\
+            get_object()
         function_scope = a_class['a_func'].get_object().get_scope()
         self.assertEquals(a_class, function_scope['cls'].get_object())
 
@@ -151,13 +165,15 @@ class PyCoreScopesTest(unittest.TestCase):
         code = 'def my_decorator(func):\n    return func\n'\
                'class AClass(object):\n' \
                '    @my_decorator\n    def a_func(self):\n        pass\n'
-        a_class = self.pycore.get_string_module(code)['AClass']. get_object()
+        a_class = libutils.get_string_module(self.project, code)['AClass'].\
+            get_object()
         function_scope = a_class['a_func'].get_object().get_scope()
         self.assertEquals(a_class, function_scope['self'].
                           get_object().get_type())
 
     def test_inside_class_scope_attribute_lookup(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'class C(object):\n'
             '    an_attr = 1\n'
             '    def a_func(self):\n        pass')
@@ -169,7 +185,8 @@ class PyCoreScopesTest(unittest.TestCase):
         self.assertTrue(f_in_c.lookup('an_attr') is None)
 
     def test_inside_class_scope_attribute_lookup2(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'class C(object):\n'
             '    def __init__(self):\n        self.an_attr = 1\n'
             '    def a_func(self):\n        pass')
@@ -179,7 +196,8 @@ class PyCoreScopesTest(unittest.TestCase):
         self.assertTrue(f_in_c.lookup('an_attr') is None)
 
     def test_get_inner_scope_for_staticmethods(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'class C(object):\n'
             '    @staticmethod\n'
             '    def a_func(self):\n        pass\n')
@@ -188,20 +206,21 @@ class PyCoreScopesTest(unittest.TestCase):
         self.assertEquals(f_in_c, scope.get_inner_scope_for_line(4))
 
     def test_getting_overwritten_scopes(self):
-        scope = self.pycore.get_string_scope(
-            'def f():\n    pass\ndef f():\n    pass\n')
+        scope = libutils.get_string_scope(
+            self.project, 'def f():\n    pass\ndef f():\n    pass\n')
         self.assertEquals(2, len(scope.get_scopes()))
         f1_scope = scope.get_scopes()[0]
         f2_scope = scope.get_scopes()[1]
         self.assertNotEquals(f1_scope, f2_scope)
 
     def test_assigning_builtin_names(self):
-        mod = self.pycore.get_string_module('range = 1\n')
+        mod = libutils.get_string_module(self.project, 'range = 1\n')
         range = mod.get_scope().lookup('range')
         self.assertEquals((mod, 1), range.get_definition_location())
 
     def test_get_inner_scope_and_logical_lines(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'class C(object):\n'
             '    def f():\n        s = """\n1\n2\n"""\n        a = 1\n')
         c_scope = scope.get_scopes()[0]
@@ -209,7 +228,8 @@ class PyCoreScopesTest(unittest.TestCase):
         self.assertEquals(f_in_c, scope.get_inner_scope_for_line(7))
 
     def test_getting_defined_names_for_classes(self):
-        scope = self.pycore.get_string_scope(
+        scope = libutils.get_string_scope(
+            self.project,
             'class A(object):\n    def a(self):\n        pass\n'
             'class B(A):\n    def b(self):\n        pass\n')
         a_scope = scope['A'].get_object().get_scope()  # noqa
@@ -220,8 +240,8 @@ class PyCoreScopesTest(unittest.TestCase):
         self.assertTrue('b' in b_scope.get_defined_names())
 
     def test_getting_defined_names_for_modules(self):
-        scope = self.pycore.get_string_scope(
-            'class A(object):\n    pass\n')
+        scope = libutils.get_string_scope(
+            self.project, 'class A(object):\n    pass\n')
         self.assertTrue('open' in scope.get_names())
         self.assertTrue('A' in scope.get_names())
         self.assertTrue('open' not in scope.get_defined_names())


### PR DESCRIPTION
These methods didn't use anything within the 'pycore' object except to
pass that in as a parameter. It's better to have people call a library
function instead and use the 'project' object without having to access
'pycore' directly.

No functionality change intended.
