### PR TITLE
Fix #114. Extract augmented assignment

### DIFF
--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -235,7 +235,7 @@ class StatementEvaluator(object):
         keys = None
         values = None
         if node.keys and node.keys[0]:
-            keys, values = next(filter(itemgetter(0), zip(node.keys, node.values)), (None, None))
+            keys, values = next(iter(filter(itemgetter(0), zip(node.keys, node.values))), (None, None))
             if keys:
                 keys = self._get_object_for_node(keys)
             if values:

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -547,7 +547,7 @@ class _ExtractMethodParts(object):
         # if not make_global, do not pass any global names; they are
         # all visible.
         if self.info.global_ and not self.info.make_global:
-            return ()
+            return list(self.info_collector.read & self.info_collector.postread & self.info_collector.written)
         if not self.info.one_line:
             result = (self.info_collector.prewritten &
                       self.info_collector.read)
@@ -661,6 +661,11 @@ class _FunctionInformationCollector(object):
         ast.walk(node.value, self)
         for child in node.targets:
             ast.walk(child, self)
+
+    def _AugAssign(self, node):
+        ast.walk(node.value, self)
+        self._read_variable(node.target.id, node.target.lineno)
+        self._written_variable(node.target.id, node.target.lineno)
 
     def _ClassDef(self, node):
         self._written_variable(node.name, node.lineno)

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -682,6 +682,7 @@ class RenameRefactoringTest(unittest.TestCase):
                                         'new_var')
         self.assertEqual(code.replace('a_var', 'new_var', 2), refactored)
 
+    @testutils.only_for_versions_higher('3.5')
     def test_renaming_in_generalized_dict_unpacking(self):
         code = dedent('''\
             a_var = {**{'stuff': 'can'}, **{'stuff': 'crayon'}}


### PR DESCRIPTION
Fix issue in #114 where extracting code that writes to global variables or contains augmented assignments produces refactored code that doesn't behave the same as the original code.