### PR TITLE
Bugfix for detecting pynames in aliased import statements

### DIFF
--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -101,8 +101,9 @@ class ScopeNameFinder(object):
                                                      offset, lineno):
             name = self.worder.get_primary_at(offset).strip()
             return (None, holding_scope.parent[name])
-        # from statement module
-        if self.worder.is_from_statement_module(offset):
+        # module in a from statement or an imported name that is aliased
+        if (self.worder.is_from_statement_module(offset) or
+            self.worder.is_import_statement_aliased_module(offset)):
             module = self.worder.get_primary_at(offset)
             module_pyname = self._find_module(module)
             return (None, module_pyname)

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -223,6 +223,16 @@ class RenameRefactoringTest(unittest.TestCase):
                         self.project.find_module('newmod') is not None)
         self.assertEquals('from newmod import a_func\n', mod2.read())
 
+    def test_renaming_modules_aliased(self):
+        mod1 = testutils.create_module(self.project, 'mod1')
+        mod1.write('def a_func():\n    pass\n')
+        mod2 = testutils.create_module(self.project, 'mod2')
+        mod2.write('import mod1 as m\nm.a_func()\n')
+        self._rename(mod1, None, 'newmod')
+        self.assertTrue(not mod1.exists() and
+                        self.project.find_module('newmod') is not None)
+        self.assertEquals('import newmod as m\nm.a_func()\n', mod2.read())
+
     def test_renaming_packages(self):
         pkg = testutils.create_package(self.project, 'pkg')
         mod1 = testutils.create_module(self.project, 'mod1', pkg)


### PR DESCRIPTION
This case wasn't being handled correctly; e.g, the pyname for "foo" in
`import foo as bar` evaluates to an `AssignedName` instead of an
`ImportedModule`. This is similar to the module name in a "from" import,
adding a special case to handle it in the same way.

Fixes #229 