### PR TITLE
Fix token matching RE used to determine line starts

### DIFF
--- a/rope/base/codeanalyze.py
+++ b/rope/base/codeanalyze.py
@@ -129,13 +129,17 @@ class _CustomGenerator(object):
                 i += 1
         return result
 
-    # Doesn't match quotes which are escaped
-    _main_tokens = re.compile(r'((?<!\\)(\'\'\'|"""|\'|")|#|\[|\]|\{|\}|\(|\))')
+    # Matches all backslashes before the token, to detect escaped quotes
+    _main_tokens = re.compile(r'(\\*)((\'\'\'|"""|\'|")|#|\[|\]|\{|\}|\(|\))')
 
     def _analyze_line(self, line):
         token = None
         for match in self._main_tokens.finditer(line):
-            token = match.group()
+            prefix = match.group(1)
+            token = match.group(2)
+            # Skip any tokens which are escaped
+            if len(prefix) % 2 == 1:
+                continue
             if token in ["'''", '"""', "'", '"']:
                 if not self.in_string:
                     self.in_string = token


### PR DESCRIPTION
Handle an escaped backslash at the end of a string to not mean an
escaped quote. This is a bugfix, but ideally this should not rely on RE
to parse the python syntax (this is very hard to get right).

Fixes #180.