### PR TITLE
Add pytest.ini to collect all tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = *test.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
-python_files = *test.py
+python_files = 
+   *test.py
+   __init__.py


### PR DESCRIPTION
Running `pytest` on rope project causes pytest to collect only 194 or so tests:

```
$ pytest
[snip]
===================== 194 passed, 314 warnings in 7.61s =====================
```

while running `python setup.py test` shows that there are supposed to be a lot more tests:

```
Test failed: <unittest.runner.TextTestResult run=1708 errors=2 failures=137>
error: Test failed: <unittest.runner.TextTestResult run=1708 errors=2 failures=137>
```

This is because most of rope test's file names does not match pytest's default test file name patterns.

Adding a pytest.ini to overrride the filename pattern solves this issue.