### PR TITLE
Implement `yield from` syntax into patchedast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # **Upcoming release**
 
-- #270 Fix rename import statement with dots and as keyword (@climbus)
+## Syntax support
+
+- #443 Implement `yield from` syntax support to patchedast.py
+
+## Bug fixes
+- #270, #432 Fix rename import statement with dots and as keyword (@climbus)
 
 # Release 0.21.1
 

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -863,6 +863,10 @@ class _PatchingASTWalker(object):
             children.append(node.value)
         self._handle(node, children)
 
+    def _YieldFrom(self, node):
+        children = ["yield", "from", node.value]
+        self._handle(node, children)
+
     def _While(self, node):
         children = ["while", node.test, ":"]
         children.extend(node.body)

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1067,6 +1067,7 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_children("Yield", ["yield", " ", NameConstant])
 
+    @testutils.only_for_versions_higher("3.3")
     def test_yield_from_node(self):
         source = dedent("""\
             def f(lst):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1067,6 +1067,15 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_children("Yield", ["yield", " ", NameConstant])
 
+    def test_yield_from_node(self):
+        source = dedent("""\
+            def f(lst):
+                yield from lst
+        """)
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children("YieldFrom", ["yield", " ", "from", " ", "Name"])
+
     def test_while_node(self):
         source = dedent("""\
             while True:

--- a/ropetest/refactor/restructuretest.py
+++ b/ropetest/refactor/restructuretest.py
@@ -265,3 +265,27 @@ class RestructureTest(unittest.TestCase):
         refactoring = restructure.Restructure(self.project, "${a}", "${a}")
         self.project.do(refactoring.get_changes())
         self.assertEqual(mod_text, self.mod.read())
+
+    def test_yield_from(self):
+        mod_text = dedent("""\
+            def f(lst):
+                yield from lst
+        """)
+        self.mod.write(mod_text)
+        refactoring = restructure.Restructure(
+            self.project,
+            "yield from ${a}",
+            dedent("""\
+                for it in ${a}:
+                   yield it"""),
+        )
+        self.project.do(refactoring.get_changes())
+        self.assertEqual(
+            dedent("""\
+            def f(lst):
+                for it in lst:
+                   yield it
+            """),
+            self.mod.read(),
+        )
+

--- a/ropetest/refactor/restructuretest.py
+++ b/ropetest/refactor/restructuretest.py
@@ -266,6 +266,7 @@ class RestructureTest(unittest.TestCase):
         self.project.do(refactoring.get_changes())
         self.assertEqual(mod_text, self.mod.read())
 
+    @testutils.only_for_versions_higher("3.3")
     def test_yield_from(self):
         mod_text = dedent("""\
             def f(lst):


### PR DESCRIPTION
# Description

Implement `yield from` syntax for restructuring and extraction.

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
