### PR TITLE
Setup version

### DIFF
--- a/rope/__init__.py
+++ b/rope/__init__.py
@@ -1,7 +1,7 @@
 """rope, a python refactoring library"""
 
 INFO = __doc__
-VERSION = '0.11.0'
+VERSION = '0.12.0'
 COPYRIGHT = """\
 Copyright (C) 2015-2018 Nicholas Smith
 Copyright (C) 2014-2015 Matej Cepl

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import io
+import os.path
 import sys
 
 try:
@@ -9,12 +10,6 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-
-import rope
-
-import ropetest
-import ropetest.contrib
-import ropetest.refactor
 
 
 class RunTests(Command):
@@ -31,6 +26,7 @@ class RunTests(Command):
         pass
 
     def run(self):
+        import ropetest
         tests = unittest.TestSuite(ropetest.suite())
         runner = unittest.TextTestRunner(verbosity=2)
         results = runner.run(tests)
@@ -58,12 +54,25 @@ classifiers = [
 
 
 def get_long_description():
-    lines = io.open('README.rst', 'r', encoding='utf8').read().splitlines(False)
+    lines = io.open('README.rst', 'r',
+                    encoding='utf8').read().splitlines(False)
     end = lines.index('Getting Started')
     return '\n' + '\n'.join(lines[:end]) + '\n'
 
+
+def get_version():
+    version = None
+    with io.open(os.path.join(
+            os.path.dirname(__file__), 'rope', '__init__.py')) as inif:
+        for line in inif:
+            if line.startswith('VERSION'):
+                version = line.split('=')[1].strip(" \t'")
+                break
+    return version
+
+
 setup(name='rope',
-      version=rope.VERSION,
+      version=get_version(),
       description='a python refactoring library...',
       long_description=get_long_description(),
       author='Ali Gholami Rudi',


### PR DESCRIPTION
I have this bug report in [email](https://groups.google.com/d/msg/rope-dev/afB5KgNhSvk/zkubyRUZAwAJ):
```
OS: windows 10
Python: 3.6.7

When I install rope, I have this error: 

Collecting rope
  Using cached 
https://files.pythonhosted.org/packages/af/9b/e92c1d561631da9fbeaf4d5d67ecb65b7d284a63069ee37aec44a2eefae4/rope-0.12.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File 
"C:\Users\abukreev\AppData\Local\Temp\pip-install-jve2b1hl\rope\setup.py", 
line 13, in <module>
        import rope
    ModuleNotFoundError: No module named 'rope'
```

I agree that importing too much in setup.py is a bad idea.

What do you think?