### PR TITLE
When inlining function allow comparisons in arguments

### DIFF
--- a/rope/base/worder.py
+++ b/rope/base/worder.py
@@ -488,7 +488,8 @@ class _RealFinder(object):
         while current > first:
             primary_start = current
             current = self._find_primary_start(current)
-            while current != first and self.code[current] not in '=,':
+            while current != first and (self.code[current] not in '=,'
+                    or self.code[current-1] in '=!<>'):
                 current = self._find_last_non_space_char(current - 1)
             primary = self.raw[current + 1:primary_start + 1].strip()
             if self.code[current] == '=':

--- a/ropetest/refactor/inlinetest.py
+++ b/ropetest/refactor/inlinetest.py
@@ -217,6 +217,13 @@ class InlineTest(unittest.TestCase):
         self._inline2(self.mod, self.mod.read().index('a_func') + 1)
         self.assertEquals('print(1, 3)\n', self.mod.read())
 
+    def test_arguments_containing_comparisons(self):
+        self.mod.write('def a_func(param1, param2, param3):'
+                       '\n    param2.name\n'
+                       'a_func(2 <= 1, item, True)\n')
+        self._inline2(self.mod, self.mod.read().index('a_func') + 1)
+        self.assertEquals('item.name\n', self.mod.read())
+
     def test_badly_formatted_text(self):
         self.mod.write('def a_func  (  param1 =  1 ,param2 = 2 )  :'
                        '\n    print(param1, param2)\n'


### PR DESCRIPTION
When inlining `a_func`
```python
def a_func(param1, param2, param3):
    param2.name
a_func(2 <= 1, item, True)
```
the current result is `True.name`.

This is because the `2<= 1` argument is treated as a keyword argument and so the `True` argument becomes `param2`

This PR includes a fix to worder so it understands comparisons are not keyword arguments