### PR TITLE
Check for Nonetype Node

### DIFF
--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -46,7 +46,7 @@ def get_child_nodes(node):
     if isinstance(node, ast.Module):
         return node.body
     result = []
-    if node._fields is not None:
+    if node and node._fields is not None:
         for name in node._fields:
             child = getattr(node, name)
             if isinstance(child, list):


### PR DESCRIPTION
I'm still trying to figure out what is going on here - so apologize for being light on details.

I have been trying to do a file rename refactor, which fails with:
```
>>> AttributeError: 'NoneType' object has no attribute '_fields'
```

Trying to see what the reproduction scenario is, but I *think* it is handling client code that looks something like this:


Operation: rename c.py -> z.py

```
# filename a/e.py

def foo():
       - from a.b import c 
       + from a.b import z
       z.foo()
```

Taking a look at 
https://github.com/python-rope/rope/blob/65080c52d5e1d6c196417b7c877af89ff44f5278/rope/base/evaluate.py#L289-L291

It seems I have a function scope with no node.

