### PR TITLE
Wrong parameter default value in Inline Parameter

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -551,7 +551,7 @@ after inlining p2 parameter will have:
 
 .. code-block:: python
 
-  def f(p1=1, p2=1):
+  def f(p1=1, p2=2):
       pass
 
   f(3, 2)


### PR DESCRIPTION
The default value in the Inline Parameter example was 1, and when using Inline was passing 2.