### PR TITLE
Improve empty tuple and handling of parentheses around tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - #443 Implement `yield from` syntax support to patchedast.py
 
 ## Bug fixes
+
+- #445 Improve empty tuple and handling of parentheses around tuple
+
+## Bug fixes
 - #270, #432 Fix rename import statement with dots and as keyword (@climbus)
 
 # Release 0.21.1

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -842,7 +842,18 @@ class _PatchingASTWalker(object):
 
     def _Tuple(self, node):
         if node.elts:
-            self._handle(node, self._child_nodes(node.elts, ","), eat_parens=True)
+            children = collections.deque(self._child_nodes(node.elts, ","))
+            start = self.source.offset
+            inner_start = (
+                self.lines.get_line_start(node.elts[0].lineno) + node.elts[0].col_offset
+            )
+            while start <= inner_start:
+                inner_start = self.source.rfind_token("(", start, inner_start)
+                if inner_start is None:
+                    break
+                children.appendleft("(")
+                children.append(")")
+            self._handle(node, children, eat_parens=True)
         else:
             self._handle(node, ["(", ")"])
 

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1058,6 +1058,30 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_children("Tuple", ["(", "", ")"])
 
+    def test_empty_tuple_node2(self):
+        source = "a = ((), None)\n"
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            "Tuple", ["(", "", "Tuple", "", ",", " ", "Constant", "", ")"]
+        )
+
+    def test_empty_tuple_node3(self):
+        source = "a = (), None\n"
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            "Tuple", ["Tuple", "", ",", " ", "Constant"]
+        )
+
+    def test_tuple_with_complex_parentheses(self):
+        source = "a = ( # (he\n ((((), None))))\n"
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            "Tuple", ["(", " # (he\n ", "(", "", "(", "", "(", "", "Tuple", "", ",", " ", "Constant", "", ")", "", ")", "", ")", "", ")"]
+        )
+
     def test_yield_node(self):
         source = dedent("""\
             def f():

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1063,7 +1063,7 @@ class PatchedASTTest(unittest.TestCase):
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_children(
-            "Tuple", ["(", "", "Tuple", "", ",", " ", "Constant", "", ")"]
+            "Tuple", ["(", "", "Tuple", "", ",", " ", NameConstant, "", ")"]
         )
 
     def test_empty_tuple_node3(self):
@@ -1071,7 +1071,7 @@ class PatchedASTTest(unittest.TestCase):
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_children(
-            "Tuple", ["Tuple", "", ",", " ", "Constant"]
+            "Tuple", ["Tuple", "", ",", " ", NameConstant]
         )
 
     def test_tuple_with_complex_parentheses(self):
@@ -1079,7 +1079,7 @@ class PatchedASTTest(unittest.TestCase):
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_children(
-            "Tuple", ["(", " # (he\n ", "(", "", "(", "", "(", "", "Tuple", "", ",", " ", "Constant", "", ")", "", ")", "", ")", "", ")"]
+            "Tuple", ["(", " # (he\n ", "(", "", "(", "", "(", "", "Tuple", "", ",", " ", NameConstant, "", ")", "", ")", "", ")", "", ")"]
         )
 
     def test_yield_node(self):


### PR DESCRIPTION
# Description

Improve handling of empty tuple and handling of parentheses around tuple by patchedast. Previously, these cases would've caused MismatchedTokenError.

# Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
