### PR TITLE
Remove note about project moving to python-rope/rope

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,4 @@
 
-**Note:** *Please note that this project has been moved to* `GitHub python-rope / rope`_
-
 .. _GitHub python-rope / rope: https://github.com/python-rope/rope
 
 


### PR DESCRIPTION
'Cos this project is already at github.com/python-rope/rope