### PR TITLE
Avoid overlapping regions when extract similar=True

### DIFF
--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -251,8 +251,15 @@ class _ExtractPerformer(object):
         finder = similarfinder.SimilarFinder(self.info.pymodule)
         matches = []
         for start, end in regions:
-            matches.extend((finder.get_matches(collector.body_pattern,
-                                               collector.checks, start, end)))
+            region_matches = finder.get_matches(collector.body_pattern,
+                                               collector.checks, start, end)
+            # Don't extract overlapping regions
+            last_match_end = -1
+            for region_match in region_matches:
+                start, end = region_match.get_region()
+                if last_match_end < start:
+                    matches.append(region_match)
+                    last_match_end = end
         collector.matches = matches
 
     def _where_to_search(self):

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -636,6 +636,27 @@ class ExtractMethodTest(unittest.TestCase):
                    '        self.attr = self.new_func(p2)\n'
         self.assertEquals(expected, refactored)
 
+    def test_extract_method_and_similar_sttemnts_overlapping_regions(self):
+        code = 'def func(p):\n' \
+               '    a = p\n' \
+               '    b = a\n' \
+               '    c = b\n' \
+               '    d = c\n' \
+               '    return d'
+        start = code.index('a')
+        end = code.rindex('a') + 1
+        refactored = self.do_extract_method(
+            code, start, end, 'new_func', similar=True)
+        expected = 'def func(p):\n' \
+                   '    b = new_func(p)\n' \
+                   '    d = new_func(b)\n' \
+                   '    return d\n' \
+                   'def new_func(p):\n' \
+                   '    a = p\n' \
+                   '    b = a\n' \
+                   '    return b\n'
+        self.assertEquals(expected, refactored)
+
     def test_definition_should_appear_where_it_is_visible(self):
         code = 'if True:\n    a = 1\nelse:\n    b = 1\n'
         start = code.rindex('1')


### PR DESCRIPTION
If similar regions are found during extract method that overlap, the refactored code is invalid

For example, if the first two lines of `func` are extracted
```python
def func(p):
    a = p
    b = a
    c = b
    d = c
    return d
```
the following is produced
```python
def func(p):
    b = new_func(p)c = new_func(a)d = new_func(b)
    b = new_func(p)
    d = new_func(b)
    return d
def new_func(p):
    a = p
    b = a
    return b
```

With this PR a correct refactoring is performed
```python
def func(p):
    b = new_func(p)
    d = new_func(b)
    return d
def new_func(p):
    a = p
    b = a
    return b
```