### PR TITLE
Rename to be more descriptive and take a project object.

### DIFF
--- a/docs/library.rst
+++ b/docs/library.rst
@@ -310,6 +310,17 @@ resource.
   module_name = libutils.modname(resource)
 
 
+``libutils.path_relative_to_project_root()``
+--------------------------------------------
+
+Retrieve the path relative to the project's root directory.
+
+.. code-block:: python
+
+  # Get the path relative to the project's root directory.
+  relpath = libutils.relative(myproject.address, path)
+
+
 ``libutils.path_to_resource()``
 -------------------------------
 
@@ -324,17 +335,6 @@ values for ``type`` are the strings ``'file'`` or ``'folder'``.
 
   # Resource for a non-existing folder.
   new_folder = libutils.path_to_resource(myproject, '/path/to/folder', type='folder')
-
-
-``libutils.relative()``
------------------------
-
-Retrieve the path relative to the ``root``.
-
-.. code-block:: python
-
-  # Get the path relative to the project's root directory.
-  relpath = libutils.relative(myproject.address, path)
 
 
 ``libutils.report_change()``

--- a/rope/base/libutils.py
+++ b/rope/base/libutils.py
@@ -4,6 +4,7 @@ import os.path
 import rope.base.project
 import rope.base.pycore
 from rope.base import pyobjectsdef
+from rope.base import utils
 from rope.base import taskhandle
 
 
@@ -18,7 +19,7 @@ def path_to_resource(project, path, type=None):
     `Project.get_file()`, and `Project.get_folder()` methods.
 
     """
-    project_path = relative(project.address, path)
+    project_path = path_relative_to_project_root(project, path)
     if project_path is None:
         project_path = rope.base.project._realpath(path)
         project = rope.base.project.get_no_project()
@@ -31,6 +32,10 @@ def path_to_resource(project, path, type=None):
     return None
 
 
+def path_relative_to_project_root(project, path):
+    return relative(project.address, path)
+
+@utils.deprecated()
 def relative(root, path):
     root = rope.base.project._realpath(root).replace(os.path.sep, '/')
     path = rope.base.project._realpath(path).replace(os.path.sep, '/')

--- a/rope/base/oi/transform.py
+++ b/rope/base/oi/transform.py
@@ -278,8 +278,8 @@ class DOITextualToPyObject(TextualToPyObject):
 
     def path_to_resource(self, path):
         import rope.base.libutils
-        root = self.project.address
-        relpath = rope.base.libutils.relative(root, path)
+        relpath = rope.base.libutils.path_relative_to_project_root(
+            self.project, path)
         if relpath is not None:
             path = relpath
         return super(DOITextualToPyObject, self).path_to_resource(path)


### PR DESCRIPTION
The 'relative' function was only being used to get the path relative to the project's root. This changes the API to take the project object and renamed to make it explicit what's happening.
