### PR TITLE
add support for DictComp and SetComp to patched_ast

### DIFF
--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -493,6 +493,19 @@ class _PatchingASTWalker(object):
         children.append(']')
         self._handle(node, children)
 
+    def _SetComp(self, node):
+        children = ['{', node.elt]
+        children.extend(node.generators)
+        children.append('}')
+        self._handle(node, children)
+
+    def _DictComp(self, node):
+        children = ['{']
+        children.extend([node.key, ':', node.value])
+        children.extend(node.generators)
+        children.append('}')
+        self._handle(node, children)
+    
     def _Module(self, node):
         self._handle(node, list(node.body), eat_spaces=True)
 

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -578,6 +578,43 @@ class PatchedASTTest(unittest.TestCase):
             'comprehension', ['for', ' ', 'Name', ' ', 'in', ' ',
                               'Call', ' ', 'if', ' ', 'Name'])
 
+    def test_set_comp_node(self):
+        # make sure we are in a python version with set comprehensions
+        source = '{i for i in range(1) if True}\n'
+
+        try:
+            eval(source)
+        except SyntaxError:
+            return
+
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_region('SetComp', 0, len(source) - 1)
+        checker.check_children(
+            'SetComp', ['{', '', 'Name', ' ', 'comprehension', '', '}'])
+        checker.check_children(
+            'comprehension', ['for', ' ', 'Name', ' ', 'in', ' ',
+                              'Call', ' ', 'if', ' ', 'Name'])
+
+    def test_dict_comp_node(self):
+        # make sure we are in a python version with dict comprehensions
+        source = '{i:i for i in range(1) if True}\n'
+
+        try:
+            eval(source)
+        except SyntaxError:
+            return
+
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_region('DictComp', 0, len(source) - 1)
+        checker.check_children(
+            'DictComp', ['{', '', 'Name', '', ':', '', 'Name',
+                         ' ', 'comprehension', '', '}'])
+        checker.check_children(
+            'comprehension', ['for', ' ', 'Name', ' ', 'in', ' ',
+                              'Call', ' ', 'if', ' ', 'Name'])
+
     def test_ext_slice_node(self):
         source = 'x = xs[0,:]\n'
         ast_frag = patchedast.get_patched_ast(source, True)


### PR DESCRIPTION
This fixes a specific bug I had where I could not use extract_method feature if the code being extracted had a set or dict comprehension.  This was due to patched_ast not adding region information to anything in those parts of the ast and so the code could not be reconstructed.