### PR TITLE
Fix MismatchedTokenError caused by use of exec with parentheses in Python 2

### DIFF
--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -460,25 +460,6 @@ class _PatchingASTWalker(object):
         children.append(self.exec_close_paren_or_space)
         self._handle(node, children)
 
-    # def _Exec(self, node):
-    #     children = []
-    #     children.extend(['exec', '(', node.body])
-    #     if node.globals:
-    #         children.extend([',', node.globals])
-    #     if node.locals:
-    #         children.extend([',', node.locals])
-    #     children.append(')')
-    #     self._handle(node, children)
-
-    # def _Exec(self, node):
-    #     children = []
-    #     children.extend(['exec', node.body])
-    #     if node.globals:
-    #         children.extend(['in', node.globals])
-    #     if node.locals:
-    #         children.extend([',', node.locals])
-    #     self._handle(node, children)
-
     def _ExtSlice(self, node):
         children = []
         for index, dim in enumerate(node.dims):
@@ -862,7 +843,6 @@ class _Source(object):
                 else:
                     self._skip_comment()
         except (ValueError, TypeError) as e:
-            print e
             raise MismatchedTokenError(
                 'Token <%s> at %s cannot be matched' %
                 (token, self._get_location()))

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -77,6 +77,9 @@ class _PatchingASTWalker(object):
     Number = object()
     String = object()
     semicolon_or_as_in_except = object()
+    exec_open_paren_or_space = object()
+    exec_close_paren_or_space = object()
+    exec_in_or_comma = object()
 
     def __call__(self, node):
         method = getattr(self, '_' + node.__class__.__name__, None)
@@ -124,6 +127,15 @@ class _PatchingASTWalker(object):
                     # INFO: This has been added to handle deprecated
                     # semicolon in except
                     region = self.source.consume_except_as_or_semicolon()
+                elif child == self.exec_open_paren_or_space:
+                    # These three cases handle the differences between
+                    # the deprecated exec statement and the exec
+                    # function.
+                    region = self.source.consume_exec_open_paren_or_space()
+                elif child == self.exec_in_or_comma:
+                    region = self.source.consume_exec_in_or_comma()
+                elif child == self.exec_close_paren_or_space:
+                    region = self.source.consume_exec_close_paren_or_space()
                 else:
                     if hasattr(ast, 'JoinedStr') and isinstance(node, (ast.JoinedStr, ast.FormattedValue)):
                         region = self.source.consume_joined_string(child)
@@ -440,13 +452,32 @@ class _PatchingASTWalker(object):
         self._handle(node, children)
 
     def _Exec(self, node):
-        children = []
-        children.extend(['exec', node.body])
+        children = ['exec', self.exec_open_paren_or_space, node.body]
         if node.globals:
-            children.extend(['in', node.globals])
+            children.extend([self.exec_in_or_comma, node.globals])
         if node.locals:
             children.extend([',', node.locals])
+        children.append(self.exec_close_paren_or_space)
         self._handle(node, children)
+
+    # def _Exec(self, node):
+    #     children = []
+    #     children.extend(['exec', '(', node.body])
+    #     if node.globals:
+    #         children.extend([',', node.globals])
+    #     if node.locals:
+    #         children.extend([',', node.locals])
+    #     children.append(')')
+    #     self._handle(node, children)
+
+    # def _Exec(self, node):
+    #     children = []
+    #     children.extend(['exec', node.body])
+    #     if node.globals:
+    #         children.extend(['in', node.globals])
+    #     if node.locals:
+    #         children.extend([',', node.locals])
+    #     self._handle(node, children)
 
     def _ExtSlice(self, node):
         children = []
@@ -830,7 +861,8 @@ class _Source(object):
                     break
                 else:
                     self._skip_comment()
-        except (ValueError, TypeError):
+        except (ValueError, TypeError) as e:
+            print e
             raise MismatchedTokenError(
                 'Token <%s> at %s cannot be matched' %
                 (token, self._get_location()))
@@ -868,6 +900,18 @@ class _Source(object):
 
     def consume_except_as_or_semicolon(self):
         repattern = re.compile(r'as|,')
+        return self._consume_pattern(repattern)
+
+    def consume_exec_open_paren_or_space(self):
+        repattern = re.compile(r'\(|')
+        return self._consume_pattern(repattern)
+
+    def consume_exec_in_or_comma(self):
+        repattern = re.compile(r'in|,')
+        return self._consume_pattern(repattern)
+
+    def consume_exec_close_paren_or_space(self):
+        repattern = re.compile(r'\)|')
         return self._consume_pattern(repattern)
 
     def _good_token(self, token, offset, start=None):

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1298,6 +1298,37 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         self.assertEqual(expected, refactored)
 
+    def test_extract_exec(self):
+        code = dedent('''\
+            exec("def f(): pass", {})
+        ''')
+        start, end = self._convert_line_range_to_offset(code, 1, 1)
+        refactored = self.do_extract_method(code, start, end, 'new_func')
+        expected = dedent('''\
+
+            def new_func():
+                exec("def f(): pass", {})
+
+            new_func()
+        ''')
+        self.assertEqual(expected, refactored)
+
+    @testutils.only_for_versions_lower('3')
+    def test_extract_exec_statement(self):
+        code = dedent('''\
+            exec "def f(): pass" in {}
+        ''')
+        start, end = self._convert_line_range_to_offset(code, 1, 1)
+        refactored = self.do_extract_method(code, start, end, 'new_func')
+        expected = dedent('''\
+
+            def new_func():
+                exec "def f(): pass" in {}
+
+            new_func()
+        ''')
+        self.assertEqual(expected, refactored)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -599,7 +599,7 @@ class PatchedASTTest(unittest.TestCase):
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_region('Exec', 0, len(source) - 1)
-        checker.check_children('Exec', ['exec', ' ', 'Str'])
+        checker.check_children('Exec', ['exec', '', '', ' ', 'Str', '', ''])
 
     @testutils.only_for_versions_lower('3')
     def test_exec_node(self):
@@ -608,8 +608,18 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_region('Exec', 0, len(source) - 1)
         checker.check_children(
-            'Exec', ['exec', ' ', 'Str', ' ', 'in',
-                     ' ', 'Call', '', ',', ' ', 'Call'])
+            'Exec', ['exec', '', '', ' ', 'Str', ' ', 'in',
+                     ' ', 'Call', '', ',', ' ', 'Call', '', ''])
+
+    @testutils.only_for_versions_lower('3')
+    def test_exec_node_with_parens(self):
+        source = 'exec("", locals(), globals())\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_region('Exec', 0, len(source) - 1)
+        checker.check_children(
+            'Exec', ['exec', '', '(', '', 'Str', '', ',',
+                     ' ', 'Call', '', ',', ' ', 'Call', '', ')'])
 
     def test_for_node(self):
         source = 'for i in range(1):\n    pass\nelse:\n    pass\n'


### PR DESCRIPTION
Original patch was created by @ceridwen, thank you for your contribution!

The original patch looks good, this PR just made minor cleanup and added some tests.

Fix #117.
Close #126.