### PR TITLE
Discuss: should we move off the Google Groups developer mailing list to Github?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,10 +40,9 @@ you open a project).
 Bug Reports
 ===========
 
-Send your bug reports and feature requests to `rope-dev (at)
-googlegroups.com`_.
+Send your bug reports and feature requests at `python-rope's issue tracker`_ in Github.
 
-.. _`rope-dev (at) googlegroups.com`: http://groups.google.com/group/rope-dev
+.. _`python-rope's issue tracker`: https://github.com/python-rope/rope/issues
 
 
 License

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -14,32 +14,34 @@ welcome to!
 How to Help Rope?
 =================
 
-Rope's mailing list is `rope-dev (at) googlegroups.com`_.  Click the
-"Join group to post" button to subscribe. Then:
+Rope's development happens in `python-rope's Github page`_. Then:
 
 * Use rope
 * Send bug reports and request features
 * Submit patches for bugs or new features
 * Discuss your ideas
 
-.. _`rope-dev (at) googlegroups.com`: http://groups.google.com/group/rope-dev
-
+.. _`python-rope's Github page`: https://github.com/python-rope/rope
 
 Wish List
 =========
 
-You are welcome to send your patches to the `rope-dev (at)
-googlegroups.com`_ mailing list.  Here is a list of suggestions.
+You are welcome to make pull requests in `python-rope's Github page`_.
+
+Here is a list of suggestions.
 
 Issues
 ------
 
-The `dev/issues.rst`_ file is actually the main rope todo file.  There
-is a section called "unresolved issues"; it contains almost every kind
-of task.  Most of them need some thought or discussion.  Pickup
-whichever you are most interested in.  If you have ideas or questions
-about them, don't hesitate to discuss it in the mailing list.
+The `unresolved issues list`_ in Github is the latest todo list.
 
+There is also a rather outdated list in `dev/issues.rst`_. There
+is a section called "unresolved issues"; it contains almost every kind
+of task.  This file will need some cleanup, thoughts, and discussions.
+Pickup whichever you are most interested in.  If you have ideas or questions
+about them, don't hesitate to create a Github ticket for it.
+
+.. _`unresolved issues list`: https://github.com/python-rope/rope/issues
 .. _`dev/issues.rst`: dev/issues.rst
 
 Write Plugins For Other IDEs

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -38,6 +38,7 @@ The `unresolved issues list`_ in Github is the latest todo list.
 There is also a rather outdated list in `dev/issues.rst`_. There
 is a section called "unresolved issues"; it contains almost every kind
 of task.  This file will need some cleanup, thoughts, and discussions.
+
 Pickup whichever you are most interested in.  If you have ideas or questions
 about them, don't hesitate to create a Github ticket for it.
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -14,19 +14,29 @@ welcome to!
 How to Help Rope?
 =================
 
-Rope's development happens in `python-rope's Github page`_. Then:
+Rope's development happens in  `python-rope's Github`_.
 
-* Use rope
+Use `python-rope's Github Issue Tracker`_ to discuss development-related issues:
+
 * Send bug reports and request features
 * Submit patches for bugs or new features
-* Discuss your ideas
 
-.. _`python-rope's Github page`: https://github.com/python-rope/rope
+Use `python-rope's Github Discussion`_ for other discussions, such as:
+
+* Help using rope
+* Help integrating rope with text editors/tools
+* Discuss your ideas
+* Engage with the rope community
+
+.. _`python-rope's Github`: https://github.com/python-rope/rope
+.. _`python-rope's Github Issue Tracker`: https://github.com/python-rope/rope/issues
+.. _`python-rope's Github Discussion`: https://github.com/python-rope/rope/discussions
+
 
 Wish List
 =========
 
-You are welcome to make pull requests in `python-rope's Github page`_.
+You are welcome to make pull requests in `python-rope's Github Issue Tracker`_.
 
 Here is a list of suggestions.
 


### PR DESCRIPTION
As of the time of posting, the developer's Google Group seems to be dead. Unless someone has the know-how and ability to restore the Google Groups mailing list and take ownership to manage it, then it would make sense to just abandon it and do all dev discussion in Github.

Should we just move completely to Github? Maybe enable Github Discussions for the repository?

This Pull Request does not constitute a decision to abandon the mailing list. If we decide to continue with the mailing list, then this pull request should be closed.