### PR TITLE
Add an option to prefer "from pkg import mod" imports

### DIFF
--- a/rope/base/default_config.py
+++ b/rope/base/default_config.py
@@ -79,6 +79,10 @@ def set_prefs(prefs):
     # appear in the importing namespace.
     prefs['ignore_bad_imports'] = False
 
+    # If `True`, rope will insert new module imports as
+    # `from <package> import <module>` by default.
+    prefs['prefer_module_from_imports'] = False
+
     # If `True`, rope will transform a comma list of imports into
     # multiple separate import statements when organizing
     # imports.

--- a/rope/refactor/importutils/__init__.py
+++ b/rope/refactor/importutils/__init__.py
@@ -278,6 +278,7 @@ def add_import(project, pymodule, module_name, name=None):
     imports = get_module_imports(project, pymodule)
     candidates = []
     names = []
+    selected_import = None
     # from mod import name
     if name is not None:
         from_import = FromImport(module_name, 0, [(name, None)])
@@ -286,7 +287,10 @@ def add_import(project, pymodule, module_name, name=None):
     # from pkg import mod
     if '.' in module_name:
         pkg, mod = module_name.rsplit('.', 1)
-        candidates.append(FromImport(pkg, 0, [(mod, None)]))
+        from_import = FromImport(pkg, 0, [(mod, None)])
+        if project.prefs.get('prefer_module_from_imports'):
+            selected_import = from_import
+        candidates.append(from_import)
         if name:
             names.append(mod + '.' + name)
         else:
@@ -301,7 +305,8 @@ def add_import(project, pymodule, module_name, name=None):
     candidates.append(normal_import)
 
     visitor = actions.AddingVisitor(project, candidates)
-    selected_import = normal_import
+    if selected_import is None:
+        selected_import = normal_import
     for import_statement in imports.imports:
         if import_statement.accept(visitor):
             selected_import = visitor.import_info


### PR DESCRIPTION
Rope seemed to always choose the normal import by default, but this
leads to ugly code when the module is deeply nested in pacakges. This
option gives preference to the "from pkg import mod" style from-import.

Ex, when moving `mod1.do_something` to `pkg.mod2`

Before:
`mod3.py`:
```python
import mod1

mod1.do_something()
```

After [`prefer_module_from_imports = False`]:
`mod3.py`
```python
import mod1
import pkg.mod2

pkg.mod2.do_something()
```

After [`prefer_module_from_imports = True`]:
`mod3.py`
```python
import mod1
from pkg import mod2

mod2.do_something()
```