### PR TITLE
Fix test and handling of dict rename in Python 2.x

### DIFF
--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -235,7 +235,7 @@ class StatementEvaluator(object):
         keys = None
         values = None
         if node.keys and node.keys[0]:
-            keys, values = next(filter(itemgetter(0), zip(node.keys, node.values)), (None, None))
+            keys, values = next(iter(filter(itemgetter(0), zip(node.keys, node.values))), (None, None))
             if keys:
                 keys = self._get_object_for_node(keys)
             if values:

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -682,6 +682,7 @@ class RenameRefactoringTest(unittest.TestCase):
                                         'new_var')
         self.assertEqual(code.replace('a_var', 'new_var', 2), refactored)
 
+    @testutils.only_for_versions_higher('3.5')
     def test_renaming_in_generalized_dict_unpacking(self):
         code = dedent('''\
             a_var = {**{'stuff': 'can'}, **{'stuff': 'crayon'}}


### PR DESCRIPTION
#319 introduced some changes in dict-unpacking, but the implementation causes some tests to fail in Python 2.7 because the implementation uses constructs that aren't correct in Python 2.7. This fixes those failing tests.