### PR TITLE
Fix get definition location for Python 3.8

### DIFF
--- a/rope/base/pynames.py
+++ b/rope/base/pynames.py
@@ -21,7 +21,8 @@ class DefinedName(PyName):
         return self.pyobject
 
     def get_definition_location(self):
-        return (self.pyobject.get_module(), self.pyobject.get_ast().lineno)
+        lineno = utils.guess_def_lineno(self.pyobject.get_module(), self.pyobject.get_ast())
+        return (self.pyobject.get_module(), lineno)
 
 
 class AssignedName(PyName):

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -390,8 +390,11 @@ class _ScopeVisitor(object):
                     def _eval(type_=type_, arg=arg):
                         return type_.get_property_object(
                             arguments.ObjectArguments([arg]))
+
+                    lineno = utils.guess_def_lineno(self.get_module(), node)
+
                     self.names[node.name] = pynames.EvaluatedName(
-                        _eval, module=self.get_module(), lineno=node.lineno)
+                        _eval, module=self.get_module(), lineno=lineno)
                     break
         else:
             self.names[node.name] = pynames.DefinedName(pyfunction)

--- a/ropetest/contrib/codeassisttest.py
+++ b/ropetest/contrib/codeassisttest.py
@@ -352,14 +352,81 @@ class CodeAssistTest(unittest.TestCase):
         result = get_definition_location(self.project, code, len(code) - 11)
         self.assertEqual((None, 1), result)
 
-    def test_get_definition_location_dotted_names(self):
+    def test_get_definition_location_dotted_names_method(self):
         code = 'class AClass(object):\n' \
                '    @staticmethod\n' \
                '    def a_method():\n' \
                '        pass\n' \
                'AClass.a_method()'
         result = get_definition_location(self.project, code, len(code) - 3)
+        self.assertEqual((None, 3), result)
+
+    def test_get_definition_location_dotted_names_property(self):
+        code = 'class AClass(object):\n' \
+               '    @property\n' \
+               '    @somedecorator\n' \
+               '    def a_method():\n' \
+               '        pass\n' \
+               'AClass.a_method()'
+        result = get_definition_location(self.project, code, len(code) - 3)
+        self.assertEqual((None, 4), result)
+
+    def test_get_definition_location_dotted_names_free_function(self):
+        code = '@custom_decorator\n' \
+               'def a_method():\n' \
+               '    pass\n' \
+               'a_method()'
+        result = get_definition_location(self.project, code, len(code) - 3)
         self.assertEqual((None, 2), result)
+
+    @testutils.only_for_versions_higher('3.5')
+    def test_get_definition_location_dotted_names_async_def(self):
+        code = 'class AClass(object):\n' \
+               '    @property\n' \
+               '    @decorator2\n' \
+               '    async def a_method():\n' \
+               '        pass\n' \
+               'AClass.a_method()'
+        result = get_definition_location(self.project, code, len(code) - 3)
+        self.assertEqual((None, 4), result)
+
+    def test_get_definition_location_dotted_names_class(self):
+        code = '@custom_decorator\n' \
+               'class AClass(object):\n' \
+               '    def a_method():\n' \
+               '        pass\n' \
+               'AClass.a_method()'
+        result = get_definition_location(self.project, code, len(code) - 12)
+        self.assertEqual((None, 2), result)
+
+    def test_get_definition_location_dotted_names_with_space(self):
+        code = 'class AClass(object):\n' \
+               '    @staticmethod\n' \
+               '    def a_method():\n' \
+               '        \n' \
+               '        pass\n' \
+               'AClass.a_method()'
+        result = get_definition_location(self.project, code, len(code) - 3)
+        self.assertEqual((None, 3), result)
+
+    def test_get_definition_location_dotted_names_inline_body(self):
+        code = 'class AClass(object):\n' \
+               '    @staticmethod\n' \
+               '    def a_method(): pass\n' \
+               'AClass.a_method()'
+        result = get_definition_location(self.project, code, len(code) - 3)
+        self.assertEqual((None, 3), result)
+
+    def test_get_definition_location_dotted_names_inline_body_split_arg(self):
+        code = 'class AClass(object):\n' \
+               '    @staticmethod\n' \
+               '    def a_method(\n' \
+               '        self,\n' \
+               '        arg1\n' \
+               '    ): pass\n' \
+               'AClass.a_method()'
+        result = get_definition_location(self.project, code, len(code) - 3)
+        self.assertEqual((None, 3), result)
 
     def test_get_definition_location_dotted_module_names(self):
         module_resource = testutils.create_module(self.project, 'mod')
@@ -389,7 +456,7 @@ class CodeAssistTest(unittest.TestCase):
                '@staticmethod\n    def a_method():\n' \
                '        pass\nAClass.\\\n     a_method()'
         result = get_definition_location(self.project, code, len(code) - 3)
-        self.assertEqual((None, 2), result)
+        self.assertEqual((None, 3), result)
 
     def test_get_definition_location_dot_line_break_inside_parens(self):
         code = 'class A(object):\n    def a_method(self):\n        pass\n' + \


### PR DESCRIPTION
This PR changes `get_definition_location()` to point to the line where the class/function is defined rather than pointing to the decorator. This makes older versions match Python 3.8's more correct behaviour.

Note that this is a backwards incompatible change if someone depends on `get_definition_location()` pointing to the decorator.

Note: this PR also contains commits from https://github.com/python-rope/rope/pull/306, you most likely would want to review the diffs just from this branch to that one rather than seeing both changes simultaneously.