### PR TITLE
Fix extract info collection for list comprehension with multiple targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## Bug fixes
 
 - #134, #453 Preserve newline format when writing files  (@lieryan)
+- #457 Fix extract info collection for list comprehension with multiple targets
+  (@lieryan)
 
 
 # Release 0.22.0

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -887,7 +887,7 @@ class _FunctionInformationCollector(object):
         elif isinstance(node, ast.Name):
             yield node.id
         else:
-            assert False, f"Unexpected node type in list comprehension target: {node}"
+            assert False, "Unexpected node type in list comprehension target: %s" % node
 
     def _If(self, node):
         self._handle_conditional_node(node)

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1942,6 +1942,26 @@ class ExtractMethodTest(unittest.TestCase):
         """)
         self.assertEqual(expected, refactored)
 
+    def test_extract_method_with_list_comprehension_multiple_targets(self):
+        code = dedent("""\
+            def foo():
+                x = [(a, b) for a, b in []]
+                f = 23
+                print("hello")
+        """)
+        start, end = self._convert_line_range_to_offset(code, 4, 4)
+        refactored = self.do_extract_method(code, start, end, "baz")
+        expected = dedent("""\
+            def foo():
+                x = [(a, b) for a, b in []]
+                f = 23
+                baz()
+
+            def baz():
+                print("hello")
+        """)
+        self.assertEqual(expected, refactored)
+
     def test_extract_function_with_for_else_statemant(self):
         code = dedent("""\
             def a_func():


### PR DESCRIPTION
# Description

Fix an error when extracting a method containing list comprehension with multiple targets:

```python
mylist = [(a, b) for a, b in lst]
```

produces an error:

```
AttributeError: 'Tuple' object has no attribute 'id'
```


# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md