### PR TITLE
fix(extract-method): Extracts method when list comprehension within method's scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ## New feature
 - #464 Improve autoimport code to use a sqllite3 database, cache all available modules quickly, search for names and produce import statements, sort import statements.
 
+## Bug fixes
+
+- #461 Fix bug while extracting method with list comprehension in class method (@dryobates)
+
 # Release 1.0.0
 
 Date: 2022-04-08

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -133,6 +133,9 @@ class PyComprehension(pyobjects.PyComprehension):
             self.pycore, self, _ComprehensionVisitor
         )
 
+    def get_kind(self):
+        return "Comprehension"
+
 
 class PyClass(pyobjects.PyClass):
     def __init__(self, pycore, ast_node, parent):

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1942,6 +1942,26 @@ class ExtractMethodTest(unittest.TestCase):
         """)
         self.assertEqual(expected, refactored)
 
+    def test_extract_method_with_list_comprehension_in_class_method(self):
+        code = dedent("""\
+            class SomeClass:
+                def method(self):
+                    result = [i for i in range(1)]
+                    print(1)
+        """)
+        start, end = self._convert_line_range_to_offset(code, 4, 4)
+        refactored = self.do_extract_method(code, start, end, "baz", similar=True)
+        expected = dedent("""\
+            class SomeClass:
+                def method(self):
+                    result = [i for i in range(1)]
+                    self.baz()
+
+                def baz(self):
+                    print(1)
+        """)
+        self.assertEqual(expected, refactored)
+
     def test_extract_method_with_list_comprehension_and_iter(self):
         code = dedent("""\
             def foo():


### PR DESCRIPTION
Fixed extracting method from class method when there is list comprehension inside method.

# Description

Fixes #461

# Checklist (delete if not relevant):

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated CHANGELOG.md
