### PR TITLE
Treat timemodule.so as a special case for Fedora python2

### DIFF
--- a/rope/base/stdmods.py
+++ b/rope/base/stdmods.py
@@ -43,6 +43,10 @@ def normalize_so_name(name):
     """
     if "cpython" in name:
         return os.path.splitext(os.path.splitext(name)[0])[0]
+    # XXX: Special handling for Fedora python2 distribution
+    # See: https://github.com/python-rope/rope/issues/211
+    if name == "timemodule.so":
+        return "time"
     return os.path.splitext(name)[0]
 
 

--- a/ropetest/builtinstest.py
+++ b/ropetest/builtinstest.py
@@ -502,6 +502,11 @@ class BuiltinModulesTest(unittest.TestCase):
         import rope.base.stdmods
         self.assertTrue('time' in rope.base.stdmods.standard_modules())
 
+    def test_timemodule_normalizes_to_time(self):
+        import rope.base.stdmods
+        self.assertEqual(
+            rope.base.stdmods.normalize_so_name('timemodule.so'), 'time')
+
 
 def suite():
     result = unittest.TestSuite()


### PR DESCRIPTION
Fixes #211 