### PR TITLE
Disable flake8 in default config

### DIFF
--- a/rope/base/default_config.py
+++ b/rope/base/default_config.py
@@ -1,4 +1,5 @@
 # The default ``config.py``
+# flake8: noqa
 
 
 def set_prefs(prefs):


### PR DESCRIPTION
As config.py gets created in the project root, flake8 will, if enabled,
will find it and complain about style violations.

Ignoring .ropeproject in setup.cfg would introduce Rope-specific noise
in every affected project.