### PR TITLE
Fix _ComprehensionVisitor.get_pyobject()

### DIFF
--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -579,10 +579,10 @@ class _ComprehensionVisitor(_ScopeVisitor):
 
     def _Name(self, node):
         if isinstance(node.ctx, ast.Store):
-            self.names[node.id] = DefinedName(self._get_pyobject(node))
+            self.names[node.id] = self._get_pyobject(node)
 
     def _get_pyobject(self, node):
-        return pyobjects.PyDefinedObject(None, node, self.owner_object)
+        return pynames.AssignedName(lineno=node.lineno, module=self.get_module())
 
 
 class _GlobalVisitor(_ScopeVisitor):

--- a/ropetest/advanced_oi_test.py
+++ b/ropetest/advanced_oi_test.py
@@ -1124,3 +1124,12 @@ class NewStaticOITest(unittest.TestCase):
         a_class = pymod["A"].get_object()
         x_var = pymod["x"].get_object().get_type()
         self.assertEqual(a_class, x_var)
+
+    def test_set_comprehension(self):
+        code = dedent("""\
+            x = {s.strip() for s in X()}
+            x.add('x')
+        """)
+        self.mod.write(code)
+        pymod = self.project.get_pymodule(self.mod)
+        x_var = pymod['x'].pyobject.get()


### PR DESCRIPTION
This should return AssignedName rather than DefinedName/PyDefinedObject.

Fix this error when analyzing module containing comprehensions:

    TypeError: 'PyDefinedObject' object is not subscriptable

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
