### PR TITLE
Don't split imports which are not matched by the filter

### DIFF
--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -162,7 +162,7 @@ class ModuleImports(object):
         """force a single import per statement"""
         for import_stmt in self.imports[:]:
             import_info = import_stmt.import_info
-            if import_info.is_empty():
+            if import_info.is_empty() or import_stmt.readonly:
                 continue
             if len(import_info.names_and_aliases) > 1:
                 for name_and_alias in import_info.names_and_aliases:

--- a/ropetest/refactor/importutilstest.py
+++ b/ropetest/refactor/importutilstest.py
@@ -633,6 +633,21 @@ class ImportUtilsTest(unittest.TestCase):
                           self.import_tools.organize_imports(pymod,
                                                              unused=False))
 
+    def test_splitting_imports_with_filter(self):
+        self.mod.write('from pkg1 import mod1, mod2\n'
+                       'from pkg2 import mod3, mod4\n')
+        pymod = self.project.get_pymodule(self.mod)
+        self.project.prefs['split_imports'] = True
+
+        def import_filter(stmt):
+          return stmt.import_info.module_name == 'pkg1'
+
+        self.assertEquals(
+            'from pkg1 import mod1\nfrom pkg1 import mod2\n'
+            'from pkg2 import mod3, mod4\n',
+            self.import_tools.organize_imports(pymod, unused=False,
+                                               import_filter=import_filter))
+
     def test_splitting_duplicate_imports(self):
         self.mod.write('from pkg2 import mod1\nfrom pkg2 import mod1, mod2\n')
         pymod = self.project.get_pymodule(self.mod)


### PR DESCRIPTION
This previously would leave the old import in place because it is
readonly; really it shouldn't even touch these imports if they are
supposed to be filtered.