### PR TITLE
Improve the heuristic for joining lines when extracting one line expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Syntax support
 
 - #451, $456 Implement structural pattern matching (PEP634) (@lieryan)
+- #458 Improve the heuristic for joining lines when extracting one line
+  expression (@lieryan)
 
 ## Bug fixes
 

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -750,7 +750,7 @@ class _ExtractVariableParts(object):
         self.info = info
 
     def get_definition(self):
-        result = self.info.new_name + " = " + _join_lines(self.info.extracted) + "\n"
+        result = self.info.new_name + " = " + _get_single_expression_body(self.info.extracted, info=self.info) + "\n"
         return result
 
     def get_body_pattern(self):

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -721,7 +721,8 @@ class _ExtractMethodParts(object):
         return unindented_body
 
     def _get_single_expression_function_body(self):
-        body = "return " + _get_single_expression_body(self.info.extracted, info=self.info)
+        extracted = _get_single_expression_body(self.info.extracted, info=self.info)
+        body = "return " + extracted
         return self._insert_globals(body)
 
     def _insert_globals(self, unindented_body):
@@ -750,7 +751,8 @@ class _ExtractVariableParts(object):
         self.info = info
 
     def get_definition(self):
-        result = self.info.new_name + " = " + _get_single_expression_body(self.info.extracted, info=self.info) + "\n"
+        extracted = _get_single_expression_body(self.info.extracted, info=self.info)
+        result = self.info.new_name + " = " + extracted + "\n"
         return result
 
     def get_body_pattern(self):
@@ -1090,7 +1092,9 @@ def _join_lines(code):
 
 def _get_single_expression_body(extracted, info):
     extracted = sourceutils.fix_indentation(extracted, 0)
-    already_parenthesized = extracted.lstrip()[0] in "({[" and extracted.rstrip()[-1] in ")}]"
+    already_parenthesized = (
+        extracted.lstrip()[0] in "({[" and extracted.rstrip()[-1] in ")}]"
+    )
     large_multiline = extracted.count("\n") >= 2 and already_parenthesized
     if not large_multiline:
         extracted = _join_lines(extracted)

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -721,10 +721,12 @@ class _ExtractMethodParts(object):
         return unindented_body
 
     def _get_one_line_function_body(self):
-        if self.info.returning_named_expr:
-            body = "return " + "(" + _join_lines(self.info.extracted) + ")"
+        extracted = sourceutils.fix_indentation(self.info.extracted, 0)
+        multiline_expression = "\n" in extracted
+        if self.info.returning_named_expr or multiline_expression:
+            body = "return " + "(" + extracted + ")"
         else:
-            body = "return " + _join_lines(self.info.extracted)
+            body = "return " + extracted
         return self._insert_globals(body)
 
     def _insert_globals(self, unindented_body):

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -722,8 +722,12 @@ class _ExtractMethodParts(object):
 
     def _get_one_line_function_body(self):
         extracted = sourceutils.fix_indentation(self.info.extracted, 0)
+        already_parenthesized = extracted.lstrip()[0] in "({[" and extracted.rstrip()[-1] in ")}]"
+        large_multiline = extracted.count("\n") >= 2 and already_parenthesized
+        if not large_multiline:
+            extracted = _join_lines(extracted)
         multiline_expression = "\n" in extracted
-        if self.info.returning_named_expr or multiline_expression:
+        if self.info.returning_named_expr or (multiline_expression and not large_multiline):
             body = "return " + "(" + extracted + ")"
         else:
             body = "return " + extracted

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -501,20 +501,7 @@ class _ExceptionalConditionChecker(object):
         return next.isalnum() or next == "_"
 
 
-class _ExtractParts(object):
-    def _get_single_expression_body(self, extracted):
-        extracted = sourceutils.fix_indentation(extracted, 0)
-        already_parenthesized = extracted.lstrip()[0] in "({[" and extracted.rstrip()[-1] in ")}]"
-        large_multiline = extracted.count("\n") >= 2 and already_parenthesized
-        if not large_multiline:
-            extracted = _join_lines(extracted)
-        multiline_expression = "\n" in extracted
-        if self.info.returning_named_expr or (multiline_expression and not large_multiline):
-            extracted = "(" + extracted + ")"
-        return extracted
-
-
-class _ExtractMethodParts(_ExtractParts):
+class _ExtractMethodParts(object):
     def __init__(self, info):
         self.info = info
         self.info_collector = self._create_info_collector()
@@ -734,7 +721,7 @@ class _ExtractMethodParts(_ExtractParts):
         return unindented_body
 
     def _get_single_expression_function_body(self):
-        body = "return " + self._get_single_expression_body(self.info.extracted)
+        body = "return " + _get_single_expression_body(self.info.extracted, info=self.info)
         return self._insert_globals(body)
 
     def _insert_globals(self, unindented_body):
@@ -1099,3 +1086,15 @@ def _join_lines(code):
         else:
             lines.append(line.strip())
     return " ".join(lines)
+
+
+def _get_single_expression_body(extracted, info):
+    extracted = sourceutils.fix_indentation(extracted, 0)
+    already_parenthesized = extracted.lstrip()[0] in "({[" and extracted.rstrip()[-1] in ")}]"
+    large_multiline = extracted.count("\n") >= 2 and already_parenthesized
+    if not large_multiline:
+        extracted = _join_lines(extracted)
+    multiline_expression = "\n" in extracted
+    if info.returning_named_expr or (multiline_expression and not large_multiline):
+        extracted = "(" + extracted + ")"
+    return extracted

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -584,7 +584,8 @@ class ExtractMethodTest(unittest.TestCase):
         expected = dedent("""\
 
             def new_func():
-                return 10 + 20
+                return (10 +\\
+                    20)
 
             a_var = new_func()
         """)
@@ -601,7 +602,8 @@ class ExtractMethodTest(unittest.TestCase):
         expected = dedent("""\
 
             def new_func():
-                return (10, 20)
+                return ((10,\\
+                    20))
 
             a_var = new_func()
         """)
@@ -1796,7 +1798,8 @@ class ExtractMethodTest(unittest.TestCase):
         expected = dedent("""\
 
             def f():
-                return "1" "2"
+                return ("1"
+                  "2")
 
             s = (f())
         """)

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -584,8 +584,7 @@ class ExtractMethodTest(unittest.TestCase):
         expected = dedent("""\
 
             def new_func():
-                return (10 +\\
-                    20)
+                return 10 + 20
 
             a_var = new_func()
         """)
@@ -602,10 +601,37 @@ class ExtractMethodTest(unittest.TestCase):
         expected = dedent("""\
 
             def new_func():
-                return ((10,\\
-                    20))
+                return (10, 20)
 
             a_var = new_func()
+        """)
+        self.assertEqual(expected, refactored)
+
+    def test_single_line_extract_method_with_large_multiline_expression(self):
+        code = dedent("""\
+            a_var = func(
+                {
+                    "hello": 1,
+                    "world": 2,
+                },
+                blah=foo,
+            )
+        """)
+        start = code.index("{") - 1
+        end = code.index("}") + 1
+        refactored = self.do_extract_method(code, start, end, "new_func")
+        expected = dedent("""\
+
+            def new_func():
+                return {
+                    "hello": 1,
+                    "world": 2,
+                }
+
+            a_var = func(
+                new_func(),
+                blah=foo,
+            )
         """)
         self.assertEqual(expected, refactored)
 
@@ -1798,8 +1824,7 @@ class ExtractMethodTest(unittest.TestCase):
         expected = dedent("""\
 
             def f():
-                return ("1"
-                  "2")
+                return "1" "2"
 
             s = (f())
         """)


### PR DESCRIPTION
# Description

Previously, we always join lines when extracting one-line expression, this leads to absurdly long lines when extracting large expressions, like dictionary definitions. With this PR, we improve the heuristic so larger multiline expressions can stay multiline after extraction while smaller expressions are joined together.

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md