### PR TITLE
Support Starred and KeyWord in Python 3.5 with backwards comptibility

### DIFF
--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -481,7 +481,12 @@ class _PatchingASTWalker(object):
         self._handle(node, children)
 
     def _keyword(self, node):
-        self._handle(node, [node.arg, '=', node.value])
+        children = []
+        if node.arg is None:
+            children.append(node.value)
+        else:
+            children.extend([node.arg, '=', node.value])
+        self._handle(node, children)
 
     def _Lambda(self, node):
         self._handle(node, ['lambda', node.args, ':', node.body])
@@ -702,6 +707,9 @@ class _PatchingASTWalker(object):
             if index < len(nodes) - 1:
                 children.append(separator)
         return children
+
+    def _Starred(self, node):
+        self._handle(node, [node.value])
 
 
 class _Source(object):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -294,9 +294,15 @@ class PatchedASTTest(unittest.TestCase):
         source = 'f(*args, **kwds)\n'
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
+        try:
+            ast.Starred()
+            expectedResult = ['Name', '', '(', '*', 'Starred', '', ',',
+                    ' **', 'keyword', '', ')']
+        except AttributeError:
+            expectedResult = ['Name', '', '(', '', '*', '', 'Name', '', ',',
+                    ' ', '**', '', 'Name', '', ')']
         checker.check_children(
-            'Call', ['Name', '', '(', '', '*', '', 'Name', '', ',',
-                     ' ', '**', '', 'Name', '', ')'])
+           'Call', expectedResult)
 
     def test_class_node(self):
         source = 'class A(object):\n    """class docs"""\n    pass\n'


### PR DESCRIPTION
Add support for Starred and keywords (http://greentreesnakes.readthedocs.io/en/latest/nodes.html#Call) due to changes in Python 3.5

Fixes the unit test:
```python
    def test_call_func_and_both_varargs_and_kwargs(self):
        source = 'f(*args, **kwds)\n'
```

This requires the previous PR #169, to ensure unit tests run under Python 3.5