### PR TITLE
Support moving global variables with move_global

### DIFF
--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -22,21 +22,21 @@ def create_move(project, resource, offset=None):
         return MoveModule(project, resource)
     this_pymodule = project.get_pymodule(resource)
     pyname = evaluate.eval_location(this_pymodule, offset)
-    if pyname is None:
-        raise exceptions.RefactoringError(
-            'Move only works on classes, functions, modules and methods.')
-    pyobject = pyname.get_object()
-    if isinstance(pyobject, pyobjects.PyModule) or \
-       isinstance(pyobject, pyobjects.PyPackage):
-        return MoveModule(project, pyobject.get_resource())
-    if isinstance(pyobject, pyobjects.PyFunction) and \
-       isinstance(pyobject.parent, pyobjects.PyClass):
-        return MoveMethod(project, resource, offset)
-    if isinstance(pyobject, pyobjects.PyDefinedObject) and \
-       isinstance(pyobject.parent, pyobjects.PyModule):
-        return MoveGlobal(project, resource, offset)
+    if pyname is not None:
+        pyobject = pyname.get_object()
+        if isinstance(pyobject, pyobjects.PyModule) or \
+           isinstance(pyobject, pyobjects.PyPackage):
+            return MoveModule(project, pyobject.get_resource())
+        if isinstance(pyobject, pyobjects.PyFunction) and \
+           isinstance(pyobject.parent, pyobjects.PyClass):
+            return MoveMethod(project, resource, offset)
+        if isinstance(pyobject, pyobjects.PyDefinedObject) and \
+           isinstance(pyobject.parent, pyobjects.PyModule) or \
+           isinstance(pyname, pynames.AssignedName):
+            return MoveGlobal(project, resource, offset)
     raise exceptions.RefactoringError(
-        'Move only works on global classes/functions, modules and methods.')
+        'Move only works on global classes/functions/variables, modules and '
+        'methods.')
 
 
 class MoveMethod(object):
@@ -203,9 +203,17 @@ class MoveGlobal(object):
         self.project = project
         this_pymodule = self.project.get_pymodule(resource)
         self.old_pyname = evaluate.eval_location(this_pymodule, offset)
+        if self.old_pyname is None:
+            raise exceptions.RefactoringError(
+                'Move refactoring should be performed on a '
+                'class/function/variable.')
+        if self._is_variable(self.old_pyname):
+            self.old_name = worder.get_name_at(resource, offset)
+            pymodule = this_pymodule
+        else:
+            self.old_name = self.old_pyname.get_object().get_name()
+            pymodule = self.old_pyname.get_object().get_module()
         self._check_exceptional_conditions()
-        self.old_name = self.old_pyname.get_object().get_name()
-        pymodule = self.old_pyname.get_object().get_module()
         self.source = pymodule.get_resource()
         self.tools = _MoveTools(self.project, self.source,
                                 self.old_pyname, self.old_name)
@@ -225,19 +233,27 @@ class MoveGlobal(object):
       return False
 
     def _check_exceptional_conditions(self):
-        if self.old_pyname is None or \
-           not isinstance(self.old_pyname.get_object(),
-                          pyobjects.PyDefinedObject):
-            raise exceptions.RefactoringError(
-                'Move refactoring should be performed on a class/function.')
-        moving_pyobject = self.old_pyname.get_object()
-        if not self._is_global(moving_pyobject):
-            raise exceptions.RefactoringError(
-                'Move refactoring should be performed ' +
-                'on a global class/function.')
+        if self._is_variable(self.old_pyname):
+            pymodule = self.old_pyname.get_definition_location()[0]
+            try:
+                pymodule.get_scope().get_name(self.old_name)
+            except exceptions.NameNotFoundError:
+                self._raise_refactoring_error()
+        elif not (isinstance(self.old_pyname.get_object(),
+                             pyobjects.PyDefinedObject) and
+                  self._is_global(self.old_pyname.get_object())):
+            self._raise_refactoring_error()
+
+    def _raise_refactoring_error(self):
+        raise exceptions.RefactoringError(
+            'Move refactoring should be performed on a global class, function '
+            'or variable.')
 
     def _is_global(self, pyobject):
         return pyobject.get_scope().parent == pyobject.get_module().get_scope()
+
+    def _is_variable(self, pyname):
+      return isinstance(pyname, pynames.AssignedName)
 
     def get_changes(self, dest, resources=None,
                     task_handle=taskhandle.NullTaskHandle()):
@@ -367,9 +383,16 @@ class MoveGlobal(object):
     def _get_moving_region(self):
         pymodule = self.project.get_pymodule(self.source)
         lines = pymodule.lines
-        scope = self.old_pyname.get_object().get_scope()
-        start = lines.get_line_start(scope.get_start())
-        end_line = scope.get_end()
+        if self._is_variable(self.old_pyname):
+            logical_lines = pymodule.logical_lines
+            lineno = logical_lines.logical_line_in(
+                self.old_pyname.get_definition_location()[1])[0]
+            start = lines.get_line_start(lineno)
+            end_line = logical_lines.logical_line_in(lineno)[1]
+        else:
+            scope = self.old_pyname.get_object().get_scope()
+            start = lines.get_line_start(scope.get_start())
+            end_line = scope.get_end()
         while end_line < lines.length() and \
                 lines.get_line(end_line + 1).strip() == '':
             end_line += 1


### PR DESCRIPTION
This is a refactoring I really find useful, most often in the case of constants which are defined in some file that need to be moved elsewhere. Rope already supports this type of refactoring for functions and classes, but variables are a bit more tricky due to the lack of "def" or other declaration.

This implementation takes a simple approach to move the definition location of a global variable from one module to another, extending the MoveGlobal refactoring. See the added tests for examples.

Please let me know what you think! This case isn't as simple as the others, but I think there's a lot of value in supporting it at least to some degree.