### PR TITLE
Fix return value of __enter__ for builtin File

### DIFF
--- a/rope/base/builtins.py
+++ b/rope/base/builtins.py
@@ -603,7 +603,7 @@ class File(BuiltinClass):
                 BuiltinFunction(returned=returned, function=function,
                                 builtin=builtin))
         add('__iter__', get_iterator(str_object))
-        add('__enter__', returned=self)
+        add('__enter__', returned=pyobjects.PyObject(self))
         for method in ['next', 'read', 'readline', 'readlines']:
             add(method, str_list)
         for method in ['close', 'flush', 'lineno', 'isatty', 'seek', 'tell',

--- a/ropetest/pycoretest.py
+++ b/ropetest/pycoretest.py
@@ -1,6 +1,6 @@
 import sys
 
-from rope.base.builtins import File
+from rope.base.builtins import File, BuiltinClass
 
 try:
     import unittest2 as unittest
@@ -555,10 +555,15 @@ class PyCoreTest(unittest.TestCase):
         pymod.get_attributes()
 
     def test_with_statement(self):
-        code = 'with open("file") as f:    pass\n'
+        code = 'a = 10\n' \
+               'with open("file") as f:    pass\n'
         pymod = libutils.get_string_module(self.project, code)
-        assigned = pymod.get_attributes()['f']
-        self.assertEqual(File, type(assigned.get_object()))
+
+        assigned = pymod.get_attribute('a')
+        self.assertEqual(BuiltinClass, type(assigned.get_object().get_type()))
+
+        assigned = pymod.get_attribute('f')
+        self.assertEqual(File, type(assigned.get_object().get_type()))
 
     def test_check_for_else_block(self):
         code = 'for i in range(10):\n' \


### PR DESCRIPTION
When __enter__ is called within a 'with' expression, wrap the
return value with a pyobject instead of returning 'File' directly.
This will keep us consistent with existing functionality