### PR TITLE
#248 fix false triple quoted string

### DIFF
--- a/rope/base/codeanalyze.py
+++ b/rope/base/codeanalyze.py
@@ -143,7 +143,7 @@ class _CustomGenerator(object):
             if token in ["'''", '"""', "'", '"']:
                 if not self.in_string:
                     self.in_string = token
-                elif self.in_string == token:
+                elif self.in_string == token or (self.in_string in ['"', "'"] and token == 3*self.in_string):
                     self.in_string = ''
             if self.in_string:
                 continue

--- a/ropetest/codeanalyzetest.py
+++ b/ropetest/codeanalyzetest.py
@@ -600,12 +600,12 @@ class LogicalLineFinderTest(unittest.TestCase):
 
     def test_generating_line_starts2(self):
         code = 'a = 1\na = 2\n\na = \\ 3\n'
-        line_finder = LogicalLineFinder(SourceLinesAdapter(code))
+        line_finder = self._logical_finder(code)
         self.assertEqual([2, 4], list(line_finder.generate_starts(2)))
 
     def test_generating_line_starts3(self):
         code = 'a = 1\na = 2\n\na = \\ 3\n'
-        line_finder = LogicalLineFinder(SourceLinesAdapter(code))
+        line_finder = self._logical_finder(code)
         self.assertEqual([2], list(line_finder.generate_starts(2, 3)))
 
     def test_generating_line_starts_for_multi_line_statements(self):

--- a/ropetest/codeanalyzetest.py
+++ b/ropetest/codeanalyzetest.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 try:
     import unittest2 as unittest
 except ImportError:
@@ -618,6 +619,21 @@ class LogicalLineFinderTest(unittest.TestCase):
                '            a = 1\n    b = 1\n'
         line_finder = self._logical_finder(code)
         self.assertEqual([4, 5], list(line_finder.generate_starts(4)))
+
+    def test_false_triple_quoted_string(self):
+        code = dedent("""\
+            def foo():
+                a = 0
+                p = 'foo'''
+
+            def bar():
+                a = 1
+                a += 1
+        """)
+        line_finder = self._logical_finder(code)
+        self.assertEqual([1, 2, 3, 5, 6, 7], list(line_finder.generate_starts()))
+        self.assertEqual((3, 3), line_finder.logical_line_in(3))
+        self.assertEqual([5, 6, 7], list(line_finder.generate_starts(4)))
 
 
 class TokenizerLogicalLineFinderTest(LogicalLineFinderTest):

--- a/ropetest/contrib/codeassisttest.py
+++ b/ropetest/contrib/codeassisttest.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import os.path
+from textwrap import dedent
 try:
     import unittest2 as unittest
 except ImportError:
@@ -471,6 +472,19 @@ class CodeAssistTest(unittest.TestCase):
                '    print(a_var)\n'
         result = get_definition_location(self.project, code, len(code) - 3)
         self.assertEqual((None, 3), result)
+
+    def test_get_definition_location_false_triple_quoted_string(self):
+        code = dedent('''\
+            def foo():
+                a = 0
+                p = "foo"""
+
+            def bar():
+                a = 1
+                a += 1
+        ''')
+        result = get_definition_location(self.project, code, code.index("a += 1"))
+        self.assertEqual((None, 6), result)
 
     def test_code_assists_in_parens(self):
         code = 'def a_func(a_var):\n    pass\na_var = 10\na_func(a_'


### PR DESCRIPTION
Fix the linked issue #248. 

This issue is because the three single quotes here: `p = 'foo'''` is misrecognised as a triple-quoted string, which is not consistent with how Python interprets it as an opening and closing of single-quoted string.