### PR TITLE
Fix patchedast for Python 3.8

### DIFF
--- a/rope/base/codeanalyze.py
+++ b/rope/base/codeanalyze.py
@@ -358,7 +358,7 @@ def get_string_pattern_with_prefix(prefix):
 
 
 def get_string_pattern():
-    prefix = r'(?<![fF])(\b[uU]?[rR]?)?'
+    prefix = r'(?<![fF])(\b[uUbB]?[rR]?)?'
     return get_string_pattern_with_prefix(prefix)
 
 

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -346,6 +346,10 @@ class _PatchingASTWalker(object):
             self._handle(node, [self.Number])
             return
 
+        if node.value is Ellipsis:
+            self._handle(node, ['...'])
+            return
+
         assert False
 
     def _Num(self, node):

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -1,9 +1,11 @@
 import collections
+import numbers
 import re
 import warnings
 
 from rope.base import ast, codeanalyze, exceptions
 from rope.base.utils import pycompat
+
 
 try:
     basestring
@@ -330,6 +332,21 @@ class _PatchingASTWalker(object):
 
     def _Delete(self, node):
         self._handle(node, ['del'] + self._child_nodes(node.targets, ','))
+
+    def _Constant(self, node):
+        if isinstance(node.value, str):
+            self._handle(node, [self.String])
+            return
+
+        if any(node.value is v for v in [True, False, None]):
+            self._handle(node, [str(node.value)])
+            return
+
+        if isinstance(node.value, numbers.Number):
+            self._handle(node, [self.Number])
+            return
+
+        assert False
 
     def _Num(self, node):
         self._handle(node, [self.Number])

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -334,7 +334,7 @@ class _PatchingASTWalker(object):
         self._handle(node, ['del'] + self._child_nodes(node.targets, ','))
 
     def _Constant(self, node):
-        if isinstance(node.value, str):
+        if isinstance(node.value, basestring):
             self._handle(node, [self.String])
             return
 
@@ -356,6 +356,9 @@ class _PatchingASTWalker(object):
         self._handle(node, [self.Number])
 
     def _Str(self, node):
+        self._handle(node, [self.String])
+
+    def _Bytes(self, node):
         self._handle(node, [self.String])
 
     def _Continue(self, node):

--- a/rope/refactor/similarfinder.py
+++ b/rope/refactor/similarfinder.py
@@ -204,7 +204,7 @@ class _ASTMatcher(object):
                     if not self._match_nodes(c1, c2, mapping):
                         return False
             else:
-                if child1 != child2:
+                if type(child1) is not type(child2) or child1 != child2:
                     return False
         return True
 

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -29,7 +29,7 @@ class PatchedASTTest(unittest.TestCase):
         source = '1 + b"("\n'
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
-        str_fragment = '"("'
+        str_fragment = 'b"("'
         start = source.index(str_fragment)
         checker.check_region(Bytes, start, start + len(str_fragment))
         checker.check_children(Bytes, [str_fragment])

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -14,6 +14,7 @@ try:
 except NameError:
     basestring = (str, bytes)
 
+NameConstant = 'Name' if sys.version_info <= (3, 8) else 'NameConstant'
 
 class PatchedASTTest(unittest.TestCase):
 
@@ -124,7 +125,7 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_region('BoolOp', 0, len(source) - 1)
         checker.check_children(
-            'BoolOp', ['Name', ' ', 'and', ' ', 'Name'])
+            'BoolOp', [NameConstant, ' ', 'and', ' ', NameConstant])
 
     def test_basic_closing_parens(self):
         source = '1 + (2)\n'
@@ -263,7 +264,7 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_region('Assert', 0, len(source) - 1)
         checker.check_children(
-            'Assert', ['assert', ' ', 'Name'])
+            'Assert', ['assert', ' ', NameConstant])
 
     def test_assert2(self):
         source = 'assert True, "error"\n'
@@ -271,7 +272,7 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_region('Assert', 0, len(source) - 1)
         checker.check_children(
-            'Assert', ['assert', ' ', 'Name', '', ',', ' ', 'Str'])
+            'Assert', ['assert', ' ', NameConstant, '', ',', ' ', 'Str'])
 
     def test_aug_assign_node(self):
         source = 'a += 1\n'
@@ -594,7 +595,7 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_region('If', 0, len(source) - 1)
         checker.check_children(
-            'If', ['if', ' ', 'Name', '', ':', '\n    ', 'Pass', '\n',
+            'If', ['if', ' ', NameConstant, '', ':', '\n    ', 'Pass', '\n',
                    'else', '', ':', '\n    ', 'Pass'])
 
     def test_if_node2(self):
@@ -603,7 +604,7 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_region('If', 0, len(source) - 1)
         checker.check_children(
-            'If', ['if', ' ', 'Name', '', ':', '\n    ', 'Pass', '\n',
+            'If', ['if', ' ', NameConstant, '', ':', '\n    ', 'Pass', '\n',
                    'If'])
 
     def test_if_node3(self):
@@ -613,7 +614,7 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_region('If', 0, len(source) - 1)
         checker.check_children(
-            'If', ['if', ' ', 'Name', '', ':', '\n    ', 'Pass', '\n',
+            'If', ['if', ' ', NameConstant, '', ':', '\n    ', 'Pass', '\n',
                    'else', '', ':', '\n    ', 'If'])
 
     def test_import_node(self):
@@ -630,7 +631,7 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_region('Lambda', 0, len(source) - 1)
         checker.check_children(
-            'Lambda', ['lambda', ' ', 'arguments', '', ':', ' ', 'Name'])
+            'Lambda', ['lambda', ' ', 'arguments', '', ':', ' ', NameConstant])
         expected_child = pycompat.ast_arg_type.__name__
         checker.check_children(
             'arguments', [expected_child, '', ',', ' ',
@@ -654,7 +655,7 @@ class PatchedASTTest(unittest.TestCase):
             'ListComp', ['[', '', 'Name', ' ', 'comprehension', '', ']'])
         checker.check_children(
             'comprehension', ['for', ' ', 'Name', ' ', 'in', ' ',
-                              'Call', ' ', 'if', ' ', 'Name'])
+                              'Call', ' ', 'if', ' ', NameConstant])
 
     def test_list_comp_node_with_multiple_comprehensions(self):
         source = '[i for i in range(1) for j in range(1) if True]\n'
@@ -666,7 +667,7 @@ class PatchedASTTest(unittest.TestCase):
                          ' ', 'comprehension', '', ']'])
         checker.check_children(
             'comprehension', ['for', ' ', 'Name', ' ', 'in', ' ',
-                              'Call', ' ', 'if', ' ', 'Name'])
+                              'Call', ' ', 'if', ' ', NameConstant])
 
     def test_set_node(self):
         # make sure we are in a python version with set literals
@@ -699,7 +700,7 @@ class PatchedASTTest(unittest.TestCase):
             'SetComp', ['{', '', 'Name', ' ', 'comprehension', '', '}'])
         checker.check_children(
             'comprehension', ['for', ' ', 'Name', ' ', 'in', ' ',
-                              'Call', ' ', 'if', ' ', 'Name'])
+                              'Call', ' ', 'if', ' ', NameConstant])
 
     def test_dict_comp_node(self):
         # make sure we are in a python version with dict comprehensions
@@ -718,7 +719,7 @@ class PatchedASTTest(unittest.TestCase):
                          ' ', 'comprehension', '', '}'])
         checker.check_children(
             'comprehension', ['for', ' ', 'Name', ' ', 'in', ' ',
-                              'Call', ' ', 'if', ' ', 'Name'])
+                              'Call', ' ', 'if', ' ', NameConstant])
 
     def test_ext_slice_node(self):
         source = 'x = xs[0,:]\n'
@@ -747,7 +748,7 @@ class PatchedASTTest(unittest.TestCase):
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_children('Expr', ['BoolOp'])
-        checker.check_children('BoolOp', ['UnaryOp', ' ', 'or', ' ', 'Name'])
+        checker.check_children('BoolOp', ['UnaryOp', ' ', 'or', ' ', NameConstant])
 
     @testutils.only_for_versions_lower('3')
     def test_print_node(self):
@@ -790,7 +791,7 @@ class PatchedASTTest(unittest.TestCase):
         source = 'def f():\n    return None\n'
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
-        checker.check_children('Return', ['return', ' ', 'Name'])
+        checker.check_children('Return', ['return', ' ', NameConstant])
 
     def test_empty_return_node(self):
         source = 'def f():\n    return\n'
@@ -852,14 +853,14 @@ class PatchedASTTest(unittest.TestCase):
         source = 'def f():\n    yield None\n'
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
-        checker.check_children('Yield', ['yield', ' ', 'Name'])
+        checker.check_children('Yield', ['yield', ' ', NameConstant])
 
     def test_while_node(self):
         source = 'while True:\n    pass\nelse:\n    pass\n'
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_children(
-            'While', ['while', ' ', 'Name', '', ':', '\n    ', 'Pass', '\n',
+            'While', ['while', ' ', NameConstant, '', ':', '\n    ', 'Pass', '\n',
                       'else', '', ':', '\n    ', 'Pass'])
 
     @testutils.only_for('2.5')
@@ -973,7 +974,7 @@ class PatchedASTTest(unittest.TestCase):
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_children(
-            'IfExp', ['Num', ' ', 'if', ' ', 'Name', ' ', 'else',
+            'IfExp', ['Num', ' ', 'if', ' ', NameConstant, ' ', 'else',
                       ' ', 'Num'])
 
     def test_delete_node(self):
@@ -1060,6 +1061,8 @@ class _ResultChecker(object):
 
             def __call__(self, node):
                 for text in goal:
+                    if sys.version_info >= (3, 8) and text in ['Num', 'Str', 'NameConstant']:
+                        text = 'Constant'
                     if str(node).startswith(text):
                         self.result = node
                         break
@@ -1088,6 +1091,8 @@ class _ResultChecker(object):
             else:
                 self.test_case.assertNotEqual(
                     '', text, 'probably ignoring some node')
+                if sys.version_info >= (3, 8) and expected in ['Num', 'Str', 'NameConstant']:
+                    expected = 'Constant'
                 self.test_case.assertTrue(
                     child.__class__.__name__.startswith(expected),
                     msg='Expected <%s> but was <%s>' %

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -15,6 +15,7 @@ except NameError:
     basestring = (str, bytes)
 
 NameConstant = 'Name' if sys.version_info <= (3, 8) else 'NameConstant'
+Bytes = 'Bytes' if (3, 0) <= sys.version_info <= (3, 8) else 'Str'
 
 class PatchedASTTest(unittest.TestCase):
 
@@ -23,6 +24,15 @@ class PatchedASTTest(unittest.TestCase):
 
     def tearDown(self):
         super(PatchedASTTest, self).tearDown()
+
+    def test_bytes_string(self):
+        source = '1 + b"("\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        str_fragment = '"("'
+        start = source.index(str_fragment)
+        checker.check_region(Bytes, start, start + len(str_fragment))
+        checker.check_children(Bytes, [str_fragment])
 
     def test_integer_literals_and_region(self):
         source = 'a = 10\n'

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -86,6 +86,13 @@ class PatchedASTTest(unittest.TestCase):
         # start = source.index('10')
         checker.check_children('Num', ['10'])
 
+    def test_ellipsis(self):
+        source = 'a[...]\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        start = source.index('...')
+        checker.check_region('Ellipsis', start, start + len('...'))
+
     def test_ass_name_node(self):
         source = 'a = 10\n'
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -1061,7 +1068,7 @@ class _ResultChecker(object):
 
             def __call__(self, node):
                 for text in goal:
-                    if sys.version_info >= (3, 8) and text in ['Num', 'Str', 'NameConstant']:
+                    if sys.version_info >= (3, 8) and text in ['Num', 'Str', 'NameConstant', 'Ellipsis']:
                         text = 'Constant'
                     if str(node).startswith(text):
                         self.result = node
@@ -1091,7 +1098,7 @@ class _ResultChecker(object):
             else:
                 self.test_case.assertNotEqual(
                     '', text, 'probably ignoring some node')
-                if sys.version_info >= (3, 8) and expected in ['Num', 'Str', 'NameConstant']:
+                if sys.version_info >= (3, 8) and expected in ['Num', 'Str', 'NameConstant', 'Ellipsis']:
                     expected = 'Constant'
                 self.test_case.assertTrue(
                     child.__class__.__name__.startswith(expected),

--- a/ropetest/refactor/similarfindertest.py
+++ b/ropetest/refactor/similarfindertest.py
@@ -33,6 +33,12 @@ class SimilarFinderTest(unittest.TestCase):
         result = [(source.index('10'), source.index('10') + 2)]
         self.assertEqual(result, list(finder.get_match_regions('10')))
 
+    def test_bool_is_not_similar_to_integer(self):
+        source = 'a = False\nb = 0'
+        finder = self._create_finder(source)
+        result = [(source.index('False'), source.index('False') + len('False'))]
+        self.assertEqual(result, list(finder.get_match_regions('False')))
+
     def test_simple_addition(self):
         source = 'a = 1 + 2\n'
         finder = self._create_finder(source)


### PR DESCRIPTION
Fix most of the errors in patchedast due to changes in the ast module in Python 3.8. 

In the future, patchedast probably could be simplified a lot removing most of the regex parsing it currently does and making use of the new `end_lineno` and `end_col_offset` attribute, but since we probably still need to support older python, it may take a while until rope can fully take advantage of those attributes.

This branch also fixes some bugs with bytestring literal syntax (`b""`).

Before:

```
(rope-py3.8)$ pytest
[snip]
139 failed, 1573 passed, 14 skipped, 1807 warnings
```

After:

```
(rope-py3.8)$ pytest
[snip]
3 failed, 1711 passed, 14 skipped, 1621 warnings
$ tox
[snip]
  py27: commands succeeded
  py34: commands succeeded
  py35: commands succeeded
  py36: commands succeeded
  py37: commands succeeded
ERROR:   py38: commands failed
```

There are still some tests failing in Python 3.8 in codeassist module, but I think they should be fixed as a separate PR.