### PR TITLE
Python 3.9 ast changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -307,6 +307,9 @@ class StatementEvaluator(object):
         elif isinstance(node.slice, ast.Slice):
             self._call_function(node.value, '__getitem__',
                                 [node.slice])
+        elif isinstance(node.slice, ast.expr):
+            self._call_function(node.value, '__getitem__',
+                                [node.value])
 
     def _Slice(self, node):
         self.result = self._get_builtin_name('slice')

--- a/rope/base/oi/soa.py
+++ b/rope/base/oi/soa.py
@@ -126,7 +126,7 @@ class SOAVisitor(object):
         for subscript, levels in nodes:
             instance = evaluate.eval_node(self.scope, subscript.value)
             args_pynames = [evaluate.eval_node(self.scope,
-                                               subscript.slice.value)]
+                                               subscript.slice)]
             value = rope.base.oi.soi._infer_assignment(
                 rope.base.pynames.AssignmentValue(node.value, levels,
                                                   type_hint=type_hint),
@@ -149,5 +149,5 @@ class _SOAAssignVisitor(astutils._NodeNameCollector):
 
     def _added(self, node, levels):
         if isinstance(node, rope.base.ast.Subscript) and \
-           isinstance(node.slice, rope.base.ast.Index):
+           isinstance(node.slice, (rope.base.ast.Index, rope.base.ast.expr)):
             self.nodes.append((node, levels))

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -838,8 +838,12 @@ class PatchedASTTest(unittest.TestCase):
         source = 'x = xs[0,:]\n'
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
-        checker.check_region('ExtSlice', 7, len(source) - 2)
-        checker.check_children('ExtSlice', ['Index', '', ',', '', 'Slice'])
+        if sys.version_info >= (3, 9):
+            checker.check_region('Tuple', 7, len(source) - 2)
+            checker.check_children('Tuple', ['Num', '', ',', '', 'Slice'])
+        else:
+            checker.check_region('ExtSlice', 7, len(source) - 2)
+            checker.check_children('ExtSlice', ['Index', '', ',', '', 'Slice'])
 
     def test_simple_module_node(self):
         source = 'pass\n'
@@ -933,9 +937,13 @@ class PatchedASTTest(unittest.TestCase):
         source = 'a[1]\n'
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
-        checker.check_children(
-            'Subscript', ['Name', '', '[', '', 'Index', '', ']'])
-        checker.check_children('Index', ['Num'])
+        if sys.version_info >= (3, 9):
+            checker.check_children(
+                'Subscript', ['Name', '', '[', '', 'Num', '', ']'])
+        else:
+            checker.check_children(
+                'Subscript', ['Name', '', '[', '', 'Index', '', ']'])
+            checker.check_children('Index', ['Num'])
 
     def test_tuple_node(self):
         source = '(1, 2)\n'


### PR DESCRIPTION
The ast module in Python 3.9 has some API changes. Quoting [1]:

> Simplified AST for subscription. Simple indices will be represented by their value, extended slices will be represented as tuples.  Index(value) will return a value itself, ExtSlice(slices) will return Tuple(slices, Load()). (Contributed by Serhiy Storchaka in bpo-34822.)

The second patch is still a work-in-progress, for two reasons: I don't know if the bit I added is functionally correct (though it resolves 20/24 of the test failures), and I don't know how to handle `ast.Call` (and potentially anything else) that seems to be the cause of the remaining 4 failures.

Help required.

[1] https://docs.python.org/3/whatsnew/3.9.html#changes-in-the-python-api
