### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -683,7 +683,7 @@ Organize imports sorts imports, too.  It does that according to
 Handling Long Imports
 ---------------------
 
-``Handle long imports`` command trys to make long imports look better by
+``Handle long imports`` command tries to make long imports look better by
 transforming ``import pkg1.pkg2.pkg3.pkg4.mod1`` to ``from
 pkg1.pkg2.pkg3.pkg4 import mod1``.  Long imports can be identified
 either by having lots of dots or being very long.  The default

--- a/rope/base/builtins.py
+++ b/rope/base/builtins.py
@@ -1,4 +1,4 @@
-"""This module trys to support builtin types and functions."""
+"""This module tries to support builtin types and functions."""
 import inspect
 import io
 

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -140,7 +140,7 @@ class AutoImport:
         ).fetchall()
         return sort_and_deduplicate_tuple(
             results
-        )  # Remove duplicates from multiple occurences of the same item
+        )  # Remove duplicates from multiple occurrences of the same item
 
     def search(self, name: str, exact_match: bool = False) -> List[Tuple[str, str]]:
         """

--- a/rope/refactor/change_signature.py
+++ b/rope/refactor/change_signature.py
@@ -154,7 +154,7 @@ class ChangeSignature:
         """Get changes caused by this refactoring
 
         `changers` is a list of `_ArgumentChanger`.  If `in_hierarchy`
-        is `True` the changers are applyed to all matching methods in
+        is `True` the changers are applied to all matching methods in
         the class hierarchy.
         `resources` can be a list of `rope.base.resource.File` that
         should be searched for occurrences; if `None` all python files

--- a/rope/refactor/occurrences.py
+++ b/rope/refactor/occurrences.py
@@ -18,7 +18,7 @@ calling the `create_finder()` function.
   * `imports`: If False, don't return instances that are in import
     statements.
 
-  * `unsure`: If a prediate function, return instances where we don't
+  * `unsure`: If a predicate function, return instances where we don't
     know what the name references. It also filters based on the
     predicate function.
 

--- a/ropetest/codeanalyzetest.py
+++ b/ropetest/codeanalyzetest.py
@@ -346,7 +346,7 @@ class WordRangeFinderTest(unittest.TestCase):
         result = self._find_primary(code, len(code) - 1)
         self.assertEqual("(4 + 1).x", result)
 
-    # XXX: cancatenated string literals
+    # XXX: concatenated string literals
     def xxx_test_getting_primary_cancatenating_strs(self):
         code = 's = "a"\n"b" "c"\n'
         result = self._find_primary(code, len(code) - 2)


### PR DESCRIPTION
There are small typos in:
- docs/overview.rst
- rope/base/builtins.py
- rope/contrib/autoimport/sqlite.py
- rope/refactor/change_signature.py
- rope/refactor/occurrences.py
- ropetest/codeanalyzetest.py

Fixes:
- Should read `tries` rather than `trys`.
- Should read `predicate` rather than `prediate`.
- Should read `occurrences` rather than `occurences`.
- Should read `concatenated` rather than `cancatenated`.
- Should read `applied` rather than `applyed`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md