### PR TITLE
Include comment lines preceding definition in move_global

### DIFF
--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -393,6 +393,13 @@ class MoveGlobal(object):
             scope = self.old_pyname.get_object().get_scope()
             start = lines.get_line_start(scope.get_start())
             end_line = scope.get_end()
+
+        # Include comment lines before the definition
+        start_line = lines.get_line_number(start)
+        while start_line > 1 and lines.get_line(start_line - 1).startswith('#'):
+          start_line -= 1
+        start = lines.get_line_start(start_line)
+
         while end_line < lines.length() and \
                 lines.get_line(end_line + 1).strip() == '':
             end_line += 1

--- a/ropetest/refactor/movetest.py
+++ b/ropetest/refactor/movetest.py
@@ -66,6 +66,14 @@ class MoveRefactoringTest(unittest.TestCase):
         self.assertEquals('class AClass(object):\n    pass\n',
                           self.mod2.read())
 
+    def test_moving_with_comment_prefix(self):
+        self.mod1.write('a = 1\n# 1\n# 2\nclass AClass(object):\n    pass\n')
+        self._move(self.mod1, self.mod1.read().index('AClass') + 1,
+                   self.mod2)
+        self.assertEquals('a = 1\n', self.mod1.read())
+        self.assertEquals('# 1\n# 2\nclass AClass(object):\n    pass\n',
+                          self.mod2.read())
+
     def test_changing_other_modules_replacing_normal_imports(self):
         self.mod1.write('class AClass(object):\n    pass\n')
         self.mod3.write('import mod1\na_var = mod1.AClass()\n')


### PR DESCRIPTION
It is common to prefix globals with a comment, e.g. for disabling lint
warnings, TODOs, etc. These should be moved along with the source by
move_global.