### PR TITLE
create_generate with goal_resource param

### DIFF
--- a/rope/contrib/generate.py
+++ b/rope/contrib/generate.py
@@ -5,7 +5,7 @@ from rope.base import (change, pyobjects, exceptions, pynames, worder,
 from rope.refactor import sourceutils, importutils, functionutils, suites
 
 
-def create_generate(kind, project, resource, offset):
+def create_generate(kind, project, resource, offset, goal_resource=None):
     """A factory for creating `Generate` objects
 
     `kind` can be 'variable', 'function', 'class', 'module' or
@@ -13,7 +13,7 @@ def create_generate(kind, project, resource, offset):
 
     """
     generate = eval('Generate' + kind.title())
-    return generate(project, resource, offset)
+    return generate(project, resource, offset, goal_resource=goal_resource)
 
 
 def create_module(project, name, sourcefolder=None):

--- a/ropetest/contrib/generatetest.py
+++ b/ropetest/contrib/generatetest.py
@@ -284,6 +284,32 @@ class GenerateTest(unittest.TestCase):
             '    if 1:\n        g()\n',
             self.mod.read())
 
+    def test_create_generate_class_with_goal_resource(self):
+        code = 'c = C()\n'
+        self.mod.write(code)
+
+        result = generate.create_generate(
+            "class",
+            self.project,
+            self.mod,
+            code.index("C"),
+            goal_resource=self.mod2)
+
+        self.assertTrue(isinstance(result, generate.GenerateClass))
+        self.assertEqual(result.goal_resource, self.mod2)
+
+    def test_create_generate_class_without_goal_resource(self):
+        code = 'c = C()\n'
+        self.mod.write(code)
+
+        result = generate.create_generate(
+            "class",
+            self.project,
+            self.mod,
+            code.index("C"))
+
+        self.assertTrue(isinstance(result, generate.GenerateClass))
+        self.assertIsNone(result.goal_resource)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I'm working on option generating class in different file in ropevim. RopeVim uses "create_generate" function, it doesn't provide option to set "goal_resource".

I added this to rope. It will be nice if this can be merged. Thanks ;)