### PR TITLE
Fix error "'_ExpressionVisitor' object has no attribute 'defineds'"

### DIFF
--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -342,6 +342,9 @@ class _ExpressionVisitor(object):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
 
+    def _assigned(self, name, assignment=None):
+        self.scope_visitor._assigned(name, assignment)
+
     def _GeneratorExp(self, node):
         list_comp = PyComprehension(
             self.scope_visitor.pycore, node, self.scope_visitor.owner_object

--- a/ropetest/pyscopestest.py
+++ b/ropetest/pyscopestest.py
@@ -95,6 +95,17 @@ class PyCoreScopesTest(unittest.TestCase):
             ["b_var", "c_var"],
         )
 
+    # @testutils.only_for_versions_higher("3.8")
+    def test_inline_assignment(self):
+        scope = libutils.get_string_scope(
+            self.project,
+            """values = (a_var := 2,)""",
+        )
+        self.assertEqual(
+            list(sorted(scope.get_defined_names())),
+            ["a_var", "values"],
+        )
+
     @testutils.only_for_versions_higher("3.8")
     def test_inline_assignment_in_comprehensions(self):
         scope = libutils.get_string_scope(

--- a/ropetest/pyscopestest.py
+++ b/ropetest/pyscopestest.py
@@ -95,7 +95,7 @@ class PyCoreScopesTest(unittest.TestCase):
             ["b_var", "c_var"],
         )
 
-    # @testutils.only_for_versions_higher("3.8")
+    @testutils.only_for_versions_higher("3.8")
     def test_inline_assignment(self):
         scope = libutils.get_string_scope(
             self.project,


### PR DESCRIPTION
# Description

In rope master, code that uses inline assignment (`:=` operator), doing a AutoImport.generate_cache() produces an error:

```
Traceback (most recent call last):
  File "ref.py", line 8, in <module>
    importer.generate_cache()
  File "/home/user/rope/rope/contrib/autoimport.py", line 107, in generate_cache
    self.update_resource(file, underlined)
  File "/home/user/rope/rope/contrib/autoimport.py", line 160, in update_resource
    self._add_names(pymodule, modname, underlined)
  File "/home/user/rope/rope/contrib/autoimport.py", line 183, in _add_names
    attributes = pymodule._get_structural_attributes()
  File "/home/user/rope/rope/base/utils/__init__.py", line 32, in newfunc
    return func(self, *args, **kwds)
  File "/home/user/rope/rope/base/pyobjects.py", line 179, in _get_structural_attributes
    self.structural_attributes = self._create_structural_attributes()
  File "/home/user/rope/rope/base/pyobjects.py", line 232, in _create_structural_attributes
    ast.walk(child, new_visitor)
  File "/home/user/rope/rope/base/ast.py", line 40, in walk
    return method(node)
  File "/home/user/rope/rope/base/pyobjectsdef.py", line 460, in _Assign
    ast.walk(node, _AssignVisitor(self))
  File "/home/user/rope/rope/base/ast.py", line 40, in walk
    return method(node)
  File "/home/user/rope/rope/base/pyobjectsdef.py", line 380, in _Assign
    ast.walk(node.value, _ExpressionVisitor(self.scope_visitor))
  File "/home/user/rope/rope/base/ast.py", line 42, in walk
    walk(child, walker)
  File "/home/user/rope/rope/base/ast.py", line 40, in walk
    return method(node)
  File "/home/user/rope/rope/base/pyobjectsdef.py", line 367, in _NamedExpr
    ast.walk(node.target, _AssignVisitor(self))
  File "/home/user/rope/rope/base/ast.py", line 40, in walk
    return method(node)
  File "/home/user/rope/rope/base/pyobjectsdef.py", line 392, in _Name
    self._assigned(node.id, assignment)
  File "/home/user/rope/rope/base/pyobjectsdef.py", line 383, in _assigned
    print(self.scope_visitor, self.scope_visitor.defineds)
AttributeError: '_ExpressionVisitor' object has no attribute 'defineds'

```


# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works

