### PR TITLE
Fixes #317. Improve handling of generalized dict unpacking during dict rename

### DIFF
--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -1,3 +1,5 @@
+from operator import itemgetter
+
 import rope.base.builtins
 import rope.base.pynames
 import rope.base.pyobjects
@@ -232,9 +234,12 @@ class StatementEvaluator(object):
     def _Dict(self, node):
         keys = None
         values = None
-        if node.keys:
-            keys = self._get_object_for_node(node.keys[0])
-            values = self._get_object_for_node(node.values[0])
+        if node.keys and node.keys[0]:
+            keys, values = next(filter(itemgetter(0), zip(node.keys, node.values)), (None, None))
+            if keys:
+                keys = self._get_object_for_node(keys)
+            if values:
+                values = self._get_object_for_node(values)
         self.result = rope.base.pynames.UnboundName(
             pyobject=rope.base.builtins.get_dict(keys, values))
 

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -1,4 +1,5 @@
 import sys
+from textwrap import dedent
 try:
     import unittest2 as unittest
 except ImportError:
@@ -626,6 +627,25 @@ class RenameRefactoringTest(unittest.TestCase):
         refactored = self._local_rename(code, code.index('a_var') + 1,
                                         'new_var')
         self.assertEqual(code.replace('a_var', 'new_var', 2), refactored)
+
+    def test_renaming_in_generalized_dict_unpacking(self):
+        code = dedent('''\
+            a_var = {**{'stuff': 'can'}, **{'stuff': 'crayon'}}
+
+            if "stuff" in a_var:
+                print("ya")
+        ''')
+        mod1 = testutils.create_module(self.project, 'mod1')
+        mod1.write(code)
+        refactored = self._local_rename(code, code.index('a_var') + 1,
+                                        'new_var')
+        expected = dedent('''\
+            new_var = {**{'stuff': 'can'}, **{'stuff': 'crayon'}}
+
+            if "stuff" in new_var:
+                print("ya")
+        ''')
+        self.assertEqual(expected, refactored)
 
     def test_dos_line_ending_and_renaming(self):
         code = '\r\na = 1\r\n\r\nprint(2 + a + 2)\r\n'


### PR DESCRIPTION
This PR fixes #317. 

This fixes the error:

    'NoneType' object has no attribute '_fields'

when renaming variable that contains dict with generalized unpacking.