### PR TITLE
get_string_pattern_with_prefix short str pattern modified

### DIFF
--- a/rope/base/codeanalyze.py
+++ b/rope/base/codeanalyze.py
@@ -352,7 +352,7 @@ def count_line_indents(line):
 
 def get_string_pattern_with_prefix(prefix):
     longstr = r'%s"""(\\.|"(?!"")|\\\n|[^"\\])*"""' % prefix
-    shortstr = r'%s"(\\.|\\\n|[^"\\])*"' % prefix
+    shortstr = r'%s"(\\.|\\\n|[^"\\\n])*"' % prefix
     return '|'.join([longstr, longstr.replace('"', "'"),
                      shortstr, shortstr.replace('"', "'")])
 

--- a/ropetest/codeanalyzetest.py
+++ b/ropetest/codeanalyzetest.py
@@ -347,10 +347,6 @@ class WordRangeFinderTest(unittest.TestCase):
         finder = worder.Worder(code)
         self.assertEqual(finder.get_word_range(45), (45, 49))
 
-    def test_get_word_range_with_fstring2(self):
-        code = "auth = 8\nmy_var = f'some value {auth}'\nprint(auth)\nother_val = 'some other'"
-        finder = worder.Worder(code)
-        self.assertEqual(finder.get_word_range(45), (45, 49))
 
 class ScopeNameFinderTest(unittest.TestCase):
 

--- a/ropetest/codeanalyzetest.py
+++ b/ropetest/codeanalyzetest.py
@@ -342,6 +342,15 @@ class WordRangeFinderTest(unittest.TestCase):
         finder = worder.Worder(code)
         self.assertTrue(finder.is_on_function_call_keyword(len(code) - 1))
 
+    def test_get_word_range_with_fstring(self):
+        code = 'auth = 8\nmy_var = f"some value {auth}"\nprint(auth)\nother_val = "some other"'
+        finder = worder.Worder(code)
+        self.assertEqual(finder.get_word_range(45), (45, 49))
+
+    def test_get_word_range_with_fstring2(self):
+        code = "auth = 8\nmy_var = f'some value {auth}'\nprint(auth)\nother_val = 'some other'"
+        finder = worder.Worder(code)
+        self.assertEqual(finder.get_word_range(45), (45, 49))
 
 class ScopeNameFinderTest(unittest.TestCase):
 


### PR DESCRIPTION
These are the changes to fix the bug described at [issue 288](https://github.com/python-rope/rope/issues/288) . It is passing all the tests and also solving the issue. Could you take a look at it please?