### PR TITLE
Rename AutoImport.rope_project back to AutoImport.project

### DIFF
--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -192,7 +192,7 @@ class AutoImport:
         self, name: str, exact_match: bool = False
     ) -> Generator[SearchResult, None, None]:
         """
-        Search both names for avalible imports.
+        Search both names for available imports.
 
         Returns the import statement, import name, source, and type.
         """
@@ -214,7 +214,7 @@ class AutoImport:
         self, name: str, exact_match: bool = False
     ) -> Generator[SearchResult, None, None]:
         """
-        Search both modules for avalible imports.
+        Search both modules for available imports.
 
         Returns the import statement, import name, source, and type.
         """
@@ -306,7 +306,7 @@ class AutoImport:
         """
         Generate global name cache for external modules listed in `modules`.
 
-        If no modules are provided, it will generate a cache for every module avalible.
+        If no modules are provided, it will generate a cache for every module available.
         This method searches in your sys.path and configured python folders.
         Do not use this for generating your own project's internal names,
         use generate_resource_cache for that instead.


### PR DESCRIPTION
# Description

The change in 89341d4742ac2414051fd671acad8ad48eb9ccf6 broke backward compatibility because it changed what `AutoImport.project` refers to. It was a rope Project but that commit changed it into an autoimport Package.

This PR puts the `.project` back to where it was originally.