### PR TITLE
WIP: Sublime text speedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/build/
 build/
 dist/
 MANIFEST
+codeassisttest.profile
+codeassisttest.svgz

--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -32,6 +32,7 @@ class _Project(object):
         self.data_files = _DataFiles(self)
         self._custom_source_folders = []
 
+    @utils.memoize
     def get_resource(self, resource_name):
         """Get a resource in a project.
 

--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -459,7 +459,7 @@ class _DataFiles(object):
             path += '.gz'
         return self.project.get_file(path)
 
-
+@utils.cached(1000)
 def _realpath(path):
     """Return the real path of `path`
 

--- a/rope/base/pycore.py
+++ b/rope/base/pycore.py
@@ -133,6 +133,7 @@ class PyCore(object):
     #    packages, that is most of the time
     #  - We need a separate resource observer; `self.observer`
     #    does not get notified about module and folder creations
+    # FIXME This functional could be usefully memoized....
     @utils.deprecated('Use `project.get_source_folders` instead')
     def get_source_folders(self):
         """Returns project source folders"""
@@ -153,6 +154,7 @@ class PyCore(object):
         else:
             return False
 
+    @utils.memoize
     def _find_source_folders(self, folder):
         for resource in folder.get_folders():
             if self._is_package(resource):

--- a/rope/base/pynames.py
+++ b/rope/base/pynames.py
@@ -101,6 +101,7 @@ class ImportedModule(PyName):
         self.level = level
         self.resource = resource
         self.pymodule = _get_concluded_data(self.importing_module)
+        self.cached_pyobject = None
 
     def _current_folder(self):
         resource = self.importing_module.get_module().get_resource()
@@ -128,9 +129,13 @@ class ImportedModule(PyName):
         return self.pymodule.get()
 
     def get_object(self):
-        if self._get_pymodule() is None:
-            return rope.base.pyobjects.get_unknown()
-        return self._get_pymodule()
+        if not self.cached_pyobject:
+            pymod = self._get_pymodule()
+            if pymod is None:
+                self.cached_pyobject = rope.base.pyobjects.get_unknown()
+            else:
+                self.cached_pyobject = pymod
+        return self.cached_pyobject
 
     def get_definition_location(self):
         pymodule = self._get_pymodule()

--- a/rope/base/utils.py
+++ b/rope/base/utils.py
@@ -56,7 +56,6 @@ def deprecated(message=None):
         return newfunc
     return _decorator
 
-
 def cached(count):
     """A caching decorator based on parameter objects"""
     def decorator(func):

--- a/rope/base/utils.py
+++ b/rope/base/utils.py
@@ -1,5 +1,5 @@
 import warnings
-
+from functools import partial
 
 def saveit(func):
     """A decorator that caches the return value of a function"""
@@ -81,3 +81,48 @@ class _Cached(object):
         if len(self.cache) > self.count:
             del self.cache[0]
         return result
+
+class memoize(object):
+    """cache the return value of a method
+
+    This class is meant to be used as a decorator of methods. The return value
+    from a given method invocation will be cached on the instance whose method
+    was invoked. All arguments passed to a method decorated with memoize must
+    be hashable.
+
+    If a memoized method is invoked directly on its class the result will not
+    be cached. Instead the method will be invoked like a static method:
+    class Obj(object):
+        @memoize
+        def add_to(self, arg):
+            return self + arg
+    Obj.add_to(1) # not enough arguments
+    Obj.add_to(1, 2) # returns 3, result is not cached
+    """
+    def __init__(self, func):
+        self.func = func
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self.func
+        return partial(self, obj)
+    def __call__(self, *args, **kw):
+        obj = args[0]
+        try:
+            cache = obj.__cache
+        except AttributeError:
+            cache = obj.__cache = {}
+        key = (self.func, args[1:], frozenset(kw.items()))
+        try:
+            res = cache[key]
+        except KeyError:
+            res = cache[key] = self.func(*args, **kw)
+        return res
+
+def lazyprop(fn):
+    attr_name = '_lazy_' + fn.__name__
+    @property
+    def _lazyprop(self):
+        if not hasattr(self, attr_name):
+            setattr(self, attr_name, fn(self))
+        return getattr(self, attr_name)
+    return _lazyprop

--- a/rope/contrib/codeassist.py
+++ b/rope/contrib/codeassist.py
@@ -21,7 +21,7 @@ from rope.refactor import functionutils
 
 def code_assist(project, source_code, offset, resource=None,
                 templates=None, maxfixes=1, later_locals=True,
-                case_sensitive=False):
+                case_sensitive=True):
     """Return python code completions as a list of `CodeAssistProposal`\s
 
     `resource` is a `rope.base.resources.Resource` object.  If

--- a/rope/contrib/codeassist.py
+++ b/rope/contrib/codeassist.py
@@ -13,6 +13,7 @@ from rope.base import pyobjects
 from rope.base import pyobjectsdef
 from rope.base import pyscopes
 from rope.base import worder
+from rope.base import utils
 from rope.contrib import fixsyntax
 from rope.refactor import functionutils
 
@@ -237,7 +238,7 @@ class CompletionProposal(object):
             if isinstance(pyobject, pyobjects.AbstractFunction):
                 return pyobject.get_param_names()
 
-    @property
+    @utils.lazyprop
     def type(self):
         pyname = self.pyname
         if isinstance(pyname, builtins.BuiltinName):

--- a/rope/contrib/codeassist.py
+++ b/rope/contrib/codeassist.py
@@ -4,6 +4,7 @@ import warnings
 
 import rope.base.codeanalyze
 import rope.base.evaluate
+
 from rope.base import builtins
 from rope.base import exceptions
 from rope.base import libutils
@@ -12,8 +13,8 @@ from rope.base import pynamesdef
 from rope.base import pyobjects
 from rope.base import pyobjectsdef
 from rope.base import pyscopes
-from rope.base import worder
 from rope.base import utils
+from rope.base import worder
 from rope.contrib import fixsyntax
 from rope.refactor import functionutils
 
@@ -167,7 +168,7 @@ def get_canonical_path(project, resource, offset):
     names = []
     if isinstance(pyname, pynamesdef.ParameterName):
         names = [(worder.get_name_at(pymod.get_resource(), offset),
-                  'PARAMETER') ]
+                  'PARAMETER')]
     elif isinstance(pyname, pynamesdef.AssignedName):
         names = [(worder.get_name_at(pymod.get_resource(), offset),
                   'VARIABLE')]
@@ -547,14 +548,14 @@ class _ProposalSorter(object):
 
     def _proposal_key(self, proposal1):
         def _underline_count(name):
-             return sum(1 for c in name if c == "_")
+            return sum(1 for c in name if c == "_")
         return (self.typerank.get(proposal1.type, 100),
                 _underline_count(proposal1.name),
                 proposal1.name)
-        #if proposal1.type != proposal2.type:
+        # if proposal1.type != proposal2.type:
         #    return cmp(self.typerank.get(proposal1.type, 100),
         #               self.typerank.get(proposal2.type, 100))
-        #return self._compare_underlined_names(proposal1.name,
+        # return self._compare_underlined_names(proposal1.name,
         #                                      proposal2.name)
 
 

--- a/rope/contrib/codeassist.py
+++ b/rope/contrib/codeassist.py
@@ -5,24 +5,17 @@ import warnings
 import rope.base.codeanalyze
 import rope.base.evaluate
 
-from rope.base import builtins
-from rope.base import exceptions
-from rope.base import libutils
-from rope.base import pynames
-from rope.base import pynamesdef
-from rope.base import pyobjects
-from rope.base import pyobjectsdef
-from rope.base import pyscopes
-from rope.base import utils
-from rope.base import worder
+from rope.base import (builtins, exceptions, libutils, pynames,
+                       pynamesdef, pyobjects, pyobjectsdef, pyscopes,
+                       utils, worder)
 from rope.contrib import fixsyntax
 from rope.refactor import functionutils
 
 
 def code_assist(project, source_code, offset, resource=None,
                 templates=None, maxfixes=1, later_locals=True,
-                case_sensitive=True):
-    """Return python code completions as a list of `CodeAssistProposal`\s
+                case_sensitive=False):
+    """Return python code completions as a list of `CodeAssistProposal`
 
     `resource` is a `rope.base.resources.Resource` object.  If
     provided, relative imports are handled.
@@ -57,7 +50,7 @@ def starting_offset(source_code, offset):
 
     """
     word_finder = worder.Worder(source_code, True)
-    expression, starting, starting_offset = \
+    _, _, starting_offset = \
         word_finder.get_splitted_primary_before(offset)
     return starting_offset
 

--- a/rope/refactor/topackage.py
+++ b/rope/refactor/topackage.py
@@ -13,7 +13,8 @@ class ModuleToPackage(object):
         changes = ChangeSet('Transform <%s> module to package' %
                             self.resource.path)
         new_content = self._transform_relatives_to_absolute(self.resource)
-        if new_content is not None:
+        # if new_content is not None:
+        if new_content:
             changes.add_change(ChangeContents(self.resource, new_content))
         parent = self.resource.parent
         name = self.resource.name[:-3]

--- a/ropetest/contrib/codeassisttest.py
+++ b/ropetest/contrib/codeassisttest.py
@@ -12,6 +12,7 @@ from rope.contrib.codeassist import (get_definition_location, get_doc,
                                      sorted_proposals, starting_offset,
                                      get_calltip, get_canonical_path)
 from ropetest import testutils
+import cProfile
 
 try:
     unicode
@@ -1128,4 +1129,4 @@ def suite():
     return result
 
 if __name__ == '__main__':
-    unittest.main()
+    cProfile.run('unittest.main()', 'codeassisttest.profile')


### PR DESCRIPTION
@jorgenschaefer, @aligrudi , @JulianEberius I would like to renew my effort to make `rope` acceptable for both Emacs and SublimeText world. I guess I have already lost Emacs people, but still I would like to make `rope` behave better.

Patch originally from #44 (authored by @JulianEberius) which unfortunately breaks on the current rope. For purposes of bisecting, I have split the patch into four commits, but `git bisect` still shows that both 7506026cae and b5eaf343c5 break tests. Any idea what's wrong?

An alternative could be to use jorgenschaefer/elpy@e75c963d7b ? @JulianEberius, would it solve problems `rope` had with SublimeText (or vice versa) which were supposed to be fixed by your patch?

Also, wouldn't it be better to use `functools.lru_cache` (aka `repoze.lru.lru_cache`) instead of doing our own `utils.memoize`?
