### PR TITLE
Don't change kwarg names when moving modules.

### DIFF
--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -605,7 +605,8 @@ class _MoveTools(object):
 
     def _create_finder(self, imports):
         return occurrences.create_finder(self.project, self.old_name,
-                                         self.old_pyname, imports=imports)
+                                         self.old_pyname, imports=imports,
+                                         keywords=False)
 
     def new_pymodule(self, pymodule, source):
         if source is not None:

--- a/rope/refactor/occurrences.py
+++ b/rope/refactor/occurrences.py
@@ -30,6 +30,9 @@ calling the `create_finder()` function.
 
   * `instance`: Used only when you want implicit interfaces to be
     considered.
+
+  * `keywords`: If False, don't return instances that are the names of keyword
+    arguments
 """
 
 import re
@@ -81,7 +84,8 @@ class Finder(object):
 
 
 def create_finder(project, name, pyname, only_calls=False, imports=True,
-                  unsure=None, docs=False, instance=None, in_hierarchy=False):
+                  unsure=None, docs=False, instance=None, in_hierarchy=False,
+                  keywords=True):
     """A factory for `Finder`
 
     Based on the arguments it creates a list of filters.  `instance`
@@ -95,6 +99,8 @@ def create_finder(project, name, pyname, only_calls=False, imports=True,
         filters.append(CallsFilter())
     if not imports:
         filters.append(NoImportsFilter())
+    if not keywords:
+        filters.append(NoKeywordsFilter())
     if isinstance(instance, pynames.ParameterName):
         for pyobject in instance.get_objects():
             try:
@@ -162,6 +168,10 @@ class Occurrence(object):
 
     def is_unsure(self):
         return unsure_pyname(self.get_pyname())
+
+    def is_function_keyword_parameter(self):
+        return self.tools.word_finder.is_function_keyword_parameter(
+            self.offset)
 
     @property
     @utils.saveit
@@ -271,6 +281,14 @@ class CallsFilter(object):
 
     def __call__(self, occurrence):
         if not occurrence.is_called():
+            return False
+
+
+class NoKeywordsFilter(object):
+    """Filter out keyword parameters."""
+
+    def __call__(self, occurrence):
+        if occurrence.is_function_keyword_parameter():
             return False
 
 

--- a/ropetest/refactor/movetest.py
+++ b/ropetest/refactor/movetest.py
@@ -174,6 +174,15 @@ class MoveRefactoringTest(unittest.TestCase):
         expected = 'import pkg.mod5\nprint(pkg.mod5)\n'
         self.assertEquals(expected, moved.read())
 
+    def test_moving_module_kwarg_same_name_as_old(self):
+        self.mod1.write('def foo(mod1=0):\n    pass')
+        code = 'import mod1\nmod1.foo(mod1=1)'
+        self.mod2.write(code)
+        self._move(self.mod1, None, self.pkg)
+        moved = self.project.find_module('mod2')
+        expected = 'import pkg.mod1\npkg.mod1.foo(mod1=1)'
+        self.assertEquals(expected, moved.read())
+
     def test_moving_packages(self):
         pkg2 = testutils.create_package(self.project, 'pkg2')
         code = 'import pkg.mod4\nprint(pkg.mod4)'


### PR DESCRIPTION
This fixes the following error:

```python
rope.base.exceptions.ModuleSyntaxError: Syntax Error in file <...> line <...>: keyword can't be an expression
```

This error comes from having a kwarg in a function with the same name as
the module you're moving. This change fixes this by adding a filter to
ignore keyword parameter names, which is used on the move module
refactor.