### PR TITLE
Switch to setuptools (`develop` command is kewl).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,16 @@
-from distutils.core import setup, Command
 import sys
+
+try:
+    from setuptools import Command, setup
+except ImportError:
+    from distutils.core import Command, setup
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
 
-
 import rope
+
 import ropetest
 import ropetest.contrib
 import ropetest.refactor


### PR DESCRIPTION
OK, if I want to make some development on rope I really want ``setuptools`` here (and ``develop`` command). Unless @aligrudi has strong objections, I will merge this into ``devel`` branch.

The only real objection I have heard about it is in http://thread.gmane.org/gmane.comp.python.rope/552/focus=556 which makes a vague statement about "Windows ready made installers" (I am not sure what he was talking about; ``rope`` is used by Python developers who are supposed to be able to use ``pip`` or ``python setup.py``).

@emacsway , @sergeyglazyrindev, any comments?