### PR TITLE
add default values for name/job_name properties

### DIFF
--- a/rope/base/taskhandle.py
+++ b/rope/base/taskhandle.py
@@ -5,8 +5,8 @@ from rope.base import utils, exceptions
 
 
 class BaseJobSet(ABC):
-    name: str
-    job_name: str
+    name: str = ""
+    job_name: str = ""
 
     @abstractmethod
     def started_job(self, name: str) -> None:


### PR DESCRIPTION
# Description

Prevents issues where name or job_name isn't defined such as null task handle

Can probably count as part of the task_handle ABC class.
