### PR TITLE
ast.Str and other constants are deprecated since 3.8.

### DIFF
--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -220,8 +220,8 @@ class PyDefinedObject(object):
     def get_doc(self):
         if len(self.get_ast().body) > 0:
             expr = self.get_ast().body[0]
-            if isinstance(expr, ast.Expr) and \
-               isinstance(expr.value, ast.Str):
+            ast_Str = ast.Constant if hasattr(ast, "Constant") else ast.Str
+            if isinstance(expr, ast.Expr) and isinstance(expr.value, ast_Str):
                 docstring = expr.value.s
                 coding = self.get_module().coding
                 return _decode_data(docstring, coding)


### PR DESCRIPTION
Fixes #279.