### PR TITLE
Rename variables in f-strings

### DIFF
--- a/rope/base/codeanalyze.py
+++ b/rope/base/codeanalyze.py
@@ -350,12 +350,21 @@ def count_line_indents(line):
     return 0
 
 
-def get_string_pattern():
-    start = r'(\b[uU]?[rR]?)?'
-    longstr = r'%s"""(\\.|"(?!"")|\\\n|[^"\\])*"""' % start
-    shortstr = r'%s"(\\.|\\\n|[^"\\])*"' % start
+def get_string_pattern_with_prefix(prefix):
+    longstr = r'%s"""(\\.|"(?!"")|\\\n|[^"\\])*"""' % prefix
+    shortstr = r'%s"(\\.|\\\n|[^"\\])*"' % prefix
     return '|'.join([longstr, longstr.replace('"', "'"),
                      shortstr, shortstr.replace('"', "'")])
+
+
+def get_string_pattern():
+    prefix = r'(?<![fF])(\b[uU]?[rR]?)?'
+    return get_string_pattern_with_prefix(prefix)
+
+
+def get_formatted_string_pattern():
+    prefix = r'(\b[rR]?[fF]|[fF][rR]?)'
+    return get_string_pattern_with_prefix(prefix)
 
 
 def get_comment_pattern():

--- a/rope/base/utils/pycompat.py
+++ b/rope/base/utils/pycompat.py
@@ -6,6 +6,7 @@ PY2 = sys.version_info[0] == 2
 PY27 = sys.version_info[0:2] >= (2, 7)
 PY3 = sys.version_info[0] == 3
 PY34 = sys.version_info[0:2] >= (3, 4)
+PY36 = sys.version_info[0:2] >= (3, 6)
 
 try:
     str = unicode

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -106,7 +106,7 @@ class RenameRefactoringTest(unittest.TestCase):
             'a_var = A(new_param=1)\n'
         self.assertEquals(expected, refactored)
 
-    def test_renam_functions_parameters_and_occurances_in_other_modules(self):
+    def test_rename_functions_parameters_and_occurences_in_other_modules(self):
         mod1 = testutils.create_module(self.project, 'mod1')
         mod2 = testutils.create_module(self.project, 'mod2')
         mod1.write('def a_func(a_param):\n    print(a_param)\n')
@@ -121,6 +121,29 @@ class RenameRefactoringTest(unittest.TestCase):
         refactored = self._local_rename(
             "replace = True\n'ali'.\\\nreplace\n", 2, 'is_replace')
         self.assertEquals("is_replace = True\n'ali'.\\\nreplace\n",
+                          refactored)
+
+    @testutils.only_for('3.6')
+    def test_renaming_occurrence_in_f_string(self):
+        refactored = self._local_rename(
+            "a_var = 20\na_string=f'value: {a_var}'\n", 2, 'new_var')
+        self.assertEquals("new_var = 20\na_string=f'value: {new_var}'\n",
+                          refactored)
+        return f'{refactored}'
+
+    @testutils.only_for('3.6')
+    def test_renaming_occurrence_in_nested_f_string(self):
+        refactored = self._local_rename(
+            "a_var = 20\na_string=f'{f\"{a_var}\"}'\n", 2, 'new_var')
+        self.assertEquals(
+            "new_var = 20\na_string=f'{f\"{new_var}\"}'\n",
+            refactored)
+
+    @testutils.only_for('3.6')
+    def test_not_renaming_string_contents_in_f_string(self):
+        refactored = self._local_rename(
+            "a_var = 20\na_string=f'{\"a_var\"}'\n", 2, 'new_var')
+        self.assertEquals("new_var = 20\na_string=f'{\"a_var\"}'\n",
                           refactored)
 
     def test_not_renaming_string_contents(self):

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -129,7 +129,6 @@ class RenameRefactoringTest(unittest.TestCase):
             "a_var = 20\na_string=f'value: {a_var}'\n", 2, 'new_var')
         self.assertEquals("new_var = 20\na_string=f'value: {new_var}'\n",
                           refactored)
-        return f'{refactored}'
 
     @testutils.only_for('3.6')
     def test_renaming_occurrence_in_nested_f_string(self):


### PR DESCRIPTION
Adds support for renaming variables in PEP-498 f-strings for Python >= 3.6, using the `ast` module to parse f-strings while searching for occurrences of the variable. This resolves #226.
