### PR TITLE
introduce task handle base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # **Upcoming release**
 
 
+# Improvement
+
+- #479 Add ABC and type hints for TaskHandle and JobSet (@bageljrkhanofemus)
+
 # Release 1.1.1
 
 ## Bug fixes

--- a/rope/base/taskhandle.py
+++ b/rope/base/taskhandle.py
@@ -6,7 +6,7 @@ from rope.base import exceptions
 
 class BaseJobSet(ABC):
     @abstractmethod
-    def started_job(self, name: Optional[str]) -> None:
+    def started_job(self, name: str) -> None:
         pass
 
     @abstractmethod

--- a/rope/base/taskhandle.py
+++ b/rope/base/taskhandle.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from typing import Optional, Sequence
 
@@ -7,10 +5,6 @@ from rope.base import exceptions
 
 
 class BaseJobSet(ABC):
-    @abstractmethod
-    def __init__(self, handle: BaseTaskHandle, name: str, count: int):
-        pass
-
     @abstractmethod
     def started_job(self, name: Optional[str]) -> None:
         pass
@@ -36,7 +30,7 @@ class BaseJobSet(ABC):
         pass
 
     @abstractmethod
-    def increment(self) -> int:
+    def increment(self) -> None:
         """
         Increment the number of tasks to complete.
 
@@ -46,10 +40,6 @@ class BaseJobSet(ABC):
 
 
 class BaseTaskHandle(ABC):
-    @abstractmethod
-    def __init__(self, name: str = "Task", interrupts: bool = True):
-        pass
-
     @abstractmethod
     def stop(self) -> None:
         pass

--- a/rope/base/taskhandle.py
+++ b/rope/base/taskhandle.py
@@ -1,7 +1,85 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional, Sequence
+
 from rope.base import exceptions
 
 
-class TaskHandle:
+class BaseJobSet(ABC):
+    @abstractmethod
+    def __init__(self, handle: BaseTaskHandle, name: str, count: int):
+        pass
+
+    @abstractmethod
+    def started_job(self, name: Optional[str]) -> None:
+        pass
+
+    @abstractmethod
+    def finished_job(self) -> None:
+        pass
+
+    @abstractmethod
+    def check_status(self) -> None:
+        pass
+
+    @abstractmethod
+    def get_active_job_name(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_percent_done(self) -> Optional[float]:
+        pass
+
+    @abstractmethod
+    def get_name(self) -> str:
+        pass
+
+    @abstractmethod
+    def increment(self) -> int:
+        """
+        Increment the number of tasks to complete.
+
+        This is used if the number is not known ahead of time.
+        """
+        pass
+
+
+class BaseTaskHandle(ABC):
+    @abstractmethod
+    def __init__(self, name: str = "Task", interrupts: bool = True):
+        pass
+
+    @abstractmethod
+    def stop(self) -> None:
+        pass
+
+    @abstractmethod
+    def current_jobset(self) -> Optional[BaseJobSet]:
+        pass
+
+    @abstractmethod
+    def add_observer(self) -> None:
+        pass
+
+    @abstractmethod
+    def is_stopped(self) -> bool:
+        pass
+
+    @abstractmethod
+    def get_jobsets(self) -> Sequence[BaseJobSet]:
+        pass
+
+    def create_jobset(
+        self, name: str = "JobSet", count: Optional[int] = None
+    ) -> BaseJobSet:
+        pass
+
+    def _inform_observers(self) -> None:
+        pass
+
+
+class TaskHandle(BaseTaskHandle):
     def __init__(self, name="Task", interrupts=True):
         """Construct a TaskHandle
 
@@ -52,7 +130,7 @@ class TaskHandle:
             observer()
 
 
-class JobSet:
+class JobSet(BaseJobSet):
     def __init__(self, handle, name, count):
         self.handle = handle
         self.name = name
@@ -86,8 +164,11 @@ class JobSet:
     def get_name(self):
         return self.name
 
+    def increment(self):
+        self.count += 1
 
-class NullTaskHandle:
+
+class NullTaskHandle(BaseTaskHandle):
     def __init__(self):
         pass
 
@@ -106,8 +187,15 @@ class NullTaskHandle:
     def add_observer(self, observer):
         pass
 
+    def current_jobset(self) -> None:
+        """Return the current `JobSet`"""
+        return None
 
-class NullJobSet:
+
+class NullJobSet(BaseJobSet):
+    def __init__(self, *args):
+        pass
+
     def started_job(self, name):
         pass
 
@@ -124,4 +212,7 @@ class NullJobSet:
         pass
 
     def get_name(self):
+        pass
+
+    def increment(self):
         pass

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -32,15 +32,14 @@ from rope.refactor import importutils
 
 
 def get_future_names(
-    packages: List[Package], underlined: bool, job_set: taskhandle.JobSet
+    packages: List[Package], underlined: bool, job_set: taskhandle.BaseJobSet
 ) -> Generator[Future, None, None]:
     """Get all names as futures."""
     with ProcessPoolExecutor() as executor:
         for package in packages:
             for module in get_files(package, underlined):
                 job_set.started_job(module.modname)
-                if not isinstance(job_set, taskhandle.NullJobSet):
-                    job_set.count += 1
+                job_set.increment()
                 yield executor.submit(get_names, module, package)
 
 
@@ -269,7 +268,7 @@ class AutoImport:
         self,
         resources: List[Resource] = None,
         underlined: bool = False,
-        task_handle=taskhandle.NullTaskHandle(),
+        task_handle: taskhandle.BaseTaskHandle = taskhandle.NullTaskHandle(),
     ):
         """Generate global name cache for project files.
 
@@ -299,7 +298,7 @@ class AutoImport:
     def generate_modules_cache(
         self,
         modules: List[str] = None,
-        task_handle=taskhandle.NullTaskHandle(),
+        task_handle: taskhandle.BaseTaskHandle = taskhandle.NullTaskHandle(),
         single_thread: bool = False,
         underlined: bool = False,
     ):


### PR DESCRIPTION
# Description

Introduces a base task handle (and job set) class. I noticed that NullTaskHandle and TaskHandle did not provide identical APIs so I used ABC base classes to do so. I also created a method to increment the count of a job set for autoimport and used that.
This will break any jobsets which didn't match the TaskHandle API.
Since the increment method is abstract, it will break jobsets without it as well. I can make it non-abstract but that seems like bad practice.

# Checklist (delete if not relevant):

- [x] I have updated CHANGELOG.md
