### PR TITLE
Preserve newline format when writing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # **Upcoming release**
 
-...
+## Bug fixes
+
+- #134, #453 Preserve newline format when writing files 
 
 # Release 0.22.0
 

--- a/rope/base/change.py
+++ b/rope/base/change.py
@@ -330,7 +330,10 @@ class _ResourceOperations(object):
         return self.fscommands
 
     def write_file(self, resource, contents):
-        data = rope.base.fscommands.unicode_to_file_data(contents)
+        data = rope.base.fscommands.unicode_to_file_data(
+            contents,
+            newlines=resource.newlines,
+        )
         fscommands = self._get_fscommands(resource)
         fscommands.write(resource.real_path, data)
         for observer in list(self.project.observers):

--- a/rope/base/fscommands.py
+++ b/rope/base/fscommands.py
@@ -229,9 +229,14 @@ def unicode_to_file_data(contents, encoding=None):
 
 def file_data_to_unicode(data, encoding=None):
     result = _decode_data(data, encoding)
+    newline = "\n"
+    if "\r\n" in result:
+        result = result.replace("\r\n", "\n")
+        newline = "\r\n"
     if "\r" in result:
-        result = result.replace("\r\n", "\n").replace("\r", "\n")
-    return result
+        result = result.replace("\r", "\n")
+        newline = "\r"
+    return result, newline
 
 
 def _decode_data(data, encoding):

--- a/rope/base/fscommands.py
+++ b/rope/base/fscommands.py
@@ -214,7 +214,9 @@ def _execute(args, cwd=None):
     return process.returncode
 
 
-def unicode_to_file_data(contents, encoding=None):
+def unicode_to_file_data(contents, encoding=None, newlines=None):
+    if newlines and newlines != "\n":
+        contents = contents.replace("\n", newlines)
     if not isinstance(contents, unicode):
         return contents
     if encoding is None:

--- a/rope/base/fscommands.py
+++ b/rope/base/fscommands.py
@@ -215,10 +215,10 @@ def _execute(args, cwd=None):
 
 
 def unicode_to_file_data(contents, encoding=None, newlines=None):
-    if newlines and newlines != "\n":
-        contents = contents.replace("\n", newlines)
     if not isinstance(contents, unicode):
         return contents
+    if newlines and newlines != "\n":
+        contents = contents.replace("\n", newlines)
     if encoding is None:
         encoding = read_str_coding(contents)
     if encoding is not None:

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -199,7 +199,7 @@ class PyModule(pyobjects.PyModule):
         try:
             if source_code is None:
                 source_bytes = resource.read_bytes()
-                source_code = fscommands.file_data_to_unicode(source_bytes)
+                source_code, _ = fscommands.file_data_to_unicode(source_bytes)
             else:
                 if isinstance(source_code, unicode):
                     source_bytes = fscommands.unicode_to_file_data(source_code)

--- a/rope/base/resources.py
+++ b/rope/base/resources.py
@@ -105,8 +105,6 @@ class File(Resource):
     """Represents a file"""
 
     def __init__(self, project, name):
-        # from rope.base.project import Project
-        # self.project = Project()
         super(File, self).__init__(project, name)
 
     def read(self):

--- a/rope/base/resources.py
+++ b/rope/base/resources.py
@@ -105,12 +105,14 @@ class File(Resource):
     """Represents a file"""
 
     def __init__(self, project, name):
+        self.newlines = None
         super(File, self).__init__(project, name)
 
     def read(self):
         data = self.read_bytes()
         try:
-            return fscommands.file_data_to_unicode(data)
+            content, self.newlines = fscommands.file_data_to_unicode(data)
+            return content
         except UnicodeDecodeError as e:
             raise exceptions.ModuleDecodeError(self.path, e.reason)
 

--- a/ropetest/projecttest.py
+++ b/ropetest/projecttest.py
@@ -478,6 +478,19 @@ class ProjectTest(unittest.TestCase):
         sample_file.write("1\n")
         self.assertEqual(b"1\r", sample_file.read_bytes())
 
+    def test_file_binary(self):
+        sample_file = self.project.root.create_file("my_file.txt")
+        contents = b"1\r\n"
+        file = open(sample_file.real_path, "wb")
+        file.write(contents)
+        file.close()
+        self.assertIsNone(sample_file.newlines)
+        self.assertEqual(b"1\r\n", sample_file.read_bytes())
+        self.assertIsNone(sample_file.newlines)
+
+        sample_file.write(b"1\nx\r")
+        self.assertEqual((b"1\nx\r"), sample_file.read_bytes())
+
     # TODO: Detecting utf-16 encoding
     def xxx_test_using_utf16(self):
         sample_file = self.project.root.create_file("my_file.txt")

--- a/ropetest/projecttest.py
+++ b/ropetest/projecttest.py
@@ -439,7 +439,7 @@ class ProjectTest(unittest.TestCase):
         file.close()
         self.assertEqual(contents, sample_file.read_bytes())
 
-    def test_read_on_file_with_unix_line_ending(self):
+    def test_file_with_unix_line_ending(self):
         sample_file = self.project.root.create_file("my_file.txt")
         contents = b"1\n"
         file = open(sample_file.real_path, "wb")
@@ -449,7 +449,10 @@ class ProjectTest(unittest.TestCase):
         self.assertEqual("1\n", sample_file.read())
         self.assertEqual("\n", sample_file.newlines)
 
-    def test_read_on_file_with_dos_line_ending(self):
+        sample_file.write("1\n")
+        self.assertEqual(b"1\n", sample_file.read_bytes())
+
+    def test_file_with_dos_line_ending(self):
         sample_file = self.project.root.create_file("my_file.txt")
         contents = b"1\r\n"
         file = open(sample_file.real_path, "wb")
@@ -459,7 +462,10 @@ class ProjectTest(unittest.TestCase):
         self.assertEqual("1\n", sample_file.read())
         self.assertEqual("\r\n", sample_file.newlines)
 
-    def test_read_on_file_with_mac_line_ending(self):
+        sample_file.write("1\n")
+        self.assertEqual(b"1\r\n", sample_file.read_bytes())
+
+    def test_file_with_mac_line_ending(self):
         sample_file = self.project.root.create_file("my_file.txt")
         contents = b"1\r"
         file = open(sample_file.real_path, "wb")
@@ -468,6 +474,9 @@ class ProjectTest(unittest.TestCase):
         self.assertIsNone(sample_file.newlines)
         self.assertEqual("1\n", sample_file.read())
         self.assertEqual("\r", sample_file.newlines)
+
+        sample_file.write("1\n")
+        self.assertEqual(b"1\r", sample_file.read_bytes())
 
     # TODO: Detecting utf-16 encoding
     def xxx_test_using_utf16(self):

--- a/ropetest/projecttest.py
+++ b/ropetest/projecttest.py
@@ -439,6 +439,36 @@ class ProjectTest(unittest.TestCase):
         file.close()
         self.assertEqual(contents, sample_file.read_bytes())
 
+    def test_read_on_file_with_unix_line_ending(self):
+        sample_file = self.project.root.create_file("my_file.txt")
+        contents = b"1\n"
+        file = open(sample_file.real_path, "wb")
+        file.write(contents)
+        file.close()
+        self.assertIsNone(sample_file.newlines)
+        self.assertEqual("1\n", sample_file.read())
+        self.assertEqual("\n", sample_file.newlines)
+
+    def test_read_on_file_with_dos_line_ending(self):
+        sample_file = self.project.root.create_file("my_file.txt")
+        contents = b"1\r\n"
+        file = open(sample_file.real_path, "wb")
+        file.write(contents)
+        file.close()
+        self.assertIsNone(sample_file.newlines)
+        self.assertEqual("1\n", sample_file.read())
+        self.assertEqual("\r\n", sample_file.newlines)
+
+    def test_read_on_file_with_mac_line_ending(self):
+        sample_file = self.project.root.create_file("my_file.txt")
+        contents = b"1\r"
+        file = open(sample_file.real_path, "wb")
+        file.write(contents)
+        file.close()
+        self.assertIsNone(sample_file.newlines)
+        self.assertEqual("1\n", sample_file.read())
+        self.assertEqual("\r", sample_file.newlines)
+
     # TODO: Detecting utf-16 encoding
     def xxx_test_using_utf16(self):
         sample_file = self.project.root.create_file("my_file.txt")


### PR DESCRIPTION
# Description

If a file is not using local line ending, then we write it back into the same line ending format.

Fixes #134

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md