### PR TITLE
Implement renaming of walrus operator and loop variables in comprehensions

### DIFF
--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -335,6 +335,9 @@ class _ExpressionVisitor(object):
     def _ListComp(self, node):
         self._GeneratorExp(node)
 
+    def _NamedExpr(self, node):
+        ast.walk(node, _AssignVisitor(self))
+
 
 class _AssignVisitor(object):
 

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -329,7 +329,9 @@ class _ExpressionVisitor(object):
         self.scope_visitor._assigned(name, assignment)
 
     def _GeneratorExp(self, node):
-        ast.walk(node.elt, self)
+        for child in ['elt', 'key', 'value']:
+            if hasattr(node, child):
+                ast.walk(getattr(node, child), self)
         for comp in node.generators:
             ast.walk(comp.target, _AssignVisitor(self))
             ast.walk(comp, self)
@@ -337,6 +339,12 @@ class _ExpressionVisitor(object):
                 ast.walk(if_, self)
 
     def _ListComp(self, node):
+        self._GeneratorExp(node)
+
+    def _SetComp(self, node):
+        self._GeneratorExp(node)
+
+    def _DictComp(self, node):
         self._GeneratorExp(node)
 
     def _NamedExpr(self, node):

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -329,14 +329,19 @@ class _ExpressionVisitor(object):
         self.scope_visitor._assigned(name, assignment)
 
     def _GeneratorExp(self, node):
+        ast.walk(node.elt, self)
         for comp in node.generators:
             ast.walk(comp.target, _AssignVisitor(self))
+            ast.walk(comp, self)
+            for if_ in comp.ifs:
+                ast.walk(if_, self)
 
     def _ListComp(self, node):
         self._GeneratorExp(node)
 
     def _NamedExpr(self, node):
-        ast.walk(node, _AssignVisitor(self))
+        ast.walk(node.target, _AssignVisitor(self))
+        ast.walk(node.value, self)
 
 
 class _AssignVisitor(object):

--- a/ropetest/pyscopestest.py
+++ b/ropetest/pyscopestest.py
@@ -60,6 +60,30 @@ class PyCoreScopesTest(unittest.TestCase):
             ['b_var', 'c_var'],
         )
 
+    def test_inline_assignment_in_comprehensions(self):
+        scope = libutils.get_string_scope(
+            self.project, '''[
+                (a_var := b_var + (f_var := g_var))
+                for b_var in [(j_var := i_var)
+                for i_var in c_var] if a_var + (h_var := d_var)
+            ]''')
+        self.assertEqual(
+            list(sorted(scope.get_defined_names())),
+            ['a_var', 'b_var', 'f_var', 'h_var', 'i_var', 'j_var'],
+        )
+
+    def test_nested_comprehension(self):
+        scope = libutils.get_string_scope(
+            self.project, '''[
+                b_var + d_var for b_var, c_var in [
+                    e_var for e_var in f_var
+                ]
+            ]\n''')
+        self.assertEqual(
+            list(sorted(scope.get_defined_names())),
+            ['b_var', 'c_var', 'e_var'],
+        )
+
     def test_simple_class_scope(self):
         scope = libutils.get_string_scope(
             self.project,

--- a/ropetest/pyscopestest.py
+++ b/ropetest/pyscopestest.py
@@ -44,6 +44,22 @@ class PyCoreScopesTest(unittest.TestCase):
                           scope.get_scopes()[0]['SampleClass'].
                           get_object().get_type())
 
+    def test_list_comprehension_scope_inside_assignment(self):
+        scope = libutils.get_string_scope(
+            self.project, 'a_var = [b_var + d_var for b_var, c_var in e_var]\n')
+        self.assertEqual(
+            list(sorted(scope.get_defined_names())),
+            ['a_var', 'b_var', 'c_var'],
+        )
+
+    def test_list_comprehension_scope(self):
+        scope = libutils.get_string_scope(
+            self.project, '[b_var + d_var for b_var, c_var in e_var]\n')
+        self.assertEqual(
+            list(sorted(scope.get_defined_names())),
+            ['b_var', 'c_var'],
+        )
+
     def test_simple_class_scope(self):
         scope = libutils.get_string_scope(
             self.project,

--- a/ropetest/pyscopestest.py
+++ b/ropetest/pyscopestest.py
@@ -60,6 +60,30 @@ class PyCoreScopesTest(unittest.TestCase):
             ['b_var', 'c_var'],
         )
 
+    def test_set_comprehension_scope(self):
+        scope = libutils.get_string_scope(
+            self.project, '{b_var + d_var for b_var, c_var in e_var}\n')
+        self.assertEqual(
+            list(sorted(scope.get_defined_names())),
+            ['b_var', 'c_var'],
+        )
+
+    def test_generator_comprehension_scope(self):
+        scope = libutils.get_string_scope(
+            self.project, '(b_var + d_var for b_var, c_var in e_var)\n')
+        self.assertEqual(
+            list(sorted(scope.get_defined_names())),
+            ['b_var', 'c_var'],
+        )
+
+    def test_dict_comprehension_scope(self):
+        scope = libutils.get_string_scope(
+            self.project, '{b_var: d_var for b_var, c_var in e_var}\n')
+        self.assertEqual(
+            list(sorted(scope.get_defined_names())),
+            ['b_var', 'c_var'],
+        )
+
     def test_inline_assignment_in_comprehensions(self):
         scope = libutils.get_string_scope(
             self.project, '''[

--- a/ropetest/pyscopestest.py
+++ b/ropetest/pyscopestest.py
@@ -84,6 +84,7 @@ class PyCoreScopesTest(unittest.TestCase):
             ['b_var', 'c_var'],
         )
 
+    @testutils.only_for_versions_higher('3.8')
     def test_inline_assignment_in_comprehensions(self):
         scope = libutils.get_string_scope(
             self.project, '''[

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -127,6 +127,7 @@ class RenameRefactoringTest(unittest.TestCase):
             '[new_var for new_var, c_var in d_var if new_var == c_var]\nb_var = 10\n',
             refactored)
 
+    @testutils.only_for_versions_higher('3.8')
     def test_renaming_inline_assignment(self):
         code = dedent('''\
             while a_var := next(foo):

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -1,4 +1,5 @@
 import sys
+from textwrap import dedent
 try:
     import unittest2 as unittest
 except ImportError:
@@ -86,6 +87,30 @@ class RenameRefactoringTest(unittest.TestCase):
                                         'new_param')
         self.assertEqual(
             'def a_func(new_param):\n    a = new_param\na_func(1)\n',
+            refactored)
+
+    def test_renaming_comprehension_loop_variables(self):
+        code = '[b_var for b_var, c_var in d_var if b_var == c_var]'
+        refactored = self._local_rename(code, code.index('b_var') + 1,
+                                        'new_var')
+        self.assertEqual(
+            '[new_var for new_var, c_var in d_var if new_var == c_var]',
+            refactored)
+
+    def test_renaming_list_comprehension_loop_variables_in_assignment(self):
+        code = 'a_var = [b_var for b_var, c_var in d_var if b_var == c_var]'
+        refactored = self._local_rename(code, code.index('b_var') + 1,
+                                        'new_var')
+        self.assertEqual(
+            'a_var = [new_var for new_var, c_var in d_var if new_var == c_var]',
+            refactored)
+
+    def test_renaming_generator_comprehension_loop_variables(self):
+        code = 'a_var = (b_var for b_var, c_var in d_var if b_var == c_var)'
+        refactored = self._local_rename(code, code.index('b_var') + 1,
+                                        'new_var')
+        self.assertEqual(
+            'a_var = (new_var for new_var, c_var in d_var if new_var == c_var)',
             refactored)
 
     def test_renaming_arguments_for_normal_args_changing_calls(self):

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -113,6 +113,21 @@ class RenameRefactoringTest(unittest.TestCase):
             'a_var = (new_var for new_var, c_var in d_var if new_var == c_var)',
             refactored)
 
+    def test_renaming_inline_assignment(self):
+        code = dedent('''\
+            while a_var := next(foo):
+                print(a_var)
+        ''')
+        refactored = self._local_rename(code, code.index('a_var') + 1,
+                                        'new_var')
+        self.assertEqual(
+            dedent('''\
+                while new_var := next(foo):
+                    print(new_var)
+            '''),
+            refactored,
+        )
+
     def test_renaming_arguments_for_normal_args_changing_calls(self):
         code = 'def a_func(p1=None, p2=None):\n    pass\na_func(p2=1)\n'
         refactored = self._local_rename(code, code.index('p2') + 1, 'p3')

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -113,6 +113,20 @@ class RenameRefactoringTest(unittest.TestCase):
             'a_var = (new_var for new_var, c_var in d_var if new_var == c_var)',
             refactored)
 
+    @unittest.expectedFailure
+    def test_renaming_comprehension_loop_variables_scope(self):
+        # FIXME: variable scoping for comprehensions is incorrect, we currently
+        #        don't create a scope for comprehension
+        code = dedent('''\
+            [b_var for b_var, c_var in d_var if b_var == c_var]
+            b_var = 10
+        ''')
+        refactored = self._local_rename(code, code.index('b_var') + 1,
+                                        'new_var')
+        self.assertEqual(
+            '[new_var for new_var, c_var in d_var if new_var == c_var]\nb_var = 10\n',
+            refactored)
+
     def test_renaming_inline_assignment(self):
         code = dedent('''\
             while a_var := next(foo):


### PR DESCRIPTION
This PR implements renaming variables assigned by inline assignment expression (a.k.a. walrus operator/`:=`) and the looping variables of list/set/dict/generator comprehension.

This also solves point 3 from [my comment on #249](https://github.com/python-rope/rope/issues/249#issuecomment-718248829). The variable scoping for list comprehension does not follow Python 3 semantic, but as mentioned there, fixing the scopes likely will require a significant rewrite of the scope finding mechanism.