### PR TITLE
Added _NamedExpr into `patchedast.py`

### DIFF
--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -258,6 +258,13 @@ class _PatchingASTWalker(object):
         children.extend(['=', node.value])
         self._handle(node, children)
 
+    def _AnnAssign(self, node):
+        children = [node.target, ':', node.annotation]
+        if node.value is not None:
+            children.append('=')
+            children.append(node.value)
+        self._handle(node, children)
+
     def _Repr(self, node):
         self._handle(node, ['`', node.value, '`'])
 

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -236,6 +236,10 @@ class _PatchingASTWalker(object):
     def _get_op(self, node):
         return self._operators[node.__class__.__name__].split(' ')
 
+    def _AnnAssign(self, node):
+        children = [node.target]
+        self._handle(node, children)
+
     def _Attribute(self, node):
         self._handle(node, [node.value, '.', node.attr])
 

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -236,10 +236,6 @@ class _PatchingASTWalker(object):
     def _get_op(self, node):
         return self._operators[node.__class__.__name__].split(' ')
 
-    def _AnnAssign(self, node):
-        children = [node.target]
-        self._handle(node, children)
-
     def _Attribute(self, node):
         self._handle(node, [node.value, '.', node.attr])
 
@@ -431,6 +427,10 @@ class _PatchingASTWalker(object):
 
     def _Expr(self, node):
         self._handle(node, [node.value])
+
+    def _NamedExpr(self, node):
+        children = [node.target, ':=', node.value]
+        self._handle(node, children)
 
     def _Exec(self, node):
         children = []

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1208,6 +1208,27 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         self.assertEqual(expected, refactored)
 
+    def test_extract_function_with_inline_assignment_in_condition(self):
+        code = dedent('''\
+            def foo(a):
+                if i := a == 5:
+                    i += 1
+                print(i)
+        ''')
+        start, end = self._convert_line_range_to_offset(code, 2, 3)
+        refactored = self.do_extract_method(code, start, end, 'new_func')
+        expected = dedent('''\
+            def foo(a):
+                i = new_func(a)
+                print(i)
+
+            def new_func(a):
+                if i := a == 5:
+                    i += 1
+                return i
+        ''')
+        self.assertEqual(expected, refactored)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1208,6 +1208,7 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         self.assertEqual(expected, refactored)
 
+    @testutils.only_for_versions_higher('3.8')
     def test_extract_function_with_inline_assignment_in_condition(self):
         code = dedent('''\
             def foo(a):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -120,6 +120,26 @@ class PatchedASTTest(unittest.TestCase):
         checker.check_children(
             'Assign', ['Name', ' ', '=', ' ', 'Num'])
 
+    @testutils.only_for_versions_higher('3.6')
+    def test_ann_assign_node_with_target(self):
+        source = 'a: List[int]\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        start = source.index('a')  # noqa
+        checker.check_region('AnnAssign', 0, len(source) - 1)
+        checker.check_children(
+            'AnnAssign', ['Name', '', ':', ' ', 'Subscript'])
+
+    @testutils.only_for_versions_higher('3.6')
+    def test_ann_assign_node_with_target(self):
+        source = 'a: int = 10\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        start = source.index('a')  # noqa
+        checker.check_region('AnnAssign', 0, len(source) - 1)
+        checker.check_children(
+            'AnnAssign', ['Name', '', ':', ' ', 'Name', ' ', '=', ' ', 'Num'])
+
     def test_add_node(self):
         source = '1 + 2\n'
         ast_frag = patchedast.get_patched_ast(source, True)

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -121,7 +121,7 @@ class PatchedASTTest(unittest.TestCase):
             'Assign', ['Name', ' ', '=', ' ', 'Num'])
 
     @testutils.only_for_versions_higher('3.6')
-    def test_ann_assign_node_with_target(self):
+    def test_ann_assign_node_without_target(self):
         source = 'a: List[int]\n'
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -601,6 +601,15 @@ class PatchedASTTest(unittest.TestCase):
                     ':', '\n    ', 'Pass', '\n',
                     'else', '', ':', '\n    ', 'Pass'])
 
+    @testutils.only_for_versions_higher('3.8')
+    def test_named_expr_node(self):
+        source = 'if a := 10 == 10:\n    pass\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        start = source.index('a')
+        checker.check_region('NamedExpr', start, start + 13)
+        checker.check_children('NamedExpr', ['Name', ' ', ':=', ' ', 'Compare'])
+
     def test_normal_from_node(self):
         source = 'from x import y\n'
         ast_frag = patchedast.get_patched_ast(source, True)


### PR DESCRIPTION
Also found missing _NamedExpr node, but can't fidure out how to implement it

I'm trying to fix #326 
As I can see, it works: Rename works in both sides of `:=` operator