### PR TITLE
Inlining variable into string constants

### DIFF
--- a/rope/base/codeanalyze.py
+++ b/rope/base/codeanalyze.py
@@ -355,7 +355,7 @@ def count_line_indents(line):
 def get_string_pattern():
     start = r'(\b[uU]?[rR]?)?'
     longstr = r'%s"""(\\.|"(?!"")|\\\n|[^"\\])*"""' % start
-    shortstr = r'%s"(\\.|[^"\\\n])*"' % start
+    shortstr = r'%s"(\\.|\\\n|[^"\\])*"' % start
     return '|'.join([longstr, longstr.replace('"', "'"),
                      shortstr, shortstr.replace('"', "'")])
 

--- a/ropetest/refactor/inlinetest.py
+++ b/ropetest/refactor/inlinetest.py
@@ -625,6 +625,28 @@ class InlineTest(unittest.TestCase):
         self.assertEquals(code1, self.mod.read())
         self.assertEquals(expected2, self.mod2.read())
 
+    def test_inlining_does_not_change_string_constants(self):
+        code = 'var = 1\n' \
+               'print("var\\\n' \
+               '")\n'
+        expected = 'var = 1\n' \
+                   'print("var\\\n' \
+                   '")\n'
+        refactored = self._inline(code, code.rindex('var'),
+                                  remove=False, only_current=True, docs=False)
+        self.assertEquals(expected, refactored)
+
+    def test_inlining_does_change_string_constants_if_docs_is_set(self):
+        code = 'var = 1\n' \
+               'print("var\\\n' \
+               '")\n'
+        expected = 'var = 1\n' \
+                   'print("1\\\n' \
+                   '")\n'
+        refactored = self._inline(code, code.rindex('var'),
+                                  remove=False, only_current=True, docs=True)
+        self.assertEquals(expected, refactored)
+
 
 def suite():
     result = unittest.TestSuite()


### PR DESCRIPTION
Edit: I've added a rudimentary test case and possible fix. Now if someone can tell me how the `docs` parameter can be made to show up in Emacs when the inlining is attempted, I'd be very grateful.

In the following example in all but the last three cases the variable `bar` is wrongly inlined into string constants:

```
def foo():
    bar = 42

    # incorrect, same with single quotes, r"", b"", u""
    print("bar\
")

    # correct, same with r"""""", b"""""", u""""""
    print("""bar\
""")
```
