### PR TITLE
Updated the build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
+sudo: false
 python:
   - "2.6"
   - "2.7"
 before_script:
-  - '[ "${TRAVIS_PYTHON_VERSION}" = "2.6" ] && pip install --use-mirrors unittest2 || /bin/true'
+  - '[ "${TRAVIS_PYTHON_VERSION}" = "2.6" ] && travis_retry pip install unittest2 || /bin/true'
 script: python setup.py test


### PR DESCRIPTION
Use travis' new build worker and travis_retry instead of --use-mirrors since it's deprecated.
The new travis worker is faster to boot and if the build doesn't use sudo it's possible to use it.
