### PR TITLE
Add an option to disable sorting imports entirely

### DIFF
--- a/rope/base/default_config.py
+++ b/rope/base/default_config.py
@@ -89,9 +89,13 @@ def set_prefs(prefs):
     # imports.
     prefs['split_imports'] = False
 
-    # If `True`, rope will sort imports alphabetically by module name
-    # instead of alphabetically by import statement, with from imports
-    # after normal imports.
+    # If `True`, rope will sort the top-level import statements and
+    # reinsert them at the top of the module when making changes.
+    prefs['sort_imports_at_top'] = True
+
+    # If `True` (and `sort_imports_at_top` is also `True`), rope will sort
+    # imports alphabetically by module name instead of alphabetically by import
+    # statement, with from imports after normal imports.
     prefs['sort_imports_alphabetically'] = False
 
     # Location of implementation of rope.base.oi.type_hinting.interfaces.ITypeHintingFactory

--- a/rope/base/default_config.py
+++ b/rope/base/default_config.py
@@ -89,13 +89,13 @@ def set_prefs(prefs):
     # imports.
     prefs['split_imports'] = False
 
-    # If `True`, rope will sort the top-level import statements and
+    # If `True`, rope will remove all top-level import statements and
     # reinsert them at the top of the module when making changes.
-    prefs['sort_imports_at_top'] = True
+    prefs['pull_imports_to_top'] = True
 
-    # If `True` (and `sort_imports_at_top` is also `True`), rope will sort
-    # imports alphabetically by module name instead of alphabetically by import
-    # statement, with from imports after normal imports.
+    # If `True`, rope will sort imports alphabetically by module name instead of
+    # alphabetically by import statement, with from imports after normal
+    # imports.
     prefs['sort_imports_alphabetically'] = False
 
     # Location of implementation of rope.base.oi.type_hinting.interfaces.ITypeHintingFactory

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -12,6 +12,7 @@ class ModuleImports(object):
         self.pymodule = pymodule
         self.separating_lines = 0
         self.filter = import_filter
+        self.sorted = False
 
     @property
     @utils.saveit
@@ -50,7 +51,8 @@ class ModuleImports(object):
         return result
 
     def get_changed_source(self):
-        if not self.project.prefs.get("sort_imports_at_top"):
+        if (not self.project.prefs.get("pull_imports_to_top") and
+            not self.sorted):
             return ''.join(self._rewrite_imports(self.imports))
 
         # Make sure we forward a removed import's preceding blank
@@ -211,8 +213,6 @@ class ModuleImports(object):
         return self.pymodule.get_resource().parent
 
     def sort_imports(self):
-        if not self.project.prefs.get("sort_imports_at_top"):
-            return
         if self.project.prefs.get("sort_imports_alphabetically"):
             sort_kwargs = dict(key=self._get_import_name)
         else:
@@ -232,6 +232,7 @@ class ModuleImports(object):
         last_index = self._move_imports(third_party, last_index, 1)
         last_index = self._move_imports(in_projects, last_index, 1)
         self.separating_lines = 2
+        self.sorted = True
 
     def _first_import_line(self):
         nodes = self.pymodule.get_ast().body

--- a/ropetest/refactor/importutilstest.py
+++ b/ropetest/refactor/importutilstest.py
@@ -278,6 +278,18 @@ class ImportUtilsTest(unittest.TestCase):
         self.assertEquals('import pkg1.mod1\n',
                           module_with_imports.get_changed_source())
 
+    def test_adding_imports_no_sort(self):
+        self.mod.write('import pkg2.mod3\nclass A(object):\n    pass\n\n'
+                       'import pkg2.mod2\n')
+        pymod = self.project.get_module('mod')
+        self.project.prefs['sort_imports_at_top'] = False
+        module_with_imports = self.import_tools.module_imports(pymod)
+        new_import = self.import_tools.get_import(self.mod1)
+        module_with_imports.add_import(new_import)
+        self.assertEquals('import pkg2.mod3\nclass A(object):\n    pass\n\n'
+                          'import pkg2.mod2\nimport pkg1.mod1\n',
+                          module_with_imports.get_changed_source())
+
     def test_adding_from_imports(self):
         self.mod1.write('def a_func():\n    pass\n'
                         'def another_func():\n    pass\n')
@@ -633,6 +645,17 @@ class ImportUtilsTest(unittest.TestCase):
                           self.import_tools.organize_imports(pymod,
                                                              unused=False))
 
+    def test_splitting_imports_no_sort(self):
+        self.mod.write('from pkg2 import mod3, mod4\n'
+                       'from pkg1 import mod2\nfrom pkg1 import mod1\n')
+        pymod = self.project.get_pymodule(self.mod)
+        self.project.prefs['split_imports'] = True
+        self.project.prefs['sort_imports_at_top'] = False
+        self.assertEquals('from pkg1 import mod2\nfrom pkg1 import mod1\n'
+                          'from pkg2 import mod3\nfrom pkg2 import mod4\n',
+                          self.import_tools.organize_imports(pymod,
+                                                             unused=False))
+
     def test_splitting_imports_with_filter(self):
         self.mod.write('from pkg1 import mod1, mod2\n'
                        'from pkg2 import mod3, mod4\n')
@@ -865,6 +888,14 @@ class ImportUtilsTest(unittest.TestCase):
         pymod = self.project.get_module('mod')
         self.assertEquals('import mod\n\n\ndef f():\n    print(mod)\n',
                           self.import_tools.sort_imports(pymod))
+
+    def test_sorting_imports_with_sort_disabled(self):
+        code = ('import mod\ndef f():\n    print(mod, pkg1, pkg2)\n'
+                'import pkg1\nimport pkg2\n')
+        self.mod.write(code)
+        pymod = self.project.get_module('mod')
+        self.project.prefs['sort_imports_at_top'] = False
+        self.assertEquals(code, self.import_tools.sort_imports(pymod))
 
     def test_sorting_imports_moving_to_top_and_module_docs(self):
         self.mod.write('"""\ndocs\n"""\ndef f():'


### PR DESCRIPTION
Rope, by default, rewrites import statements by removing all the
top-level import lines from the file, then sorting them, then
reinserting them at the top. This behavior of pulling everything to the
top of the file can be undesirable. As an alternative, we can rewrite
the imports in place, which won't sort them, but also won't impose this
extra constraint that all top-level imports must be at the top.