### PR TITLE
Complete async

### DIFF
--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -354,6 +354,9 @@ class _ScopeVisitor(object):
             self.names[node.name] = pynames.DefinedName(pyfunction)
         self.defineds.append(pyfunction)
 
+    def _AsyncFunctionDef(self, node):
+        return self._FunctionDef(node)
+
     def _Assign(self, node):
         ast.walk(node, _AssignVisitor(self))
 

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -404,6 +404,9 @@ class _ScopeVisitor(object):
         for child in node.body:
             ast.walk(child, self)
 
+    def _AsyncWith(self, node):
+        return self._With(node)
+
     def _excepthandler(self, node):
         node_name_type = str if pycompat.PY3 else ast.Name
         if node.name is not None and isinstance(node.name, node_name_type):

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -369,6 +369,9 @@ class _ScopeVisitor(object):
         for child in node.body + node.orelse:
             ast.walk(child, self)
 
+    def _AsyncFor(self, node):
+        return self._For(node)
+
     def _assigned(self, name, assignment):
         pyname = self.names.get(name, None)
         if pyname is None:

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -172,6 +172,14 @@ class RenameRefactoringTest(unittest.TestCase):
         self.assertEquals('async def new_func():\n    pass\nnew_func()',
                           refactored)
 
+    @testutils.only_for('3.5')
+    def test_renaming_await(self):
+        code = 'async def b_func():\n    pass\nasync def a_func():\n    await b_func()'
+        refactored = self._local_rename(code, len(code) - 5, 'new_func')
+        self.assertEquals('async def new_func():\n    pass\nasync def a_func():\n    await new_func()',
+                          refactored)
+
+
     def test_renaming_functions_across_modules(self):
         mod1 = testutils.create_module(self.project, 'mod1')
         mod1.write('def a_func():\n    pass\na_func()\n')

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -364,6 +364,22 @@ class RenameRefactoringTest(unittest.TestCase):
         self.assertEquals('async def func():\n    async for new_var in range(10):\n        print(new_var)\n',
                           refactored)
 
+    @testutils.only_for('3.5')
+    def test_renaming_async_with_context_manager(self):
+        code = 'def a_cm(): pass\n'\
+               'async def a_func():\n    async with a_cm() as x: pass'
+        refactored = self._local_rename(code, code.find('a_cm') + 1, 'another_cm')
+        expected = 'def another_cm(): pass\n'\
+                   'async def a_func():\n    async with another_cm() as x: pass'
+        self.assertEquals(refactored, expected)
+
+    @testutils.only_for('3.5')
+    def test_renaming_async_with_as_variable(self):
+        code = 'async def func():\n    async with a_func() as var:\n        print(var)\n'
+        refactored = self._local_rename(code, code.find('var') + 1, 'new_var')
+        self.assertEquals('async def func():\n    async with a_func() as new_var:\n        print(new_var)\n',
+                          refactored)
+
     def test_renaming_parameters(self):
         code = 'def a_func(param):\n    print(param)\na_func(param=hey)\n'
         refactored = self._local_rename(code, code.find('param') + 1,

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -357,6 +357,13 @@ class RenameRefactoringTest(unittest.TestCase):
         self.assertEquals('for new_var in range(10):\n    print(new_var)\n',
                           refactored)
 
+    @testutils.only_for('3.5')
+    def test_renaming_async_for_loop_variable(self):
+        code = 'async def func():\n    async for var in range(10):\n        print(var)\n'
+        refactored = self._local_rename(code, code.find('var') + 1, 'new_var')
+        self.assertEquals('async def func():\n    async for new_var in range(10):\n        print(new_var)\n',
+                          refactored)
+
     def test_renaming_parameters(self):
         code = 'def a_func(param):\n    print(param)\na_func(param=hey)\n'
         refactored = self._local_rename(code, code.find('param') + 1,

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -165,6 +165,7 @@ class RenameRefactoringTest(unittest.TestCase):
         self.assertEquals('def new_func():\n    pass\nnew_func()\n',
                           refactored)
 
+    @testutils.only_for('3.5')
     def test_renaming_async_function(self):
         code = 'async def a_func():\n    pass\na_func()'
         refactored = self._local_rename(code, len(code) - 5, 'new_func')

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -165,6 +165,12 @@ class RenameRefactoringTest(unittest.TestCase):
         self.assertEquals('def new_func():\n    pass\nnew_func()\n',
                           refactored)
 
+    def test_renaming_async_function(self):
+        code = 'async def a_func():\n    pass\na_func()'
+        refactored = self._local_rename(code, len(code) - 5, 'new_func')
+        self.assertEquals('async def new_func():\n    pass\nnew_func()',
+                          refactored)
+
     def test_renaming_functions_across_modules(self):
         mod1 = testutils.create_module(self.project, 'mod1')
         mod1.write('def a_func():\n    pass\na_func()\n')


### PR DESCRIPTION
This builds upon [the `async def` PR](https://github.com/python-rope/rope/pull/217) to add support for all of the new async-related nodes.

A few notes:

- It didn't seem necessary to do anything with the `Await` node, so I didn't add it to the AST walker.
- I'm not entirely sure if aliasing `_With` for `_AsyncWith` is correct. The `with` handler is doing *something* with `__enter__`, but the equivalent for `async with` would be `__aenter__`. Everything seems to work, but a more expert eye would certainly be welcome.