### PR TITLE
Catch OSError when a folder can't be read.

### DIFF
--- a/rope/base/resources.py
+++ b/rope/base/resources.py
@@ -142,8 +142,12 @@ class Folder(Resource):
 
     def get_children(self):
         """Return the children of this folder"""
+        try:
+            children = os.listdir(self.real_path)
+        except OSError:
+            return []
         result = []
-        for name in os.listdir(self.real_path):
+        for name in children:
             try:
                 child = self.get_child(name)
             except exceptions.ResourceNotFoundError:

--- a/ropetest/projecttest.py
+++ b/ropetest/projecttest.py
@@ -1,3 +1,4 @@
+import os
 import os.path
 try:
     import unittest2 as unittest
@@ -221,6 +222,18 @@ class ProjectTest(unittest.TestCase):
                         filePath == children[1].path)
         self.assertTrue(folderPath == children[0].path or
                         folderPath == children[1].path)
+
+    def test_does_not_fail_for_permission_denied(self):
+        bad_dir = os.path.join(self.sample_folder, "bad_dir")
+        os.makedirs(bad_dir)
+        os.chmod(bad_dir, 0o000)
+        try:
+            parent = self.project.get_resource(self.sample_folder)
+
+            parent.get_children()
+
+        finally:
+            os.chmod(bad_dir, 0o755)
 
     def test_getting_files(self):
         files = self.project.root.get_files()


### PR DESCRIPTION
When traversing a directory tree, e.g. the project root, and a
directory is not readable anymore, catch and ignore this error.

Couldn't find an appropriate place for a unit test for this. Would require setting up a directory tree with one directory being chmod 000.
