### PR TITLE
Fix windows

### DIFF
--- a/rope/base/utils/pycompat.py
+++ b/rope/base/utils/pycompat.py
@@ -34,7 +34,6 @@ except NameError:  # PY3
     def get_ast_with_items(node):
         return node.items
 
-
 else:  # PY2
 
     string_types = (basestring,)

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -441,7 +441,7 @@ class AutoImport:
                 and folder.exists()
             )
 
-        folders = reversed(self.project.get_python_path_folders())
+        folders = self.project.get_python_path_folders()
         folder_paths = map(lambda folder: pathlib.Path(folder.real_path), folders)
         folder_paths = filter(filter_folders, folder_paths)
         return list(OrderedDict.fromkeys(folder_paths))

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -11,13 +11,23 @@ from typing import Generator, Iterable, List, Optional, Set, Tuple
 from rope.base import exceptions, libutils, resourceobserver, taskhandle
 from rope.base.project import Project
 from rope.base.resources import Resource
-from rope.contrib.autoimport.defs import (ModuleFile, Name, NameType, Package,
-                                          PackageType, SearchResult, Source)
+from rope.contrib.autoimport.defs import (
+    ModuleFile,
+    Name,
+    NameType,
+    Package,
+    PackageType,
+    SearchResult,
+    Source,
+)
 from rope.contrib.autoimport.parse import get_names
-from rope.contrib.autoimport.utils import (get_files, get_modname_from_path,
-                                           get_package_tuple,
-                                           sort_and_deduplicate,
-                                           sort_and_deduplicate_tuple)
+from rope.contrib.autoimport.utils import (
+    get_files,
+    get_modname_from_path,
+    get_package_tuple,
+    sort_and_deduplicate,
+    sort_and_deduplicate_tuple,
+)
 from rope.refactor import importutils
 
 

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -435,10 +435,7 @@ class AutoImport:
 
     def _get_python_folders(self) -> List[pathlib.Path]:
         def filter_folders(folder: pathlib.Path) -> bool:
-            return (
-                folder.is_dir()
-                and folder.as_posix() != "/usr/bin"
-            )
+            return folder.is_dir() and folder.as_posix() != "/usr/bin"
 
         folders = self.project.get_python_path_folders()
         folder_paths = map(lambda folder: pathlib.Path(folder.real_path), folders)

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -436,9 +436,8 @@ class AutoImport:
     def _get_python_folders(self) -> List[pathlib.Path]:
         def filter_folders(folder: pathlib.Path) -> bool:
             return (
-                folder.as_posix() != "/usr/bin"
-                and not folder.is_file()
-                and folder.exists()
+                folder.is_dir()
+                and folder.as_posix() != "/usr/bin"
             )
 
         folders = self.project.get_python_path_folders()


### PR DESCRIPTION
# Description

On windows, the python sys.path includes random files. I do not have windows and 100% of development is on linux but it failed on pylsp's CI. I filtered out files from the search, but cannot easily test this code. I am also unsure of why files are included in sys.path on windows. 

## Fixes 

autoimport on windows.
