### PR TITLE
Fix `Worder.get_primary_at` cutting off names that start like keywords.

### DIFF
--- a/rope/base/worder.py
+++ b/rope/base/worder.py
@@ -209,7 +209,8 @@ class _RealFinder(object):
         if offset >= 0 and (self.code[offset] in '"\'})]' or
                             self._is_id_char(offset)):
             atom_start = self._find_atom_start(offset)
-            if not keyword.iskeyword(self.code[atom_start:offset + 1]):
+            if not keyword.iskeyword(self.code[atom_start:offset + 1]) or \
+               (offset + 2 < len(self.code) and self._is_id_char(offset + 2)):
                 return atom_start
         return last_atom
 

--- a/ropetest/codeanalyzetest.py
+++ b/ropetest/codeanalyzetest.py
@@ -111,6 +111,11 @@ class WordRangeFinderTest(unittest.TestCase):
         result = self._find_primary(code, code.index('attr') + 1)
         self.assertEqual('a_var.\nattr', result)
 
+    def test_word_finder_on_primary_like_keyword(self):
+        code = 'is_keyword = False\n'
+        result = self._find_primary(code, 1)
+        self.assertEqual('is_keyword', result)
+
     def test_strings(self):
         code = '"a string".split()'
         self.assertEqual('"a string".split', self._find_primary(code, 14))


### PR DESCRIPTION
E.g. names like `is_whatever` or `global_whatever`.

- Adds test for finding names that start with keywords.
- Fixes `Worder.get_primary_at` cutting off names that start with keywords.

Closes #296 