### PR TITLE
Implement `async def`, `async for`, and `await` syntax for method extraction

### DIFF
--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -754,6 +754,9 @@ class _FunctionInformationCollector(object):
             for name in visitor.read - visitor.written:
                 self._read_variable(name, node.lineno)
 
+    def _AsyncFunctionDef(self, node):
+        self._FunctionDef(node)
+
     def _Name(self, node):
         if isinstance(node.ctx, (ast.Store, ast.AugStore)):
             self._written_variable(node.id, node.lineno)

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -770,7 +770,18 @@ class _VariableReadsAndWritesFinder(object):
         return visitor.read
 
 
-class _UnmatchedBreakOrContinueFinder(object):
+class _BaseErrorFinder(object):
+    @classmethod
+    def has_errors(cls, code):
+        if code.strip() == '':
+            return False
+        node = _parse_text(code)
+        visitor = cls()
+        ast.walk(node, visitor)
+        return visitor.error
+
+
+class _UnmatchedBreakOrContinueFinder(_BaseErrorFinder):
 
     def __init__(self):
         self.error = False
@@ -809,15 +820,6 @@ class _UnmatchedBreakOrContinueFinder(object):
 
     def _ClassDef(self, node):
         pass
-
-    @staticmethod
-    def has_errors(code):
-        if code.strip() == '':
-            return False
-        node = _parse_text(code)
-        visitor = _UnmatchedBreakOrContinueFinder()
-        ast.walk(node, visitor)
-        return visitor.error
 
 
 def _get_function_kind(scope):

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -402,7 +402,7 @@ class _ExceptionalConditionChecker(object):
                                    'span multiple lines.')
         if usefunction._named_expr_count(info._parsed_extracted) - usefunction._namedexpr_last(info._parsed_extracted):
             raise RefactoringError('Extracted piece cannot '
-                                   'contain named expression (:=) statements.')
+                                   'contain named expression (:= operator).')
 
     def multi_line_conditions(self, info):
         node = _parse_text(info.source[info.region[0]:info.region[1]])

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -384,7 +384,7 @@ class _ExceptionalConditionChecker(object):
         if end_scope != info.scope and end_scope.get_end() != end_line:
             raise RefactoringError('Bad region selected for extract method')
         try:
-            extracted = info.source[info.region[0]:info.region[1]]
+            extracted = info.extracted
             if info.one_line:
                 extracted = '(%s)' % extracted
             if _UnmatchedBreakOrContinueFinder.has_errors(extracted):

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -813,6 +813,12 @@ class _PatchingASTWalker(object):
         children.append(node.operand)
         self._handle(node, children)
 
+    def _Await(self, node):
+        children = ['await']
+        if node.value:
+            children.append(node.value)
+        self._handle(node, children)
+
     def _Yield(self, node):
         children = ['yield']
         if node.value:

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -468,13 +468,23 @@ class _PatchingASTWalker(object):
             children.append(dim)
         self._handle(node, children)
 
-    def _For(self, node):
-        children = ['for', node.target, 'in', node.iter, ':']
+    def _handle_for_loop_node(self, node, is_async):
+        if is_async:
+            children = ['async', 'for']
+        else:
+            children = ['for']
+        children.extend([node.target, 'in', node.iter, ':'])
         children.extend(node.body)
         if node.orelse:
             children.extend(['else', ':'])
             children.extend(node.orelse)
         self._handle(node, children)
+
+    def _For(self, node):
+        self._handle_for_loop_node(node, is_async=False)
+
+    def _AsyncFor(self, node):
+        self._handle_for_loop_node(node, is_async=True)
 
     def _ImportFrom(self, node):
         children = ['from']

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -492,7 +492,7 @@ class _PatchingASTWalker(object):
             children.extend(['as', node.asname])
         self._handle(node, children)
 
-    def _FunctionDef(self, node):
+    def _handle_function_def_node(self, node, is_async):
         children = []
         try:
             decorators = getattr(node, 'decorator_list')
@@ -502,10 +502,20 @@ class _PatchingASTWalker(object):
             for decorator in decorators:
                 children.append('@')
                 children.append(decorator)
-        children.extend(['def', node.name, '(', node.args])
+        if is_async:
+            children.extend(['async', 'def'])
+        else:
+            children.extend(['def'])
+        children.extend([node.name, '(', node.args])
         children.extend([')', ':'])
         children.extend(node.body)
         self._handle(node, children)
+
+    def _FunctionDef(self, node):
+        self._handle_function_def_node(node, is_async=False)
+
+    def _AsyncFunctionDef(self, node):
+        self._handle_function_def_node(node, is_async=True)
 
     def _arguments(self, node):
         children = []

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1391,6 +1391,27 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         self.assertEqual(expected, refactored)
 
+    def test_extract_await_expression(self):
+        code = dedent('''\
+            def my_func(my_list):
+                for url in my_list:
+                    resp = await request(url)
+                return resp
+        ''')
+        selected = 'request(url)'
+        start, end = code.index(selected), code.index(selected) + len(selected)
+        refactored = self.do_extract_method(code, start, end, 'new_func')
+        expected = dedent('''\
+            def my_func(my_list):
+                for url in my_list:
+                    resp = await new_func(url)
+                return resp
+
+            def new_func(url):
+                return request(url)
+        ''')
+        self.assertEqual(expected, refactored)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1349,6 +1349,27 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         self.assertEqual(expected, refactored)
 
+    def test_extract_async_function(self):
+        code = dedent('''\
+            async def my_func(my_list):
+                for x in my_list:
+                    var = x + 1
+                return var
+        ''')
+        start, end = self._convert_line_range_to_offset(code, 3, 3)
+        refactored = self.do_extract_method(code, start, end, 'new_func')
+        expected = dedent('''\
+            async def my_func(my_list):
+                for x in my_list:
+                    var = new_func(x)
+                return var
+
+            def new_func(x):
+                var = x + 1
+                return var
+        ''')
+        self.assertEqual(expected, refactored)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1349,6 +1349,7 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         self.assertEqual(expected, refactored)
 
+    @testutils.only_for_versions_higher('3.5')
     def test_extract_async_function(self):
         code = dedent('''\
             async def my_func(my_list):
@@ -1370,6 +1371,7 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         self.assertEqual(expected, refactored)
 
+    @testutils.only_for_versions_higher('3.5')
     def test_extract_async_for_loop(self):
         code = dedent('''\
             def my_func(my_list):
@@ -1391,6 +1393,7 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         self.assertEqual(expected, refactored)
 
+    @testutils.only_for_versions_higher('3.5')
     def test_extract_await_expression(self):
         code = dedent('''\
             def my_func(my_list):

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1374,7 +1374,7 @@ class ExtractMethodTest(unittest.TestCase):
     @testutils.only_for_versions_higher('3.5')
     def test_extract_async_for_loop(self):
         code = dedent('''\
-            def my_func(my_list):
+            async def my_func(my_list):
                 async for x in my_list:
                     var = x + 1
                 return var
@@ -1382,7 +1382,7 @@ class ExtractMethodTest(unittest.TestCase):
         start, end = self._convert_line_range_to_offset(code, 3, 3)
         refactored = self.do_extract_method(code, start, end, 'new_func')
         expected = dedent('''\
-            def my_func(my_list):
+            async def my_func(my_list):
                 async for x in my_list:
                     var = new_func(x)
                 return var
@@ -1396,7 +1396,7 @@ class ExtractMethodTest(unittest.TestCase):
     @testutils.only_for_versions_higher('3.5')
     def test_extract_await_expression(self):
         code = dedent('''\
-            def my_func(my_list):
+            async def my_func(my_list):
                 for url in my_list:
                     resp = await request(url)
                 return resp
@@ -1405,7 +1405,7 @@ class ExtractMethodTest(unittest.TestCase):
         start, end = code.index(selected), code.index(selected) + len(selected)
         refactored = self.do_extract_method(code, start, end, 'new_func')
         expected = dedent('''\
-            def my_func(my_list):
+            async def my_func(my_list):
                 for url in my_list:
                     resp = await new_func(url)
                 return resp

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1498,6 +1498,7 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         self.assertEqual(expected, refactored)
 
+    @testutils.only_for_versions_higher('3.5')
     @testutils.only_for_versions_lower('3.8')
     def test_extract_refactor_containing_async_for_loop_should_error_before_py38(self):
         """

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1370,6 +1370,27 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         self.assertEqual(expected, refactored)
 
+    def test_extract_async_for_loop(self):
+        code = dedent('''\
+            def my_func(my_list):
+                async for x in my_list:
+                    var = x + 1
+                return var
+        ''')
+        start, end = self._convert_line_range_to_offset(code, 3, 3)
+        refactored = self.do_extract_method(code, start, end, 'new_func')
+        expected = dedent('''\
+            def my_func(my_list):
+                async for x in my_list:
+                    var = new_func(x)
+                return var
+
+            def new_func(x):
+                var = x + 1
+                return var
+        ''')
+        self.assertEqual(expected, refactored)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1315,7 +1315,7 @@ class ExtractMethodTest(unittest.TestCase):
         ''')
         extract_target = 'a == (c := 5)'
         start, end = code.index(extract_target), code.index(extract_target) + len(extract_target)
-        with self.assertRaisesRegexp(rope.base.exceptions.RefactoringError, 'Extracted piece cannot contain named expression \\(:=\\) statements.'):
+        with self.assertRaisesRegexp(rope.base.exceptions.RefactoringError, 'Extracted piece cannot contain named expression \\(:= operator\\).'):
             self.do_extract_method(code, start, end, 'new_func')
 
     def test_extract_exec(self):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -541,6 +541,15 @@ class PatchedASTTest(unittest.TestCase):
                                ['def', ' ', 'f', '', '(', '', 'arguments', '',
                                             ')', '', ':', '\n    ', 'Pass'])
 
+    def test_async_function_node(self):
+        source = 'async def f():\n    pass\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_region('AsyncFunction', 0, len(source) - 1)
+        checker.check_children('AsyncFunction',
+                               ['async', ' ', 'def', ' ', 'f', '', '(', '', 'arguments', '',
+                                            ')', '', ':', '\n    ', 'Pass'])
+
     def test_function_node2(self):
         source = 'def f(p1, **p2):\n    """docs"""\n    pass\n'
         ast_frag = patchedast.get_patched_ast(source, True)

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -640,6 +640,16 @@ class PatchedASTTest(unittest.TestCase):
                     ':', '\n    ', 'Pass', '\n',
                     'else', '', ':', '\n    ', 'Pass'])
 
+    def test_async_for_node(self):
+        source = 'async for i in range(1):\n    pass\nelse:\n    pass\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_region('AsyncFor', 0, len(source) - 1)
+        checker.check_children(
+            'AsyncFor', ['async', ' ', 'for', ' ', 'Name', ' ', 'in', ' ', 'Call', '',
+                    ':', '\n    ', 'Pass', '\n',
+                    'else', '', ':', '\n    ', 'Pass'])
+
     @testutils.only_for_versions_higher('3.8')
     def test_named_expr_node(self):
         source = 'if a := 10 == 10:\n    pass\n'

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     import unittest
 import sys
+from textwrap import dedent
 
 from rope.base import ast
 from rope.base.utils import pycompat
@@ -1187,6 +1188,15 @@ class PatchedASTTest(unittest.TestCase):
         checker.check_children(
             'Call', ['Name', '', '(', '', 'keyword', '', ',', ' *',
                      'Starred', '', ')'])
+
+    def test_await_node(self):
+        source = dedent('''\
+            def f():
+                await sleep()
+        ''')
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children('Await', ['await', ' ', 'Call'])
 
 
 class _ResultChecker(object):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -633,7 +633,12 @@ class PatchedASTTest(unittest.TestCase):
                      ' ', 'Call', '', ',', ' ', 'Call', '', ')'])
 
     def test_for_node(self):
-        source = 'for i in range(1):\n    pass\nelse:\n    pass\n'
+        source = dedent('''\
+            for i in range(1):
+                pass
+            else:
+                pass
+        ''')
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_region('For', 0, len(source) - 1)
@@ -644,14 +649,20 @@ class PatchedASTTest(unittest.TestCase):
 
     @testutils.only_for_versions_higher('3.5')
     def test_async_for_node(self):
-        source = 'async for i in range(1):\n    pass\nelse:\n    pass\n'
+        source = dedent('''\
+            async def foo():
+                async for i in range(1):
+                    pass
+                else:
+                    pass
+        ''')
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
-        checker.check_region('AsyncFor', 0, len(source) - 1)
+        checker.check_region('AsyncFor', source.index('async for'), len(source) - 1)
         checker.check_children(
             'AsyncFor', ['async', ' ', 'for', ' ', 'Name', ' ', 'in', ' ', 'Call', '',
-                    ':', '\n    ', 'Pass', '\n',
-                    'else', '', ':', '\n    ', 'Pass'])
+                    ':', '\n        ', 'Pass', '\n    ',
+                    'else', '', ':', '\n        ', 'Pass'])
 
     @testutils.only_for_versions_higher('3.8')
     def test_named_expr_node(self):
@@ -1194,7 +1205,7 @@ class PatchedASTTest(unittest.TestCase):
     @testutils.only_for_versions_higher('3.5')
     def test_await_node(self):
         source = dedent('''\
-            def f():
+            async def f():
                 await sleep()
         ''')
         ast_frag = patchedast.get_patched_ast(source, True)

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -542,6 +542,7 @@ class PatchedASTTest(unittest.TestCase):
                                ['def', ' ', 'f', '', '(', '', 'arguments', '',
                                             ')', '', ':', '\n    ', 'Pass'])
 
+    @testutils.only_for_versions_higher('3.5')
     def test_async_function_node(self):
         source = 'async def f():\n    pass\n'
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -641,6 +642,7 @@ class PatchedASTTest(unittest.TestCase):
                     ':', '\n    ', 'Pass', '\n',
                     'else', '', ':', '\n    ', 'Pass'])
 
+    @testutils.only_for_versions_higher('3.5')
     def test_async_for_node(self):
         source = 'async for i in range(1):\n    pass\nelse:\n    pass\n'
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -1189,6 +1191,7 @@ class PatchedASTTest(unittest.TestCase):
             'Call', ['Name', '', '(', '', 'keyword', '', ',', ' *',
                      'Starred', '', ')'])
 
+    @testutils.only_for_versions_higher('3.5')
     def test_await_node(self):
         source = dedent('''\
             def f():


### PR DESCRIPTION
Fix #375 

Todo:

- [x] fix version specifier
- [x] https://github.com/python-rope/rope/pull/389#issuecomment-918436011
- [x] https://github.com/python-rope/rope/pull/389#issuecomment-918439095