### PR TITLE
Preserve whitespace before the first import statements

### DIFF
--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -223,6 +223,9 @@ class ModuleImports(object):
         if self.pymodule.get_doc() is not None:
             lineno = 1
         if len(nodes) > lineno:
+            if (isinstance(nodes[lineno], ast.Import) or
+                isinstance(nodes[lineno], ast.ImportFrom)):
+                return nodes[lineno].lineno
             lineno = self.pymodule.logical_lines.logical_line_in(
                 nodes[lineno].lineno)[0]
         else:

--- a/ropetest/refactor/importutilstest.py
+++ b/ropetest/refactor/importutilstest.py
@@ -856,6 +856,15 @@ class ImportUtilsTest(unittest.TestCase):
             '"""\ndocs\n"""\nimport mod\n\n\ndef f():\n    print(mod)\n',
             self.import_tools.sort_imports(pymod))
 
+    def test_sorting_imports_moving_to_top_and_module_docs2(self):
+        self.mod.write('"""\ndocs\n"""\n\n\nimport bbb\nimport aaa\n'
+                       'def f():\n    print(mod)\nimport mod\n')
+        pymod = self.project.get_module('mod')
+        self.assertEquals(
+            '"""\ndocs\n"""\n\n\nimport aaa\nimport bbb\n\n'
+            'import mod\n\n\ndef f():\n    print(mod)\n',
+            self.import_tools.sort_imports(pymod))
+
     def test_sorting_future_imports(self):
         self.mod.write('import os\nfrom __future__ import devision\n')
         pymod = self.project.get_module('mod')

--- a/ropetest/refactor/movetest.py
+++ b/ropetest/refactor/movetest.py
@@ -335,7 +335,8 @@ class MoveRefactoringTest(unittest.TestCase):
 
     def test_moving_package_and_retaining_blank_lines(self):
         pkg2 = testutils.create_package(self.project, 'pkg2', self.pkg)
-        code = ('import pkg.mod4\n\n'
+        code = ('"""Docstring followed by blank lines."""\n\n'
+                'import pkg.mod4\n\n'
                 'from pkg import mod4\n'
                 'from x import y\n'
                 'from y import z\n'
@@ -345,7 +346,8 @@ class MoveRefactoringTest(unittest.TestCase):
                 'print(mod4)')
         self.mod1.write(code)
         self._move(self.mod4, None, pkg2)
-        expected = ('import pkg.pkg2.mod4\n\n'
+        expected = ('"""Docstring followed by blank lines."""\n\n'
+                    'import pkg.pkg2.mod4\n\n'
                     'from x import y\n'
                     'from y import z\n'
                     'from a import b\n'


### PR DESCRIPTION
If there are import statements already at the top of the module, replace
the imports at the same position. This changes the notion of "first
import line" in the case when the module has an existing import as
the first statement after the docstring (if any).