### PR TITLE
Modifies default_config.py

### DIFF
--- a/rope/base/default_config.py
+++ b/rope/base/default_config.py
@@ -15,7 +15,8 @@ def set_prefs(prefs):
     # 'build/*.o': matches 'build/lib.o' but not 'build/sub/lib.o'
     # 'build//*.o': matches 'build/lib.o' and 'build/sub/lib.o'
     prefs['ignored_resources'] = ['*.pyc', '*~', '.ropeproject',
-                                  '.hg', '.svn', '_svn', '.git', '.tox']
+                                  '.hg', '.svn', '_svn', '.git', '.tox',
+                                  '.venv', 'venv']
 
     # Specifies which files should be considered python files.  It is
     # useful when you have scripts inside your project.  Only files


### PR DESCRIPTION
In the spirit of #324  I could verify that long waiting times are a result of not ignoring `venv` or `.venv` (pick your poison). As it is best practice to use venv I think they should be ignored by default. Also this cost me way to much headache to realize and I can imagine  that I am not alone in that regard.

Greetings,
Leon