### PR TITLE
#186 preparation for support of typing module.

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1301,6 +1301,37 @@ https://www.python.org/dev/peps/pep-0484/#type-comments
            self.x.| # complete here
 
 
+Supported syntax of type hinting
+''''''''''''''''''''''''''''''''
+
+Currently rope supports the following syntax of type-hinting.
+
+Parametrized objects:
+
+- Foo
+- foo.bar.Baz
+- list[Foo] or list[foo.bar.Baz] etc.
+- set[Foo]
+- tuple[Foo]
+- dict[Foo, Bar]
+- collections.Iterable[Foo]
+- collections.Iterator[Foo]
+
+Nested expressions also allowed:
+
+- collections.Iterable[list[Foo]]
+
+TODO:
+
+Callable objects:
+
+- (Foo, Bar) -> Baz
+
+Multiple interfaces implementation:
+
+- Foo | Bar
+
+
 Custom Source Folders
 =====================
 

--- a/rope/base/builtins.py
+++ b/rope/base/builtins.py
@@ -87,6 +87,9 @@ class BuiltinClass(_BuiltinElement, pyobjects.AbstractClass):
         result.update(self.initial)
         return result
 
+    def get_module(self):
+        return builtins
+
 
 class BuiltinFunction(_BuiltinElement, pyobjects.AbstractFunction):
 

--- a/rope/base/oi/type_hinting/evaluate.py
+++ b/rope/base/oi/type_hinting/evaluate.py
@@ -1,0 +1,353 @@
+# Based on super lightweight Simple Top-Down Parser from http://effbot.org/zone/simple-top-down-parsing.htm
+# and https://bitbucket.org/emacsway/sqlbuilder/src/default/sqlbuilder/smartsql/contrib/evaluate.py
+import re
+from rope.base.utils import pycompat
+from rope.base.oi.type_hinting import utils
+from rope.base import utils as base_utils
+
+
+class SymbolBase(object):
+
+    name = None  # node/token type name
+
+    def __init__(self):
+        self.value = None  # used by name and literals
+        self.first = None
+        self.second = None
+        self.third = None  # used by tree nodes
+
+    def nud(self, parser):
+        raise SyntaxError(
+            "Syntax error (%r)." % self.name
+        )
+
+    def led(self, left, parser):
+        raise SyntaxError(
+            "Unknown operator (%r)." % self.name
+        )
+
+    def evaluate(self, pyobject):
+        raise NotImplementedError(self.name, self)
+
+    def __repr__(self):
+        if self.name == '(name)':
+            return "(%s %s)" % (self.name[1:-1], self.value)
+        out = [repr(self.name), self.first, self.second, self.third]
+        out = [str(i) for i in out if i]
+        return '(' + ' '.join(out) + ')'
+
+
+class SymbolTable(object):
+
+    def multi(func):
+        def _inner(self, names, *a, **kw):
+            for name in names.split():
+                func(self, name, *a, **kw)
+        return _inner
+
+    def __init__(self):
+        self.symbol_table = {}
+
+    def get(self, name, default=None):
+        return self.symbol_table.get(name, default)
+
+    def __getitem__(self, name):
+        return self.symbol_table[name]
+
+    def __iter__(self):
+        return iter(self.symbol_table)
+
+    def symbol(self, name, bp=0):
+        try:
+            s = self.symbol_table[name]
+        except KeyError:
+
+            class S(SymbolBase):
+                pass
+
+            s = S
+            s.__name__ = "symbol-" + name  # for debugging
+            s.name = name
+            s.lbp = bp
+            self.symbol_table[name] = s
+        else:
+            s.lbp = max(bp, s.lbp)
+        return s
+
+    @multi
+    def infix(self, name, bp):
+        symbol = self.symbol(name, bp)
+
+        @method(symbol)
+        def led(self, left, parser):
+            self.first = left
+            self.second = parser.expression(bp)
+            return self
+
+    @multi
+    def infix_r(self, name, bp):
+        symbol = self.symbol(name, bp)
+
+        @method(symbol)
+        def led(self, left, parser):
+            self.first = left
+            self.second = parser.expression(bp - 0.1)
+            return self
+
+    def ternary(self, name, name2, bp):
+        symbol = self.symbol(name, bp)
+        symbol2 = self.symbol(name2)
+
+        @method(symbol)
+        def led(self, left, parser):
+            self.first = left
+            self.second = parser.expression(symbol2.lbp)
+            parser.advance(symbol2.name)
+            self.third = parser.expression(symbol2.lbp + 0.1)
+            return self
+
+    @multi
+    def prefix(self, name, bp):
+        symbol = self.symbol(name, bp)
+
+        @method(symbol)
+        def nud(self, parser):
+            self.first = parser.expression(bp)
+            return self
+
+    @multi
+    def postfix(self, name, bp):
+        symbol = self.symbol(name, bp)
+
+        @method(symbol)
+        def led(self, left, parser):
+            self.first = left
+            return self
+
+    multi = staticmethod(multi)  # Just for code checker
+
+symbol_table = SymbolTable()
+
+
+class Lexer(object):
+
+    _token_pattern = re.compile(r"""
+        \s*
+        (?:
+              (
+                    [,()\[\]|]
+                  | ->
+                  | (?<=\s)(?:or)\b
+              )  # operator
+            | ([a-zA-Z](?:\w|\.)*)  # name
+        )
+        """, re.U | re.S | re.X)
+
+    def __init__(self, symbol_table):
+        self.symbol_table = symbol_table
+
+    def tokenize(self, program):
+        for name, value in self._tokenize_expr(program):
+            symbol = symbol_table.get(value)
+            if symbol:
+                s = symbol()
+            elif name == "(name)":
+                symbol = symbol_table[name]
+                s = symbol()
+                s.value = value
+            else:
+                raise SyntaxError("Unknown operator ({0}). Possible operators are {1!r}".format(
+                    value, list(self.symbol_table)
+                ))
+
+            yield s
+
+    def _tokenize_expr(self, program):
+        if isinstance(program, bytes):
+            program = program.decode('utf-8')
+        # import pprint; pprint.pprint(self._token_pattern.findall(program))
+        for operator, name in self._token_pattern.findall(program):
+            if operator:
+                yield '(operator)', operator
+            elif name:
+                yield '(name)', name
+            else:
+                raise SyntaxError
+        yield '(end)', '(end)'
+
+
+class Parser(object):
+
+    token = None
+    next = None
+
+    def __init__(self, lexer):
+        self.lexer = lexer
+
+    def parse(self, program):
+        generator = self.lexer.tokenize(program)
+        try:
+            self.next = generator.__next__  # PY3
+        except AttributeError:
+            self.next = generator.next
+        self.token = self.next()
+        return self.expression()
+
+    def expression(self, rbp=0):
+        t = self.token
+        self.token = self.next()
+        left = t.nud(self)
+        while rbp < self.token.lbp:
+            t = self.token
+            self.token = self.next()
+            left = t.led(left, self)
+        return left
+
+    def advance(self, name=None):
+        if name and self.token.name != name:
+            raise SyntaxError("Expected {0!r} but found {1!r}".format(name, self.token.name))
+        self.token = self.next()
+
+
+def method(s):
+    assert issubclass(s, SymbolBase)
+
+    def bind(fn):
+        setattr(s, fn.__name__, fn)
+        return fn
+
+    return bind
+
+symbol, infix, infix_r, prefix, postfix, ternary = (
+    symbol_table.symbol, symbol_table.infix, symbol_table.infix_r, symbol_table.prefix,
+    symbol_table.postfix, symbol_table.ternary
+)
+
+symbol('(', 270)
+symbol(')')
+symbol('[', 250)  # Parameters
+symbol(']')
+symbol('->', 230)
+infix('|', 170)
+infix('or', 170)
+symbol(',')
+
+symbol('(name)')
+symbol('(end)')
+
+
+@method(symbol('(name)'))
+def nud(self, parser):
+    return self
+
+
+@method(symbol('(name)'))
+def evaluate(self, pyobject):
+    return utils.resolve_type(self.value, pyobject)
+
+
+# Parametrized objects
+@method(symbol('['))
+def led(self, left, parser):
+    self.first = left
+    self.second = []
+    if parser.token.name != ']':
+        while 1:
+            if parser.token.name == ']':
+                break
+            self.second.append(parser.expression())
+            if parser.token.name != ',':
+                break
+            parser.advance(',')
+    parser.advance(']')
+    return self
+
+
+@method(symbol('['))
+def evaluate(self, pyobject):
+    return utils.parametrize_type(
+        self.first.evaluate(pyobject),
+        *[i.evaluate(pyobject) for i in self.second]
+    )
+
+
+# Anonymous Function Calls
+@method(symbol('('))
+def nud(self, parser):
+    self.second = []
+    if parser.token.name != ')':
+        while 1:
+            self.second.append(parser.expression())
+            if parser.token.name != ',':
+                break
+            parser.advance(',')
+    parser.advance(')')
+    parser.advance('->')
+    self.third = parser.expression(symbol('->').lbp + 0.1)
+    return self
+
+
+# Function Calls
+@method(symbol('('))
+def led(self, left, parser):
+    self.first = left
+    self.second = []
+    if parser.token.name != ')':
+        while 1:
+            self.second.append(parser.expression())
+            if parser.token.name != ',':
+                break
+            parser.advance(',')
+    parser.advance(')')
+    parser.advance('->')
+    self.third = parser.expression(symbol('->').lbp + 0.1)
+    return self
+
+
+@method(symbol('('))
+def evaluate(self, pyobject):
+    # TODO: Implement me
+    raise NotImplementedError
+
+
+@method(symbol('or'))
+@method(symbol('|'))
+def evaluate(self, pyobject):
+    # TODO: Implement me
+    raise  NotImplementedError
+
+
+class Compiler(object):
+
+    parser_factory = Parser
+    lexer_factory = Lexer
+    symbol_table = symbol_table
+
+    def _make_parser(self):
+        return self.parser_factory(self.lexer_factory(self.symbol_table))
+
+    @base_utils.cached(500)
+    def __call__(self, program):
+        """
+        :type program: str
+        :rtype: rope.base.oi.type_hinting.evaluate.SymbolBase
+        """
+        return self._make_parser().parse(program)
+
+compile = Compiler()
+
+
+class Evaluator(object):
+
+    compile = compile
+
+    def __call__(self, program, pyobject):
+        """Evaluates the program string or AST
+
+        :type program: str or rope.base.oi.type_hinting.evaluate.SymbolBase
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
+        """
+        ast = self.compile(program) if isinstance(program, pycompat.string_types) else program
+        return ast.evaluate(pyobject)
+
+evaluate = Evaluator()

--- a/rope/base/oi/type_hinting/factory.py
+++ b/rope/base/oi/type_hinting/factory.py
@@ -2,6 +2,7 @@ from rope.base.oi.type_hinting import interfaces
 from rope.base.oi.type_hinting.providers import (
     composite, inheritance, docstrings, numpydocstrings, pep0484_type_comments
 )
+from rope.base.oi.type_hinting.resolvers import composite as composite_resolvers, types
 from rope.base import utils
 
 
@@ -10,26 +11,37 @@ class TypeHintingFactory(interfaces.ITypeHintingFactory):
     @utils.saveit
     def make_param_provider(self):
         providers = [
-            docstrings.ParamProvider(docstrings.DocstringParamParser()),
-            docstrings.ParamProvider(numpydocstrings.NumPyDocstringParamParser()),
+            docstrings.ParamProvider(docstrings.DocstringParamParser(), self.make_resolver()),
+            docstrings.ParamProvider(numpydocstrings.NumPyDocstringParamParser(), self.make_resolver()),
         ]
         return inheritance.ParamProvider(composite.ParamProvider(*providers))
 
     @utils.saveit
     def make_return_provider(self):
         providers = [
-            docstrings.ReturnProvider(docstrings.DocstringReturnParser()),
+            docstrings.ReturnProvider(docstrings.DocstringReturnParser(), self.make_resolver()),
         ]
         return inheritance.ReturnProvider(composite.ReturnProvider(*providers))
 
     @utils.saveit
     def make_assignment_provider(self):
         providers = [
-            pep0484_type_comments.AssignmentProvider(),
-            docstrings.AssignmentProvider(docstrings.DocstringParamParser()),
-            docstrings.AssignmentProvider(numpydocstrings.NumPyDocstringParamParser()),
+            pep0484_type_comments.AssignmentProvider(self.make_resolver()),
+            docstrings.AssignmentProvider(docstrings.DocstringParamParser(), self.make_resolver()),
+            docstrings.AssignmentProvider(numpydocstrings.NumPyDocstringParamParser(), self.make_resolver()),
         ]
         return inheritance.AssignmentProvider(composite.AssignmentProvider(*providers))
+
+    @utils.saveit
+    def make_resolver(self):
+        """
+        :rtype: rope.base.oi.type_hinting.resolvers.interfaces.IResolver
+        """
+        resolvers = [
+            types.Resolver(),
+        ]
+        return composite_resolvers.Resolver(*resolvers)
+
 
 default_type_hinting_factory = TypeHintingFactory()
 

--- a/rope/base/oi/type_hinting/interfaces.py
+++ b/rope/base/oi/type_hinting/interfaces.py
@@ -4,13 +4,22 @@ class ITypeHintingFactory(object):
         """
         :rtype: rope.base.oi.type_hinting.providers.interfaces.IParamProvider
         """
+        raise NotImplementedError
 
     def make_return_provider(self):
         """
         :rtype: rope.base.oi.type_hinting.providers.interfaces.IReturnProvider
         """
+        raise NotImplementedError
 
     def make_assignment_provider(self):
         """
         :rtype: rope.base.oi.type_hinting.providers.interfaces.IAssignmentProvider
         """
+        raise NotImplementedError
+
+    def make_resolver(self):
+        """
+        :rtype: rope.base.oi.type_hinting.resolvers.interfaces.IResolver
+        """
+        raise NotImplementedError

--- a/rope/base/oi/type_hinting/providers/composite.py
+++ b/rope/base/oi/type_hinting/providers/composite.py
@@ -13,7 +13,7 @@ class ParamProvider(interfaces.IParamProvider):
         """
         :type pyfunc: rope.base.pyobjectsdef.PyFunction
         :type param_name: str
-        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
         """
         for delegate in self._delegates:
             result = delegate(pyfunc, param_name)
@@ -32,7 +32,7 @@ class ReturnProvider(interfaces.IReturnProvider):
     def __call__(self, pyfunc):
         """
         :type pyfunc: rope.base.pyobjectsdef.PyFunction
-        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
         """
         for delegate in self._delegates:
             result = delegate(pyfunc)
@@ -51,7 +51,7 @@ class AssignmentProvider(interfaces.IAssignmentProvider):
     def __call__(self, pyname):
         """
         :type pyname: rope.base.pynamesdef.AssignedName
-        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
         """
         for delegate in self._delegates:
             result = delegate(pyname)

--- a/rope/base/oi/type_hinting/providers/inheritance.py
+++ b/rope/base/oi/type_hinting/providers/inheritance.py
@@ -14,7 +14,7 @@ class ParamProvider(interfaces.IParamProvider):
         """
         :type pyfunc: rope.base.pyobjectsdef.PyFunction
         :type param_name: str
-        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
         """
         superfunc = pyfunc
         while superfunc:
@@ -35,7 +35,7 @@ class ReturnProvider(interfaces.IReturnProvider):
     def __call__(self, pyfunc):
         """
         :type pyfunc: rope.base.pyobjectsdef.PyFunction
-        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
         """
         superfunc = pyfunc
         while superfunc:
@@ -56,7 +56,7 @@ class AssignmentProvider(interfaces.IAssignmentProvider):
     def __call__(self, pyname):
         """
         :type pyname: rope.base.pynamesdef.AssignedName
-        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
         """
         super_pyname = pyname
         while super_pyname:

--- a/rope/base/oi/type_hinting/providers/interfaces.py
+++ b/rope/base/oi/type_hinting/providers/interfaces.py
@@ -4,26 +4,34 @@ class IParamProvider(object):
         """
         :type pyfunc: rope.base.pyobjectsdef.PyFunction
         :type param_name: str
-        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
         """
         raise NotImplementedError
 
 
 class IReturnProvider(object):
+    """
+    :type resolve: rope.base.oi.type_hinting.resolvers.interfaces.IResolver
+    """
+    resolve = None
 
     def __call__(self, pyfunc):
         """
         :type pyfunc: rope.base.pyobjectsdef.PyFunction
-        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
         """
         raise NotImplementedError
 
 
 class IAssignmentProvider(object):
+    """
+    :type resolve: rope.base.oi.type_hinting.resolvers.interfaces.IResolver
+    """
+    resolve = None
 
     def __call__(self, pyname):
         """
         :type pyname: rope.base.pynamesdef.AssignedName
-        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
         """
         raise NotImplementedError

--- a/rope/base/oi/type_hinting/providers/pep0484_type_comments.py
+++ b/rope/base/oi/type_hinting/providers/pep0484_type_comments.py
@@ -5,14 +5,20 @@ from rope.base.oi.type_hinting.providers import interfaces
 
 class AssignmentProvider(interfaces.IAssignmentProvider):
 
+    def __init__(self, resolver):
+        """
+        :type resolver: rope.base.oi.type_hinting.resolvers.interfaces.IResolver
+        """
+        self._resolve = resolver
+
     PEP0484_TYPE_COMMENT_PATTERNS = (
-        re.compile(r'type:\s*([^\n, ]+)'),
+        re.compile(r'type:\s*([^\n]+)'),
     )
 
     def __call__(self, pyname):
         """
         :type pyname: rope.base.pynamesdef.AssignedName
-        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
         """
         from rope.base.oi.soi import _get_lineno_for_node
         lineno = _get_lineno_for_node(pyname.assignments[0].ast_node)
@@ -21,7 +27,7 @@ class AssignmentProvider(interfaces.IAssignmentProvider):
         if '#' in line:
             type_strs = self._search_type_in_type_comment(line.split('#', 1)[1])
             if type_strs:
-                return utils.resolve_type(type_strs[0], holding_scope.pyobject)
+                return self._resolve(type_strs[0], holding_scope.pyobject)
 
     def _search_type_in_type_comment(self, code):
         """ For more info see:

--- a/rope/base/oi/type_hinting/resolvers/composite.py
+++ b/rope/base/oi/type_hinting/resolvers/composite.py
@@ -1,0 +1,22 @@
+from rope.base.oi.type_hinting.resolvers import interfaces
+
+
+class Resolver(interfaces.IResolver):
+
+    def __init__(self, *delegates):
+        """
+        :type delegates: list[rope.base.oi.type_hinting.resolvers.interfaces.IResolver]
+        """
+        self._delegates = delegates
+
+    def __call__(self, hint, pyobject):
+        """
+        :param hint: For example "List[int]" or "(Foo, Bar) -> Baz" or simple "Foo"
+        :type hint: str
+        :type pyobject: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
+        """
+        for delegate in self._delegates:
+            result = delegate(hint, pyobject)
+            if result:
+                return result

--- a/rope/base/oi/type_hinting/resolvers/interfaces.py
+++ b/rope/base/oi/type_hinting/resolvers/interfaces.py
@@ -1,0 +1,10 @@
+class IResolver(object):
+
+    def __call__(self, hint, pyobject):
+        """
+        :param hint: For example "List[int]" or "(Foo, Bar) -> Baz" or simple "Foo"
+        :type hint: str
+        :type pyobject: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
+        """
+        raise NotImplementedError

--- a/rope/base/oi/type_hinting/resolvers/types.py
+++ b/rope/base/oi/type_hinting/resolvers/types.py
@@ -1,0 +1,16 @@
+from rope.base.oi.type_hinting import evaluate
+from rope.base.oi.type_hinting.resolvers import interfaces
+
+
+class Resolver(interfaces.IResolver):
+    def __call__(self, hint, pyobject):
+        """
+        :param hint: For example "List[int]" or "(Foo, Bar) -> Baz" or simple "Foo"
+        :type hint: str
+        :type pyobject: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject
+        :rtype: rope.base.pyobjects.PyDefinedObject | rope.base.pyobjects.PyObject or None
+        """
+        try:
+            return evaluate.evaluate(hint, pyobject)
+        except (Exception):
+            pass

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -215,6 +215,8 @@ class PyModule(pyobjects.PyModule):
         """A `LogicalLinesFinder`"""
         return rope.base.codeanalyze.CachingLogicalLineFinder(self.lines)
 
+    def get_name(self):
+        return rope.base.libutils.modname(self.get_resource())
 
 class PyPackage(pyobjects.PyPackage):
 


### PR DESCRIPTION
Added parser for type-comments and docstrings, added support for the following syntax:

- Foo
- foo.bar.Baz
- list[Foo] or list[foo.bar.Baz] etc.
- set[Foo]
- tuple[Foo]
- dict[Foo, Bar]
- collections.Iterable[Foo]
- collections.Iterator[Foo]

Nested expressions also allowed:

- collections.Iterable[list[Foo]]