### PR TITLE
Implement f-string extract refactoring

### DIFF
--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -361,6 +361,9 @@ class _PatchingASTWalker(object):
     def _Bytes(self, node):
         self._handle(node, [self.String])
 
+    def _JoinedStr(self, node):
+        self._handle(node, [self.String])
+
     def _Continue(self, node):
         self._handle(node, ['continue'])
 
@@ -788,7 +791,10 @@ class _Source(object):
             original = codeanalyze.get_string_pattern()
             pattern = r'(%s)((\s|\\\n|#[^\n]*\n)*(%s))*' % \
                       (original, original)
-            _Source._string_pattern = re.compile(pattern)
+            foriginal = codeanalyze.get_formatted_string_pattern()
+            fpattern = r'(%s)((\s|\\\n|#[^\n]*\n)*(%s))*' % \
+                      (foriginal, foriginal)
+            _Source._string_pattern = re.compile(r'(?:%s)|(?:%s)' % (pattern, fpattern))
         repattern = _Source._string_pattern
         return self._consume_pattern(repattern, end)
 

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -125,7 +125,10 @@ class _PatchingASTWalker(object):
                     # semicolon in except
                     region = self.source.consume_except_as_or_semicolon()
                 else:
-                    region = self.source.consume(child, skip_comment=not isinstance(node, (ast.JoinedStr, ast.FormattedValue)))
+                    if hasattr(ast, 'JoinedStr') and isinstance(node, (ast.JoinedStr, ast.FormattedValue)):
+                        region = self.source.consume_joined_string(child)
+                    else:
+                        region = self.source.consume(child)
                 child = self.source[region[0]:region[1]]
                 token_start = region[0]
             if not first_token:
@@ -820,6 +823,11 @@ class _Source(object):
             raise MismatchedTokenError(
                 'Token <%s> at %s cannot be matched' %
                 (token, self._get_location()))
+        self.offset = new_offset + len(token)
+        return (new_offset, self.offset)
+
+    def consume_joined_string(self, token):
+        new_offset = self.source.index(token, self.offset)
         self.offset = new_offset + len(token)
         return (new_offset, self.offset)
 

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -433,13 +433,13 @@ class ExtractMethodTest(unittest.TestCase):
     @testutils.only_for_versions_higher('3.6')
     def test_extract_variable_f_string(self):
         code = dedent('''\
-            foo(f"abc {a_var} #2", 10)
+            foo(f"abc {a_var} def", 10)
         ''')
         start = code.index('f"')
-        end = code.index('2"') + 2
+        end = code.index('def"') + 4
         refactored = self.do_extract_variable(code, start, end, 'new_var')
         expected = dedent('''\
-            new_var = f"abc {a_var} #2"
+            new_var = f"abc {a_var} def"
             foo(new_var, 10)
         ''')
         self.assertEqual(expected, refactored)
@@ -594,6 +594,28 @@ class ExtractMethodTest(unittest.TestCase):
 
             def new_func(a_var):
                 return f"abc {a_var}"
+        ''')
+        self.assertEqual(expected, refactored)
+
+    @testutils.only_for_versions_higher('3.6')
+    def test_extract_method_f_string_extract_method_complex_expression(self):
+        code = dedent('''\
+            def func(a_var):
+                b_var = int
+                fill = 10
+                foo(f"abc {a_var + f'{b_var(a_var)}':{fill}16}", 10)
+        ''')
+        start = code.index('f"')
+        end = code.index('}"') + 2
+        refactored = self.do_extract_method(code, start, end, 'new_func')
+        expected = dedent('''\
+            def func(a_var):
+                b_var = int
+                fill = 10
+                foo(new_func(a_var, b_var, fill), 10)
+
+            def new_func(a_var, b_var, fill):
+                return f"abc {a_var + f'{b_var(a_var)}':{fill}16}"
         ''')
         self.assertEqual(expected, refactored)
 

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -430,6 +430,20 @@ class ExtractMethodTest(unittest.TestCase):
         expected = 'new_var = 10 + 20\na_var = new_var\n'
         self.assertEqual(expected, refactored)
 
+    @testutils.only_for_versions_higher('3.6')
+    def test_extract_variable_f_string(self):
+        code = dedent('''\
+            foo(f"abc {a_var} #2", 10)
+        ''')
+        start = code.index('f"')
+        end = code.index('2"') + 2
+        refactored = self.do_extract_variable(code, start, end, 'new_var')
+        expected = dedent('''\
+            new_var = f"abc {a_var} #2"
+            foo(new_var, 10)
+        ''')
+        self.assertEqual(expected, refactored)
+
     def test_extract_variable_multiple_lines(self):
         code = 'a = 1\nb = 2\n'
         start = code.index('1')
@@ -563,6 +577,24 @@ class ExtractMethodTest(unittest.TestCase):
         code = '\nprint(1)\n'
         refactored = self.do_extract_method(code, 0, len(code), 'new_f')
         expected = '\n\ndef new_f():\n    print(1)\n\nnew_f()\n'
+        self.assertEqual(expected, refactored)
+
+    @testutils.only_for_versions_higher('3.6')
+    def test_extract_method_f_string_extract_method(self):
+        code = dedent('''\
+            def func(a_var):
+                foo(f"abc {a_var}", 10)
+        ''')
+        start = code.index('f"')
+        end = code.index('}"') + 2
+        refactored = self.do_extract_method(code, start, end, 'new_func')
+        expected = dedent('''\
+            def func(a_var):
+                foo(new_func(a_var), 10)
+
+            def new_func(a_var):
+                return f"abc {a_var}"
+        ''')
         self.assertEqual(expected, refactored)
 
     def test_variable_writes_in_the_same_line_as_variable_read(self):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -236,11 +236,29 @@ class PatchedASTTest(unittest.TestCase):
 
     @testutils.only_for_versions_higher('3.6')
     def test_handling_format_strings_basic(self):
+        source = '1 + f"abc{a}"\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            'JoinedStr', ['f"abc{a}"'])
+
+    @testutils.only_for_versions_higher('3.6')
+    def test_handling_format_strings_with_format_spec(self):
         source = 'f"abc{a:01}"\n'
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_children(
             'JoinedStr', ['f"abc{a:01}"'])
+
+    @testutils.only_for_versions_higher('3.6')
+    def test_handling_format_strings_with_expression(self):
+        source = 'f"abc{a + b}"\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            'JoinedStr', ['f"abc{a + b}"'])
+        checker.check_children(
+            'FormattedValue', ['BinOp'])
 
     @testutils.only_for_versions_lower('3')
     def test_long_integer_literals(self):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -227,6 +227,21 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_children('Module', ['', 'Expr', '\n', 'Expr', '\n'])
 
+    def test_handling_raw_strings(self):
+        source = 'r"abc"\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            'Str', ['r"abc"'])
+
+    @testutils.only_for_versions_higher('3.6')
+    def test_handling_format_strings_basic(self):
+        source = 'f"abc{a:01}"\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            'JoinedStr', ['f"abc{a:01}"'])
+
     @testutils.only_for_versions_lower('3')
     def test_long_integer_literals(self):
         source = "0x1L + a"

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -240,7 +240,19 @@ class PatchedASTTest(unittest.TestCase):
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_children(
-            'JoinedStr', ['f"abc{a}"'])
+            'JoinedStr', ['f"', 'abc', 'FormattedValue', '', '"'])
+        checker.check_children(
+            'FormattedValue', ['{', '', 'Name', '', '}'])
+
+    @testutils.only_for_versions_higher('3.6')
+    def test_handling_format_strings_with_implicit_join(self):
+        source = '''"1" + rf'abc{a}' f"""xxx{b} """\n'''
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            'JoinedStr', ["rf'", 'abc', 'FormattedValue', '\' f"""xxx', 'FormattedValue', ' ', '"""'])
+        checker.check_children(
+            'FormattedValue', ['{', '', 'Name', '', '}'])
 
     @testutils.only_for_versions_higher('3.6')
     def test_handling_format_strings_with_format_spec(self):
@@ -248,7 +260,19 @@ class PatchedASTTest(unittest.TestCase):
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_children(
-            'JoinedStr', ['f"abc{a:01}"'])
+            'JoinedStr', ['f"', 'abc', 'FormattedValue', '', '"'])
+        checker.check_children(
+            'FormattedValue', ['{', '', 'Name', '', ':', '', '01', '', '}'])
+
+    @testutils.only_for_versions_higher('3.6')
+    def test_handling_format_strings_with_inner_format_spec(self):
+        source = 'f"abc{a:{length}01}"\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            'JoinedStr', ['f"', 'abc', 'FormattedValue', '', '"'])
+        checker.check_children(
+            'FormattedValue', ['{', '', 'Name', '', ':', '{', 'Name', '}', '01', '', '}'])
 
     @testutils.only_for_versions_higher('3.6')
     def test_handling_format_strings_with_expression(self):
@@ -256,9 +280,9 @@ class PatchedASTTest(unittest.TestCase):
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_children(
-            'JoinedStr', ['f"abc{a + b}"'])
+            'JoinedStr', ['f"', 'abc', 'FormattedValue', '', '"'])
         checker.check_children(
-            'FormattedValue', ['BinOp'])
+            'FormattedValue', ['{', '', 'BinOp', '', '}'])
 
     @testutils.only_for_versions_lower('3')
     def test_long_integer_literals(self):


### PR DESCRIPTION
Closes #313. This implements patchedast and extract refactoring for code that contains f-string.

The region matching is a bit dodgy with implicitly joined strings that has a mixture of f-string and regular string and probably other corner cases as well, owing to how the ast doesn't seem to provide an easy way to find the offsets of formatted values without writing a full fledged string expression parser, but it works well enough for most other situations.