### PR TITLE
#282 Implement PEP-448 generalized dict-unpacking

### DIFF
--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -369,7 +369,11 @@ class _PatchingASTWalker(object):
         children.append('{')
         if node.keys:
             for index, (key, value) in enumerate(zip(node.keys, node.values)):
-                children.extend([key, ':', value])
+                if key is None:
+                    # PEP-448 dict unpacking: {a: b, **unpack}
+                    children.extend(['**', value])
+                else:
+                    children.extend([key, ':', value])
                 if index < len(node.keys) - 1:
                     children.append(',')
         children.append('}')

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 try:
     import unittest2 as unittest
 except ImportError:
@@ -63,6 +64,26 @@ class ExtractMethodTest(unittest.TestCase):
         refactored = self.do_extract_method(code, start, end, 'extracted')
         expected = "def a_func():\n    extracted()\n    print('two')\n\n" \
                    "def extracted():\n    print('one')\n\nprint('hey')\n"
+        self.assertEqual(expected, refactored)
+
+    @testutils.only_for('3.5')
+    def test_extract_function_containing_dict_generalized_unpacking(self):
+        code = dedent('''\
+            def a_func(dict1):
+                dict2 = {}
+                a_var = {a: b, **dict1, **dict2}
+        ''')
+        start = code.index('{a')
+        end = code.index('2}') + len('2}')
+        refactored = self.do_extract_method(code, start, end, 'extracted')
+        expected = dedent('''\
+            def a_func(dict1):
+                dict2 = {}
+                a_var = extracted(dict1, dict2)
+
+            def extracted(dict1, dict2):
+                return {a: b, **dict1, **dict2}
+        ''')
         self.assertEqual(expected, refactored)
 
     def test_simple_extract_function_with_parameter(self):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -499,6 +499,16 @@ class PatchedASTTest(unittest.TestCase):
             'Dict', ['{', '', 'Num', '', ':', ' ', 'Num', '', ',',
                      ' ', 'Num', '', ':', ' ', 'Num', '', '}'])
 
+    @testutils.only_for('3.5')
+    def test_dict_node_with_unpacking(self):
+        source = '{**dict1, **dict2}\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_region('Dict', 0, len(source) - 1)
+        checker.check_children(
+            'Dict', ['{', '', '**', '', 'Name', '', ',',
+                     ' ', '**', '', 'Name', '', '}'])
+
     def test_div_node(self):
         source = '1 / 2\n'
         ast_frag = patchedast.get_patched_ast(source, True)


### PR DESCRIPTION
Fixes #282. This PR adds dictionary unpacking syntax:

    {**a, **b}

to patchedast and allows refactoring to include lines which contains constructions with this syntax.