### PR TITLE
Check exception conditions before using pyname in move_global

### DIFF
--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -203,13 +203,13 @@ class MoveGlobal(object):
         self.project = project
         this_pymodule = self.project.get_pymodule(resource)
         self.old_pyname = evaluate.eval_location(this_pymodule, offset)
+        self._check_exceptional_conditions()
         self.old_name = self.old_pyname.get_object().get_name()
         pymodule = self.old_pyname.get_object().get_module()
         self.source = pymodule.get_resource()
         self.tools = _MoveTools(self.project, self.source,
                                 self.old_pyname, self.old_name)
         self.import_tools = self.tools.import_tools
-        self._check_exceptional_conditions()
 
     def _import_filter(self, stmt):
       module_name = libutils.modname(self.source)

--- a/ropetest/refactor/movetest.py
+++ b/ropetest/refactor/movetest.py
@@ -129,6 +129,13 @@ class MoveRefactoringTest(unittest.TestCase):
             self._move(self.mod1, self.mod1.read().index('AClass') + 1,
                        self.mod2)
 
+    def test_raising_exception_for_moving_variable(self):
+        code = 'CONSTANT = 5\n'
+        self.mod1.write(code)
+        with self.assertRaises(exceptions.RefactoringError):
+            mover = move.create_move(self.project, self.mod1,
+                                     code.index('CONSTANT') + 1)
+
     def test_raising_exception_for_mov_glob_elemnts_to_the_same_module(self):
         self.mod1.write('def a_func():\n    pass\n')
         with self.assertRaises(exceptions.RefactoringError):


### PR DESCRIPTION
Don't make assumptions about the pyname until exceptional conditions are
checked. Previously, if the name was just a variable (not a class or function)
initializing the class would raise an AttributeError (not RefactoringError).

```
  File "/third_party/py/rope/refactor/move.py", line 206, in __init__
    self.old_name = self.old_pyname.get_object().get_name()
AttributeError: 'PyObject' object has no attribute 'get_name'
```

\+ simple test to show that this case raises the intended error.