### PR TITLE
Added support for `async def`.

### DIFF
--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -354,6 +354,9 @@ class _ScopeVisitor(object):
             self.names[node.name] = pynames.DefinedName(pyfunction)
         self.defineds.append(pyfunction)
 
+    def _AsyncFunctionDef(self, node):
+        return self._FunctionDef(node)
+
     def _Assign(self, node):
         ast.walk(node, _AssignVisitor(self))
 

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -165,6 +165,7 @@ class RenameRefactoringTest(unittest.TestCase):
         self.assertEquals('def new_func():\n    pass\nnew_func()\n',
                           refactored)
 
+    @testutils.only_for('3.5')
     def test_renaming_async_function(self):
         code = 'async def a_func():\n    pass\na_func()'
         refactored = self._local_rename(code, len(code) - 5, 'new_func')

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -165,6 +165,12 @@ class RenameRefactoringTest(unittest.TestCase):
         self.assertEquals('def new_func():\n    pass\nnew_func()\n',
                           refactored)
 
+    def test_renaming_async_function(self):
+        code = 'async def a_func():\n    pass\na_func()'
+        refactored = self._local_rename(code, len(code) - 5, 'new_func')
+        self.assertEquals('async def new_func():\n    pass\nnew_func()',
+                          refactored)
+
     def test_renaming_functions_across_modules(self):
         mod1 = testutils.create_module(self.project, 'mod1')
         mod1.write('def a_func():\n    pass\na_func()\n')


### PR DESCRIPTION
This includes a basic unit test, though it might be good to extend all of the
current function rename tests to test async as well.