### PR TITLE
Remove all relevant unused imports when moving globals

### DIFF
--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -211,6 +211,19 @@ class MoveGlobal(object):
         self.import_tools = self.tools.import_tools
         self._check_exceptional_conditions()
 
+    def _import_filter(self, stmt):
+      module_name = libutils.modname(self.source)
+      if isinstance(stmt.import_info, importutils.NormalImport):
+          return any(module_name == name
+                     for name, alias in stmt.import_info.names_and_aliases)
+      elif isinstance(stmt.import_info, importutils.FromImport):
+          if '.' in module_name:
+              package_name = '.'.join(module_name.split('.')[:-1])
+              if stmt.import_info.module_name == package_name:
+                  return True
+          return stmt.import_info.module_name == module_name
+      return False
+
     def _check_exceptional_conditions(self):
         if self.old_pyname is None or \
            not isinstance(self.old_pyname.get_object(),
@@ -262,7 +275,8 @@ class MoveGlobal(object):
                 should_import = source is not None
                 # Removing out of date imports
                 pymodule = self.tools.new_pymodule(pymodule, source)
-                source = self.tools.remove_old_imports(pymodule)
+                source = self.import_tools.organize_imports(
+                    pymodule, sort=False, import_filter=self._import_filter)
                 # Adding new import
                 if should_import:
                     pymodule = self.tools.new_pymodule(pymodule, source)
@@ -285,6 +299,8 @@ class MoveGlobal(object):
         renamer = ModuleSkipRenamer(occurrence_finder, self.source,
                                     handle, start, end)
         source = renamer.get_changed_module()
+        pymodule = libutils.get_string_module(self.project, source, self.source)
+        source = self.import_tools.organize_imports(pymodule, sort=False)
         if handle.occurred:
             pymodule = libutils.get_string_module(
                 self.project, source, self.source)
@@ -304,8 +320,6 @@ class MoveGlobal(object):
         pymodule = self.tools.new_pymodule(pymodule, source)
 
         moving, imports = self._get_moving_element_with_imports()
-        source = self.tools.remove_old_imports(pymodule)
-        pymodule = self.tools.new_pymodule(pymodule, source)
         pymodule, has_changed = self._add_imports2(pymodule, imports)
 
         module_with_imports = self.import_tools.module_imports(pymodule)
@@ -329,6 +343,11 @@ class MoveGlobal(object):
         pymodule = libutils.get_string_module(self.project, source, dest)
         source = self.import_tools.organize_imports(pymodule, sort=False,
                                                     unused=False)
+        # Remove unused imports of the old module
+        pymodule = libutils.get_string_module(self.project, source, dest)
+        source = self.import_tools.organize_imports(
+            pymodule, sort=False, selfs=False, unused=True,
+            import_filter=self._import_filter)
         return ChangeContents(dest, source)
 
     def _get_moving_element_with_imports(self):
@@ -446,7 +465,6 @@ class MoveModule(object):
         new_name = self._new_modname(dest)
         module_imports = importutils.get_module_imports(self.project, pymodule)
         changed = False
-
         source = None
         if libutils.modname(dest):
             changed = self._change_import_statements(dest, new_name,
@@ -471,7 +489,6 @@ class MoveModule(object):
         if source is not None and source != pymodule.resource.read():
             return source
         return None
-
 
     def _change_import_statements(self, dest, new_name, module_imports):
         moving_module = self.source

--- a/ropetest/refactor/movetest.py
+++ b/ropetest/refactor/movetest.py
@@ -37,13 +37,23 @@ class MoveRefactoringTest(unittest.TestCase):
         self.assertEquals('class AClass(object):\n    pass\n',
                           self.mod2.read())
 
-    def test_changing_other_modules_adding_normal_imports(self):
+    def test_changing_other_modules_replacing_normal_imports(self):
         self.mod1.write('class AClass(object):\n    pass\n')
         self.mod3.write('import mod1\na_var = mod1.AClass()\n')
         self._move(self.mod1, self.mod1.read().index('AClass') + 1,
                    self.mod2)
-        self.assertEquals('import mod1\nimport mod2\na_var = mod2.AClass()\n',
+        self.assertEquals('import mod2\na_var = mod2.AClass()\n',
                           self.mod3.read())
+
+    def test_changing_other_modules_adding_normal_imports(self):
+        self.mod1.write('class AClass(object):\n    pass\n'
+                        'def a_function():\n    pass\n')
+        self.mod3.write('import mod1\na_var = mod1.AClass()\n'
+                        'mod1.a_function()')
+        self._move(self.mod1, self.mod1.read().index('AClass') + 1,
+                   self.mod2)
+        self.assertEquals('import mod1\nimport mod2\na_var = mod2.AClass()\n' +
+                          'mod1.a_function()', self.mod3.read())
 
     def test_adding_imports_prefer_from_module(self):
         self.project.prefs['prefer_module_from_imports'] = True
@@ -79,9 +89,8 @@ class MoveRefactoringTest(unittest.TestCase):
                         'mod1.a_function()')
         self._move(self.mod1, self.mod1.read().index('AClass') + 1,
                    self.mod2)
-        self.assertEquals('import mod1\nimport mod2\n'
-                          'a_var = mod2.AClass()\nmod1.a_function()',
-                          self.mod3.read())
+        self.assertEquals('import mod1\nimport mod2\na_var = mod2.AClass()\n' +
+                          'mod1.a_function()', self.mod3.read())
 
     def test_changing_other_modules_removing_from_imports(self):
         self.mod1.write('class AClass(object):\n    pass\n')
@@ -171,6 +180,7 @@ class MoveRefactoringTest(unittest.TestCase):
                    'def a_func():\n' \
                    '    print(pkg.mod5)\n'
         self.assertEquals(expected, self.mod1.read())
+        self.assertEquals('', self.mod4.read())
 
     def test_moving_modules(self):
         code = 'import mod1\nprint(mod1)'
@@ -404,7 +414,7 @@ class MoveRefactoringTest(unittest.TestCase):
                     'print(mod4)')
         self.assertEquals(expected, self.mod1.read())
 
-    def test_moving_funtions_to_imported_module(self):
+    def test_moving_functions_to_imported_module(self):
         code = 'import mod1\n' \
                'def a_func():\n' \
                '    var = mod1.a_var\n'

--- a/ropetest/refactor/multiprojecttest.py
+++ b/ropetest/refactor/multiprojecttest.py
@@ -51,9 +51,8 @@ class MultiProjectRefactoringTest(unittest.TestCase):
         multiproject.perform(renamer.get_all_changes(self.other))
         self.assertEquals('', self.mod1.read())
         self.assertEquals('def a_func():\n    pass\n', self.other.read())
-        self.assertEquals(
-            'import mod1\nimport other\nmyvar = other.a_func()\n',
-            self.mod2.read())
+        self.assertEquals('import other\nmyvar = other.a_func()\n',
+                          self.mod2.read())
 
     def test_rename_from_the_project_not_containing_the_change(self):
         self.project2.get_prefs().add('python_path', self.project1.address)


### PR DESCRIPTION
Previously only fully-qualified imports of the name are removed, but
this potentially leaves leaves module imports that were only imported
for the name. This patch removes unused imports of the module that
previously contained the name as well.

Ex, moving `mod1.do_something` to another module

Related modules that depend on this function:
```python
from mod1 import do_something  # current implementation will remove
import mod1                    # current implementation will keep
from pkg import mod1           # current implementation will keep
```

I think that `import mod1` or `from pkg import mod1` should also be
removed if they are unused after the global is moved.

Note that this does not affect imports of other modules; only imports
of the name which is being moved or the module containing it are
candidates for deletion.