### PR TITLE
Fix extract method with list comprehension.

### DIFF
--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -888,5 +888,71 @@ class ExtractMethodTest(unittest.TestCase):
                    "    return a\n"
         self.assertEquals(expected, refactored)
 
+    def test_extract_method_with_list_comprehension(self):
+        code = "def foo():\n" \
+               "    x = [e for e in []]\n" \
+               "    f = 23\n" \
+               "\n" \
+               "    for e, f in []:\n" \
+               "        def bar():\n" \
+               "            e[42] = 1\n"
+        start, end = self._convert_line_range_to_offset(code, 4, 7)
+        refactored = self.do_extract_method(code, start, end, 'baz')
+        expected = "def foo():\n" \
+                   "    x = [e for e in []]\n" \
+                   "    f = 23\n" \
+                   "\n" \
+                   "    baz()\n" \
+                   "\n" \
+                   "def baz():\n" \
+                   "    for e, f in []:\n" \
+                   "        def bar():\n" \
+                   "            e[42] = 1\n"
+        self.assertEquals(expected, refactored)
+
+    def test_extract_method_with_list_comprehension_and_iter(self):
+        code = "def foo():\n" \
+               "    x = [e for e in []]\n" \
+               "    f = 23\n" \
+               "\n" \
+               "    for x, f in x:\n" \
+               "        def bar():\n" \
+               "            x[42] = 1\n"
+        start, end = self._convert_line_range_to_offset(code, 4, 7)
+        refactored = self.do_extract_method(code, start, end, 'baz')
+        expected = "def foo():\n" \
+                   "    x = [e for e in []]\n" \
+                   "    f = 23\n" \
+                   "\n" \
+                   "    baz(x)\n" \
+                   "\n" \
+                   "def baz(x):\n" \
+                   "    for x, f in x:\n" \
+                   "        def bar():\n" \
+                   "            x[42] = 1\n"
+        self.assertEquals(expected, refactored)
+
+    def test_extract_method_with_list_comprehension_and_orelse(self):
+        code = "def foo():\n" \
+               "    x = [e for e in []]\n" \
+               "    f = 23\n" \
+               "\n" \
+               "    for e, f in []:\n" \
+               "        def bar():\n" \
+               "            e[42] = 1\n"
+        start, end = self._convert_line_range_to_offset(code, 4, 7)
+        refactored = self.do_extract_method(code, start, end, 'baz')
+        expected = "def foo():\n" \
+                   "    x = [e for e in []]\n" \
+                   "    f = 23\n" \
+                   "\n" \
+                   "    baz()\n" \
+                   "\n" \
+                   "def baz():\n" \
+                   "    for e, f in []:\n" \
+                   "        def bar():\n" \
+                   "            e[42] = 1\n"
+        self.assertEquals(expected, refactored)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should fix https://github.com/python-rope/rope/issues/102. I've added three test cases which test my original problem and then also two variants on that where the extraction should actually add another read parameter and one where the `else` case of the loop reads variables.

Now I've implemented this by looking at that file, but really, if you can suggest anything to clean it up I'd be very grateful.