### PR TITLE
Bugfix for parsing strings with extra quote characters

### DIFF
--- a/ropetest/codeanalyzetest.py
+++ b/ropetest/codeanalyzetest.py
@@ -568,6 +568,16 @@ class LogicalLineFinderTest(unittest.TestCase):
         line_finder = self._logical_finder(code)
         self.assertEquals((1, 1), line_finder.logical_line_in(1))
 
+    def test_logical_lines_for_multiline_string_with_extra_quotes_front(self):
+        code = '""""Docs."""\na = 1\n'
+        line_finder = self._logical_finder(code)
+        self.assertEquals((2, 2), line_finder.logical_line_in(2))
+
+    def test_logical_lines_for_multiline_string_with_escaped_quotes(self):
+        code = '"""Quotes \\""" "\\"" \' """\na = 1\n'
+        line_finder = self._logical_finder(code)
+        self.assertEquals((2, 2), line_finder.logical_line_in(2))
+
     def test_generating_line_starts(self):
         code = 'a = 1\na = 2\n\na = 3\n'
         line_finder = self._logical_finder(code)


### PR DESCRIPTION
Hello,
I had an issue with rope crashing or giving truly bizarre results when moving/renaming specific modules, which I tracked down to how rope parses the source files. Any file which contains a multiline string that starts with more than 3 quote characters would cause it to incorrectly compute the logical line numbers for each scope. I've adjusted the RE which is used to delimit scopes and added some new tests for this case.

For example, `""""Hello, world!" example."""` is a valid python string that rope does not handle correctly.