### PR TITLE
Fix #18. Identify AbstractFunction parameters as ParameterName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ## Bug fixes
 
-- #506,#507 Fix extracting generator without parens
-- #411,#505 Fix extracting generator without parens
+- #506, #507 Fix issue with parsing function call args list
+- #411, #505 Fix extracting generator without parens
+- #18, #510 When the function is a builtin function, the call parameter's name was sometimes incorrectly identified as an AssignedName. This led to rename refactoring incorrectly renaming these parameters.
 
 # Release 1.3.0
 
 ## Bug fixes
 
-- #496,#497 Add MatMul operator to patchedast
+- #496, #497 Add MatMul operator to patchedast
 - #495 Fix autoimport collection for compiled modules
 
 ## Improvement

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -1,10 +1,18 @@
 from operator import itemgetter
+from typing import Optional
 
 import rope.base.builtins
 import rope.base.pynames
 import rope.base.pyobjects
-from rope.base import ast, astutils, exceptions, pyobjects, arguments, worder
-from rope.base.utils import pycompat
+from rope.base import (
+    ast,
+    astutils,
+    exceptions,
+    pyobjects,
+    pyobjectsdef,
+    arguments,
+    worder,
+)
 
 
 BadIdentifierError = exceptions.BadIdentifierError
@@ -80,15 +88,25 @@ class ScopeNameFinder:
     def get_pyname_at(self, offset):
         return self.get_primary_and_pyname_at(offset)[1]
 
-    def get_primary_and_pyname_at(self, offset):
+    def get_primary_and_pyname_at(
+        self,
+        offset: int,
+    ) -> tuple[
+        Optional[rope.base.pynames.PyName],
+        Optional[rope.base.pynames.PyName],
+    ]:
         lineno = self.lines.get_line_number(offset)
         holding_scope = self.module_scope.get_inner_scope_for_offset(offset)
         # function keyword parameter
         if self.worder.is_function_keyword_parameter(offset):
             keyword_name = self.worder.get_word_at(offset)
             pyobject = self.get_enclosing_function(offset)
-            if isinstance(pyobject, pyobjects.PyFunction):
-                return (None, pyobject.get_parameters().get(keyword_name, None))
+            if isinstance(pyobject, pyobjectsdef.PyFunction):
+                parameter_name = pyobject.get_parameters().get(keyword_name, None)
+                return (None, parameter_name)
+            elif isinstance(pyobject, pyobjects.AbstractFunction):
+                parameter_name = rope.base.pynames.ParameterName()
+                return (None, parameter_name)
         # class body
         if self._is_defined_in_class_body(holding_scope, offset, lineno):
             class_scope = holding_scope

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -1,5 +1,5 @@
 from operator import itemgetter
-from typing import Optional
+from typing import Optional, Tuple
 
 import rope.base.builtins
 import rope.base.pynames
@@ -91,7 +91,7 @@ class ScopeNameFinder:
     def get_primary_and_pyname_at(
         self,
         offset: int,
-    ) -> tuple[
+    ) -> Tuple[
         Optional[rope.base.pynames.PyName],
         Optional[rope.base.pynames.PyName],
     ]:

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -91,10 +91,7 @@ class ScopeNameFinder:
     def get_primary_and_pyname_at(
         self,
         offset: int,
-    ) -> Tuple[
-        Optional[rope.base.pynames.PyName],
-        Optional[rope.base.pynames.PyName],
-    ]:
+    ) -> Tuple[Optional[rope.base.pynames.PyName], Optional[rope.base.pynames.PyName]]:
         lineno = self.lines.get_line_number(offset)
         holding_scope = self.module_scope.get_inner_scope_for_offset(offset)
         # function keyword parameter

--- a/rope/base/oi/type_hinting/utils.py
+++ b/rope/base/oi/type_hinting/utils.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     pass
 import rope.base.utils as base_utils
-from rope.base.evaluate import ScopeNameFinder
+from rope.base import evaluate
 from rope.base.exceptions import AttributeNotFoundError
 from rope.base.pyobjects import PyClass, PyDefinedObject, PyFunction, PyObject
 from rope.base.utils import pycompat
@@ -95,7 +95,7 @@ def resolve_type(type_name, pyobject):
     else:
         mod_name, attr_name = type_name.rsplit(".", 1)
         try:
-            mod_finder = ScopeNameFinder(pyobject.get_module())
+            mod_finder = evaluate.ScopeNameFinder(pyobject.get_module())
             mod = mod_finder._find_module(mod_name).get_object()
             ret_type = mod.get_attribute(attr_name).get_object()
         except AttributeNotFoundError:

--- a/rope/base/pycore.py
+++ b/rope/base/pycore.py
@@ -253,9 +253,17 @@ class _ModuleCache:
         if resource in self.module_map:
             return self.module_map[resource]
         if resource.is_folder():
-            result = pyobjectsdef.PyPackage(self.pycore, resource, force_errors=force_errors)
+            result = pyobjectsdef.PyPackage(
+                self.pycore,
+                resource,
+                force_errors=force_errors,
+            )
         else:
-            result = pyobjectsdef.PyModule(self.pycore, resource=resource, force_errors=force_errors)
+            result = pyobjectsdef.PyModule(
+                self.pycore,
+                resource=resource,
+                force_errors=force_errors,
+            )
             if result.has_errors:
                 return result
         self.module_map[resource] = result

--- a/rope/base/pycore.py
+++ b/rope/base/pycore.py
@@ -11,11 +11,11 @@ import rope.base.oi.objectinfo
 import rope.base.oi.soa
 from rope.base import builtins
 from rope.base import exceptions
+from rope.base import pyobjectsdef
 from rope.base import stdmods
 from rope.base import taskhandle
 from rope.base import utils
 from rope.base.exceptions import ModuleNotFoundError
-from rope.base.pyobjectsdef import PyModule, PyPackage
 
 
 class PyCore:
@@ -100,7 +100,7 @@ class PyCore:
         ``ignore_syntax_errors`` project config.
 
         """
-        return PyModule(self, code, resource, force_errors=force_errors)
+        return pyobjectsdef.PyModule(self, code, resource, force_errors=force_errors)
 
     @utils.deprecated("Use `libutils.get_string_scope` instead")
     def get_string_scope(self, code, resource=None):
@@ -253,9 +253,9 @@ class _ModuleCache:
         if resource in self.module_map:
             return self.module_map[resource]
         if resource.is_folder():
-            result = PyPackage(self.pycore, resource, force_errors=force_errors)
+            result = pyobjectsdef.PyPackage(self.pycore, resource, force_errors=force_errors)
         else:
-            result = PyModule(self.pycore, resource=resource, force_errors=force_errors)
+            result = pyobjectsdef.PyModule(self.pycore, resource=resource, force_errors=force_errors)
             if result.has_errors:
                 return result
         self.module_map[resource] = result

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -35,6 +35,21 @@ class RenameRefactoringTest(unittest.TestCase):
         changes = Rename(self.project, resource, offset).get_changes(new_name, **kwds)
         self.project.do(changes)
 
+    def test_local_variable_but_not_parameter(self):
+        code = dedent("""\
+            a = 10
+            foo = dict(a=a)
+        """)
+
+        refactored = self._local_rename(code, 1, "new_a")
+        self.assertEqual(
+            dedent("""\
+                new_a = 10
+                foo = dict(a=new_a)
+            """),
+            refactored,
+        )
+
     def test_simple_global_variable_renaming(self):
         refactored = self._local_rename("a_var = 20\n", 2, "new_var")
         self.assertEqual("new_var = 20\n", refactored)


### PR DESCRIPTION
# Description

When the function is a builtin function, the call parameter's name was sometimes incorrectly identified as an AssignedName. This led to rename refactoring incorrectly renaming these parameters.

Fixes #18 

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md