### PR TITLE
Patch for moving comment prefix on global names

### DIFF
--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -680,6 +680,17 @@ def _add_imports_to_module(import_tools, pymodule, new_imports):
 def moving_code_with_imports(project, resource, source):
     import_tools = importutils.ImportTools(project)
     pymodule = libutils.get_string_module(project, source, resource)
+
+    # Strip comment prefix, if any. These need to stay before the moving
+    # section, but imports would be added between them.
+    lines = codeanalyze.SourceLinesAdapter(source)
+    start = 1
+    while start < lines.length() and lines.get_line(start).startswith('#'):
+        start += 1
+    moving_prefix = source[:lines.get_line_start(start)]
+    pymodule = libutils.get_string_module(
+        project, source[lines.get_line_start(start):], resource)
+
     origin = project.get_pymodule(resource)
 
     imports = []
@@ -710,7 +721,9 @@ def moving_code_with_imports(project, resource, source):
     lines = codeanalyze.SourceLinesAdapter(source)
     while start < lines.length() and not lines.get_line(start).strip():
         start += 1
-    moving = source[lines.get_line_start(start):]
+
+    # Reinsert the prefix which was removed at the beginning
+    moving = moving_prefix + source[lines.get_line_start(start):]
     return moving, imports
 
 

--- a/ropetest/refactor/movetest.py
+++ b/ropetest/refactor/movetest.py
@@ -74,6 +74,16 @@ class MoveRefactoringTest(unittest.TestCase):
         self.assertEquals('# 1\n# 2\nclass AClass(object):\n    pass\n',
                           self.mod2.read())
 
+    def test_moving_with_comment_prefix_imports(self):
+        self.mod1.write('import foo\na = 1\n# 1\n# 2\n'
+                        'class AClass(foo.FooClass):\n    pass\n')
+        self._move(self.mod1, self.mod1.read().index('AClass') + 1,
+                   self.mod2)
+        self.assertEquals('a = 1\n', self.mod1.read())
+        self.assertEquals('import foo\n\n\n# 1\n# 2\n'
+                          'class AClass(foo.FooClass):\n    pass\n',
+                          self.mod2.read())
+
     def test_changing_other_modules_replacing_normal_imports(self):
         self.mod1.write('class AClass(object):\n    pass\n')
         self.mod3.write('import mod1\na_var = mod1.AClass()\n')


### PR DESCRIPTION
This only half-worked, and led to the imports being inserted between the
comment prefix and the global which was moved, which actually led to the
comment being removed from the destination. Added test for this scenario
and some extra processing on import insertion to preserve the comment
prefix.

This fixes a bug introduced in #177.