### PR TITLE
Remove whitespace along with import statements

### DIFF
--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -97,13 +97,19 @@ class ModuleImports(object):
     def _remove_imports(self, imports):
         lines = self.pymodule.source_code.splitlines(True)
         after_removing = []
+        first_import_line = self._first_import_line()
         last_index = 0
         for stmt in imports:
             start, end = stmt.get_old_location()
-            after_removing.extend(lines[last_index:start - 1])
+            blank_lines = 0
+            if start != first_import_line:
+              for lineno in range(start - 2, last_index - 1, -1):
+                  if lines[lineno].strip() == '':
+                      blank_lines += 1
+                  else:
+                      break
+            after_removing.extend(lines[last_index:start - 1 - blank_lines])
             last_index = end - 1
-            for i in range(start, end):
-                after_removing.append('')
         after_removing.extend(lines[last_index:])
         return after_removing
 

--- a/ropetest/refactor/importutilstest.py
+++ b/ropetest/refactor/importutilstest.py
@@ -865,6 +865,17 @@ class ImportUtilsTest(unittest.TestCase):
             'import mod\n\n\ndef f():\n    print(mod)\n',
             self.import_tools.sort_imports(pymod))
 
+    def test_get_changed_source_preserves_blank_lines(self):
+        self.mod.write(
+            '__author__ = "author"\n\nimport aaa\n\nimport bbb\n\n'
+            'def f():\n    print(mod)\n')
+        pymod = self.project.get_module('mod')
+        module_with_imports = self.import_tools.module_imports(pymod)
+        self.assertEquals(
+            'import aaa\n\nimport bbb\n\n__author__ = "author"\n\n'
+            'def f():\n    print(mod)\n',
+            module_with_imports.get_changed_source())
+
     def test_sorting_future_imports(self):
         self.mod.write('import os\nfrom __future__ import devision\n')
         pymod = self.project.get_module('mod')


### PR DESCRIPTION
I noticed that when pulling imports to the top of a module, rope leaves the whitespace between where import statements previously were and duplicates it in the new position. For example:

```python
__author__ = "soupytwist"

import aaa

import bbb

do_stuff()
```

The output of ModuleImports.get_changed_source() on this (without any changes even) is:

```python
import aaa

import bbb

__author__ = "soupytwist"



do_stuff()
```

The extra newlines before each import statement were not removed with the import statements, so there is some extra unwanted gap left here. After some digging through module_imports, I refactored a bit so that the `_remove_imports` method would remove these newlines as well. The necessary newlines are added back (stored in each `stmt.blank_lines`) when re-inserting in `get_changed_source`, so it makes sense to remove them along with the import statements.

To be clear, the result I expect is:
```python
import aaa

import bbb

__author__ = "soupytwist"

do_stuff()
```

One small caveat to allow this to properly preserve newlines between the docstring and the first import statement is that the lines before the `_first_import_line` should not be removed, being as they are not restored.

In the process of this, I extracted a bit of common logic for line-counting being as this is done in several places in this module, including one I have introduced.

Please let me know if something is not clear or you have any suggestions. Thanks!