### PR TITLE
Autoimport autodetection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # **Upcoming release**
-
+- #516 Autoimport Now automatically detects project dependencies and can read TOML configuration
 - #733 skip directories with perm error when building autoimport index (@MrBago)
 - #722, #723 Remove site-packages from packages search tree (@tkrabel)
 - #738 Implement os.PathLike on Resource (@lieryan)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -53,15 +53,15 @@ Additionally, you can run an executable function at startup of rope.
 pytool.toml
 -----------
 If neither a config.py or a pyproject.toml is present, rope will use a pytool.toml.
-It follows the exact same syntax of the pyproject.toml.
+It follows the exact same syntax as ``pyproject.toml``.
 
-- Mac OS X: ``~/Library/Application Support/pytool.toml.``
+- Mac OS X: ``~/Library/Application Support/pytool.toml``.
 - Unix: ``~/.config/pytool.toml``` or in $XDG_CONFIG_HOME, if defined
 - Windows: ``C:\Users\<username>\AppData\Local\pytool.toml``
 
 
 Options
-=======
+-------
 .. autopytoolconfigtable:: rope.base.prefs.Prefs
 
 Autoimport Options

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -14,12 +14,11 @@ Will be used if [tool.rope] is configured.
 
     [tool.rope]
     split_imports = true
-    [tool.rope.autoimport]
-    underlined = false
     autoimport.aliases = [
         ['dt', 'datetime'],
         ['mp', 'multiprocessing'],
     ]
+    autoimport.underlined = false
 
 config.py
 ---------
@@ -54,9 +53,9 @@ Additionally, you can run an executable function at startup of rope.
 pytool.toml
 -----------
 If neither a config.py or a pyproject.toml is present, rope will use a pytool.toml.
-It follows the exact same syntax as ``pyproject.toml``.
+It follows the exact same syntax of the pyproject.toml.
 
-- Mac OS X: ``~/Library/Application Support/pytool.toml``.
+- Mac OS X: ``~/Library/Application Support/pytool.toml.``
 - Unix: ``~/.config/pytool.toml``` or in $XDG_CONFIG_HOME, if defined
 - Windows: ``C:\Users\<username>\AppData\Local\pytool.toml``
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -14,6 +14,8 @@ Will be used if [tool.rope] is configured.
 
     [tool.rope]
     split_imports = true
+    [tool.rope.autoimport]
+    underlined = false
 
 config.py
 ---------
@@ -56,8 +58,13 @@ It follows the exact same syntax of the pyproject.toml.
 
 
 Options
--------
+=======
 .. autopytoolconfigtable:: rope.base.prefs.Prefs
+
+Autoimport Options
+------------------
+.. autopytoolconfigtable:: rope.base.prefs.AutoimportPrefs
+
 
 Old Configuration File
 ----------------------

--- a/rope/base/prefs.py
+++ b/rope/base/prefs.py
@@ -15,10 +15,10 @@ from rope.base.resources import Folder
 @dataclass
 class AutoimportPrefs:
     underlined: bool = field(
-        default=False, description="Cache underlined (private) modules"
-    )
+        default=False, description="Cache underlined (private) modules")
     # memory: bool = field(default=None, description="Cache in memory instead of disk")
     # parallel: bool = field(default=True, description="Use multiple processes to parse")
+
     aliases: List[Tuple[str, str]] = field(
         default_factory=lambda: [
             ("np", "numpy"),
@@ -29,12 +29,10 @@ class AutoimportPrefs:
             ("sk", "sklearn"),
             ("sm", "statsmodels"),
         ],
-        description=dedent(
-            """
+        description=dedent("""
             Aliases for module names.  For example, `[('np', 'numpy')]` makes rope recommend
             ``import numpy as np``.
-        """
-        ),
+        """),
     )
 
 
@@ -57,8 +55,7 @@ class Prefs:
             ".mypy_cache",
             ".pytest_cache",
         ],
-        description=dedent(
-            """
+        description=dedent("""
             Specify which files and folders to ignore in the project.
             Changes to ignored resources are not added to the history and
             VCSs.  Also they are not returned in `Project.get_files()`.
@@ -68,23 +65,19 @@ class Prefs:
             '.svn': matches 'pkg/.svn' and all of its children
             'build/*.o': matches 'build/lib.o' but not 'build/sub/lib.o'
             'build//*.o': matches 'build/lib.o' and 'build/sub/lib.o'
-        """
-        ),
+        """),
     )
     python_files: List[str] = field(
         default_factory=lambda: ["*.py"],
-        description=dedent(
-            """
+        description=dedent("""
             Specifies which files should be considered python files.  It is
             useful when you have scripts inside your project.  Only files
             ending with ``.py`` are considered to be python files by
             default.
-        """
-        ),
+        """),
     )
     source_folders: List[str] = field(
-        description=dedent(
-            """
+        description=dedent("""
             Custom source folders:  By default rope searches the project
             for finding source folders (folders that should be searched
             for finding modules).  You can add paths to that list.  Note
@@ -93,8 +86,7 @@ class Prefs:
             The folders should be relative to project root and use '/' for
             separating folders regardless of the platform rope is running on.
             'src/my_source_folder' for instance.
-        """
-        ),
+        """),
         default_factory=lambda: [],
     )
     python_path: List[str] = field(
@@ -116,12 +108,10 @@ class Prefs:
     )
     perform_doa: bool = field(
         default=True,
-        description=dedent(
-            """
+        description=dedent("""
             If `False` when running modules or unit tests 'dynamic object analysis' is turned off.
             This makes them much faster.
-        """
-        ),
+        """),
     )
     validate_objectdb: bool = field(
         default=False,
@@ -139,13 +129,11 @@ class Prefs:
 
     indent_size: int = field(
         default=4,
-        description=dedent(
-            """
+        description=dedent("""
             Set the number spaces used for indenting.  According to
             :PEP:`8`, it is best to use 4 spaces.  Since most of rope's
             unit-tests use 4 spaces it is more reliable, too.
-        """
-        ),
+        """),
     )
 
     extension_modules: List[str] = field(
@@ -161,68 +149,55 @@ Builtin and c-extension modules that are allowed to be imported and inspected by
     )
     ignore_syntax_errors: bool = field(
         default=False,
-        description=dedent(
-            """
+        description=dedent("""
             If `True` modules with syntax errors are considered to be empty.
             The default value is `False`; When `False` syntax errors raise
             `rope.base.exceptions.ModuleSyntaxError` exception.
-        """
-        ),
+        """),
     )
 
     ignore_bad_imports: bool = field(
         default=False,
-        description=dedent(
-            """
+        description=dedent("""
             If `True`, rope ignores unresolvable imports.  Otherwise, they
             appear in the importing namespace.
-        """
-        ),
+        """),
     )
     prefer_module_from_imports: bool = field(
         default=False,
-        description=dedent(
-            """
+        description=dedent("""
             If `True`, rope will insert new module imports as `from <package> import <module>`by default.
-        """
-        ),
+        """),
     )
 
     split_imports: bool = field(
         default=False,
-        description=dedent(
-            """
+        description=dedent("""
             If `True`, rope will transform a comma list of imports into
             multiple separate import statements when organizing
             imports.
-        """
-        ),
+        """),
     )
 
     pull_imports_to_top: bool = field(
         default=True,
-        description=dedent(
-            """
+        description=dedent("""
             If `True`, rope will remove all top-level import statements and
             reinsert them at the top of the module when making changes.
-        """
-        ),
+        """),
     )
 
     sort_imports_alphabetically: bool = field(
         default=False,
-        description=dedent(
-            """
+        description=dedent("""
             If `True`, rope will sort imports alphabetically by module name instead
             of alphabetically by import statement, with from imports after normal
             imports.
-        """
-        ),
+        """),
     )
     type_hinting_factory: str = field(
         "rope.base.oi.type_hinting.factory.default_type_hinting_factory",
-        description=dedent(
-            """
+        description=dedent("""
             Location of implementation of
             rope.base.oi.type_hinting.interfaces.ITypeHintingFactory In general
             case, you don't have to change this value, unless you're an rope expert.
@@ -230,17 +205,14 @@ Builtin and c-extension modules that are allowed to be imported and inspected by
             listed in module rope.base.oi.type_hinting.providers.interfaces
             For example, you can add you own providers for Django Models, or disable
             the search type-hinting in a class hierarchy, etc.
-        """
-        ),
+        """),
     )
     project_opened: Optional[Callable] = field(
         None,
-        description=dedent(
-            """
+        description=dedent("""
             This function is called after opening the project.
             Can only be set in config.py.
-        """
-        ),
+        """),
     )
     py_version: Optional[Tuple[int, int]] = field(
         default=None,
@@ -252,16 +224,13 @@ Builtin and c-extension modules that are allowed to be imported and inspected by
     )
     callbacks: Dict[str, Callable[[Any], None]] = field(
         default_factory=lambda: {},
-        description=dedent(
-            """
+        description=dedent("""
             Callbacks run when configuration values are changed.
             Can only be set in config.py.
-        """
-        ),
+        """),
     )
     autoimport: AutoimportPrefs = field(
-        default_factory=AutoimportPrefs, description="Preferences for Autoimport"
-    )
+        default_factory=AutoimportPrefs, description="Preferences for Autoimport")
 
     def set(self, key: str, value: Any):
         """Set the value of `key` preference to `value`."""

--- a/rope/base/prefs.py
+++ b/rope/base/prefs.py
@@ -215,7 +215,7 @@ Builtin and c-extension modules that are allowed to be imported and inspected by
         """),
     )
     autoimport: AutoimportPrefs = field(
-        default_factory=lambda: AutoimportPrefs(), description="Preferences for Autoimport")
+        default_factory=AutoimportPrefs, description="Preferences for Autoimport")
 
     def set(self, key: str, value: Any):
         """Set the value of `key` preference to `value`."""

--- a/rope/base/prefs.py
+++ b/rope/base/prefs.py
@@ -15,11 +15,12 @@ from rope.base.resources import Folder
 @dataclass
 class AutoimportPrefs:
     underlined: bool = field(
-        default=False, description="Cache underlined (private) modules")
-    memory: bool = field(default=None, description="Cache in memory instead of disk")
-    parallel: bool = field(default=True, description="Use multiple processes to parse")
+        default=False, description="Cache underlined (private) modules"
+    )
+    # memory: bool = field(default=None, description="Cache in memory instead of disk")
+    # parallel: bool = field(default=True, description="Use multiple processes to parse")
     aliases: List[Tuple[str, str]] = field(
-        default_factory=lambda : [
+        default_factory=lambda: [
             ("np", "numpy"),
             ("pd", "pandas"),
             ("plt", "matplotlib.pyplot"),
@@ -28,10 +29,12 @@ class AutoimportPrefs:
             ("sk", "sklearn"),
             ("sm", "statsmodels"),
         ],
-        description=dedent("""
+        description=dedent(
+            """
             Aliases for module names.  For example, `[('np', 'numpy')]` makes rope recommend
             ``import numpy as np``.
-        """),
+        """
+        ),
     )
 
 
@@ -54,7 +57,8 @@ class Prefs:
             ".mypy_cache",
             ".pytest_cache",
         ],
-        description=dedent("""
+        description=dedent(
+            """
             Specify which files and folders to ignore in the project.
             Changes to ignored resources are not added to the history and
             VCSs.  Also they are not returned in `Project.get_files()`.
@@ -64,19 +68,23 @@ class Prefs:
             '.svn': matches 'pkg/.svn' and all of its children
             'build/*.o': matches 'build/lib.o' but not 'build/sub/lib.o'
             'build//*.o': matches 'build/lib.o' and 'build/sub/lib.o'
-        """),
+        """
+        ),
     )
     python_files: List[str] = field(
         default_factory=lambda: ["*.py"],
-        description=dedent("""
+        description=dedent(
+            """
             Specifies which files should be considered python files.  It is
             useful when you have scripts inside your project.  Only files
             ending with ``.py`` are considered to be python files by
             default.
-        """),
+        """
+        ),
     )
     source_folders: List[str] = field(
-        description=dedent("""
+        description=dedent(
+            """
             Custom source folders:  By default rope searches the project
             for finding source folders (folders that should be searched
             for finding modules).  You can add paths to that list.  Note
@@ -85,7 +93,8 @@ class Prefs:
             The folders should be relative to project root and use '/' for
             separating folders regardless of the platform rope is running on.
             'src/my_source_folder' for instance.
-        """),
+        """
+        ),
         default_factory=lambda: [],
     )
     python_path: List[str] = field(
@@ -107,10 +116,12 @@ class Prefs:
     )
     perform_doa: bool = field(
         default=True,
-        description=dedent("""
+        description=dedent(
+            """
             If `False` when running modules or unit tests 'dynamic object analysis' is turned off.
             This makes them much faster.
-        """),
+        """
+        ),
     )
     validate_objectdb: bool = field(
         default=False,
@@ -128,11 +139,13 @@ class Prefs:
 
     indent_size: int = field(
         default=4,
-        description=dedent("""
+        description=dedent(
+            """
             Set the number spaces used for indenting.  According to
             :PEP:`8`, it is best to use 4 spaces.  Since most of rope's
             unit-tests use 4 spaces it is more reliable, too.
-        """),
+        """
+        ),
     )
 
     extension_modules: List[str] = field(
@@ -148,55 +161,68 @@ Builtin and c-extension modules that are allowed to be imported and inspected by
     )
     ignore_syntax_errors: bool = field(
         default=False,
-        description=dedent("""
+        description=dedent(
+            """
             If `True` modules with syntax errors are considered to be empty.
             The default value is `False`; When `False` syntax errors raise
             `rope.base.exceptions.ModuleSyntaxError` exception.
-        """),
+        """
+        ),
     )
 
     ignore_bad_imports: bool = field(
         default=False,
-        description=dedent("""
+        description=dedent(
+            """
             If `True`, rope ignores unresolvable imports.  Otherwise, they
             appear in the importing namespace.
-        """),
+        """
+        ),
     )
     prefer_module_from_imports: bool = field(
         default=False,
-        description=dedent("""
+        description=dedent(
+            """
             If `True`, rope will insert new module imports as `from <package> import <module>`by default.
-        """),
+        """
+        ),
     )
 
     split_imports: bool = field(
         default=False,
-        description=dedent("""
+        description=dedent(
+            """
             If `True`, rope will transform a comma list of imports into
             multiple separate import statements when organizing
             imports.
-        """),
+        """
+        ),
     )
 
     pull_imports_to_top: bool = field(
         default=True,
-        description=dedent("""
+        description=dedent(
+            """
             If `True`, rope will remove all top-level import statements and
             reinsert them at the top of the module when making changes.
-        """),
+        """
+        ),
     )
 
     sort_imports_alphabetically: bool = field(
         default=False,
-        description=dedent("""
+        description=dedent(
+            """
             If `True`, rope will sort imports alphabetically by module name instead
             of alphabetically by import statement, with from imports after normal
             imports.
-        """),
+        """
+        ),
     )
     type_hinting_factory: str = field(
         "rope.base.oi.type_hinting.factory.default_type_hinting_factory",
-        description=dedent("""
+        description=dedent(
+            """
             Location of implementation of
             rope.base.oi.type_hinting.interfaces.ITypeHintingFactory In general
             case, you don't have to change this value, unless you're an rope expert.
@@ -204,14 +230,17 @@ Builtin and c-extension modules that are allowed to be imported and inspected by
             listed in module rope.base.oi.type_hinting.providers.interfaces
             For example, you can add you own providers for Django Models, or disable
             the search type-hinting in a class hierarchy, etc.
-        """),
+        """
+        ),
     )
     project_opened: Optional[Callable] = field(
         None,
-        description=dedent("""
+        description=dedent(
+            """
             This function is called after opening the project.
             Can only be set in config.py.
-        """),
+        """
+        ),
     )
     py_version: Optional[Tuple[int, int]] = field(
         default=None,
@@ -223,13 +252,16 @@ Builtin and c-extension modules that are allowed to be imported and inspected by
     )
     callbacks: Dict[str, Callable[[Any], None]] = field(
         default_factory=lambda: {},
-        description=dedent("""
+        description=dedent(
+            """
             Callbacks run when configuration values are changed.
             Can only be set in config.py.
-        """),
+        """
+        ),
     )
     autoimport: AutoimportPrefs = field(
-        default_factory=AutoimportPrefs, description="Preferences for Autoimport")
+        default_factory=AutoimportPrefs, description="Preferences for Autoimport"
+    )
 
     def set(self, key: str, value: Any):
         """Set the value of `key` preference to `value`."""

--- a/rope/base/prefs.py
+++ b/rope/base/prefs.py
@@ -13,6 +13,14 @@ from rope.base.resources import Folder
 
 
 @dataclass
+class AutoimportPrefs:
+    underlined: bool = field(
+        default=False, description="Cache underlined (private) modules")
+    memory: bool = field(default=None, description="Cache in memory instead of disk")
+    parallel: bool = field(default=True, description="Use multiple processes to parse")
+
+
+@dataclass
 class Prefs:
     """Class to store rope preferences."""
 
@@ -206,6 +214,8 @@ Builtin and c-extension modules that are allowed to be imported and inspected by
             Can only be set in config.py.
         """),
     )
+    autoimport: AutoimportPrefs = field(
+        default_factory=lambda: AutoimportPrefs(), description="Preferences for Autoimport")
 
     def set(self, key: str, value: Any):
         """Set the value of `key` preference to `value`."""

--- a/rope/base/versioning.py
+++ b/rope/base/versioning.py
@@ -1,3 +1,4 @@
+import dataclasses
 import hashlib
 import importlib.util
 import json
@@ -31,7 +32,9 @@ def _get_prefs_data(project) -> str:
     del prefs_data["project_opened"]
     del prefs_data["callbacks"]
     del prefs_data["dependencies"]
-    return json.dumps(prefs_data, sort_keys=True, indent=2)
+    return json.dumps(
+        prefs_data, sort_keys=True, indent=2, default=lambda o: o.__dict__
+    )
 
 
 def _get_file_content(module_name: str) -> str:

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -2,30 +2,31 @@
 
 import contextlib
 import json
-from hashlib import sha256
-import secrets
 import re
+import secrets
 import sqlite3
 import sys
 import warnings
 from collections import OrderedDict
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
+from copy import deepcopy
 from datetime import datetime
+from hashlib import sha256
 from itertools import chain
 from pathlib import Path
 from threading import local
 from typing import Generator, Iterable, Iterator, List, Optional, Set, Tuple
 
 from packaging.requirements import Requirement
-from copy import deepcopy
+
 from rope.base import exceptions, libutils, resourceobserver, taskhandle, versioning
 from rope.base.prefs import AutoimportPrefs
 from rope.base.project import Project
 from rope.base.resources import Resource
 from rope.contrib.autoimport import models
 from rope.contrib.autoimport.defs import (
-    ModuleFile,
     Alias,
+    ModuleFile,
     Name,
     NameType,
     Package,

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -141,15 +141,14 @@ class AutoImport:
             self.prefs.underlined = underlined
         self.project_package = project_package
         if memory is _deprecated_default:
-            if self.prefs.memory is None:
-                self.prefs.memory = True
-                warnings.warn(
-                    "The default value for `AutoImport(memory)` argument will "
-                    "change to use an on-disk database by default in the future. "
-                    "If you want to use an in-memory database, you need to pass "
-                    "`AutoImport(memory=True)` explicitly or set it in the config file.",
-                    DeprecationWarning,
-                )
+            self.prefs.memory = True
+            warnings.warn(
+                "The default value for `AutoImport(memory)` argument will "
+                "change to use an on-disk database by default in the future. "
+                "If you want to use an in-memory database, you need to pass "
+                "`AutoImport(memory=True)` explicitly or set it in the config file.",
+                DeprecationWarning,
+            )
         else:
             self.prefs.memory = memory
         self.thread_local = local()
@@ -211,7 +210,7 @@ class AutoImport:
         if not hasattr(self.thread_local, "connection"):
             self.thread_local.connection = self.create_database_connection(
                 project=self.project,
-                memory=self.memory,
+                memory=self.prefs.memory,
             )
         return self.thread_local.connection
 

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -17,7 +17,7 @@ from threading import local
 from typing import Generator, Iterable, Iterator, List, Optional, Set, Tuple
 
 from packaging.requirements import Requirement
-
+from copy import deepcopy
 from rope.base import exceptions, libutils, resourceobserver, taskhandle, versioning
 from rope.base.prefs import AutoimportPrefs
 from rope.base.project import Project
@@ -133,7 +133,7 @@ class AutoImport:
                 autoimport = AutoImport(..., memory=True)
         """
         self.project = project
-        self.prefs = self.project.prefs.autoimport
+        self.prefs = deepcopy(self.project.prefs.autoimport)
         project_package = get_package_tuple(project.root.pathlib, project)
         assert project_package is not None
         assert project_package.path is not None

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -2,16 +2,15 @@
 
 import contextlib
 import json
-import re
+from hashlib import sha256
 import secrets
+import re
 import sqlite3
 import sys
 import warnings
 from collections import OrderedDict
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
-from copy import deepcopy
 from datetime import datetime
-from hashlib import sha256
 from itertools import chain
 from pathlib import Path
 from threading import local
@@ -671,7 +670,7 @@ class AutoImport:
         self, resource: Resource, underlined: bool = False
     ) -> ModuleFile:
         assert self.project_package.path
-        underlined = underlined if underlined else self.prefs.underlined
+        underlined = underlined if underlined else self.underlined
         resource_path: Path = resource.pathlib
         # The project doesn't need its name added to the path,
         # since the standard python file layout accounts for that

--- a/rope/contrib/autoimport/utils.py
+++ b/rope/contrib/autoimport/utils.py
@@ -118,7 +118,7 @@ def get_files(
         yield ModuleFile(package.path, package.path.stem, underlined, False)
     else:
         assert package.path
-        for file in package.path.glob("**/*.py"):
+        for file in package.path.rglob("*.py"):
             if file.name == "__init__.py":
                 yield ModuleFile(
                     file,

--- a/rope/contrib/autoimport/utils.py
+++ b/rope/contrib/autoimport/utils.py
@@ -119,6 +119,8 @@ def get_files(
     else:
         assert package.path
         for file in package.path.rglob("*.py"):
+            if "site-packages" in file.parts:
+                continue
             if file.name == "__init__.py":
                 yield ModuleFile(
                     file,

--- a/rope/contrib/autoimport/utils.py
+++ b/rope/contrib/autoimport/utils.py
@@ -119,7 +119,7 @@ def get_files(
     else:
         assert package.path
         for file in package.path.rglob("*.py"):
-            if "site-packages" in file.parts:
+            if "site-packages" in file.relative_to(package.path).parts:
                 continue
             if file.name == "__init__.py":
                 yield ModuleFile(

--- a/ropetest/conftest.py
+++ b/ropetest/conftest.py
@@ -7,8 +7,9 @@ from ropetest import testutils
 
 
 @pytest.fixture
-def project():
-    project = testutils.sample_project()
+def project(request):
+    pyproject = request.param if hasattr(request, "param") else None
+    project = testutils.sample_project(pyproject=pyproject)
     yield project
     testutils.remove_project(project)
 
@@ -38,6 +39,7 @@ Standard project structure for pytest fixtures
 /pkg1/__init__.py   -- pkg1
 /pkg1/mod2.py       -- mod2
 """
+
 
 @pytest.fixture
 def mod1(project) -> resources.File:

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -14,7 +14,7 @@ from rope.contrib.autoimport.sqlite import AutoImport
 
 @pytest.fixture
 def autoimport(project: Project):
-    with closing(AutoImport(project)) as ai:
+    with closing(AutoImport(project, memory=True)) as ai:
         yield ai
 
 
@@ -124,9 +124,9 @@ def test_multithreading(
 
 
 def test_connection(project: Project, project2: Project):
-    ai1 = AutoImport(project)
-    ai2 = AutoImport(project)
-    ai3 = AutoImport(project2)
+    ai1 = AutoImport(project, memory=True)
+    ai2 = AutoImport(project, memory=True)
+    ai3 = AutoImport(project2, memory=True)
 
     assert ai1.connection is not ai2.connection
     assert ai1.connection is not ai3.connection

--- a/ropetest/contrib/autoimport/deptest.py
+++ b/ropetest/contrib/autoimport/deptest.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+from rope.base.project import Project
+from rope.contrib.autoimport.sqlite import AutoImport
+
+
+@pytest.fixture
+def project(request, tmp_path: Path) -> Iterable[Project]:
+    doc = request.param
+    if doc is not None:
+        file = tmp_path / "pyproject.toml"
+        file.write_text(doc, encoding="utf-8")
+        print(file, doc)
+    project = Project(tmp_path)
+    yield project
+    project.close()
+
+
+@pytest.fixture
+def autoimport(project) -> Iterable[AutoImport]:
+    autoimport = AutoImport(project, memory=True)
+    autoimport.generate_modules_cache()
+    yield autoimport
+    autoimport.close()
+
+
+@pytest.mark.parametrize("project", ((""),), indirect=True)
+def test_blank(project, autoimport):
+    assert project.prefs.dependencies is None
+    assert autoimport.search("pytoolconfig")
+
+
+@pytest.mark.parametrize("project", (("[project]\n dependencies=[]"),), indirect=True)
+def test_empty(project, autoimport):
+    assert len(project.prefs.dependencies) == 0
+    assert [] == autoimport.search("pytoolconfig")
+
+
+FILE = """
+[project]
+dependencies = [
+    "pytoolconfig",
+    "bogus"
+]
+"""
+
+
+@pytest.mark.parametrize("project", ((FILE),), indirect=True)
+def test_not_empty(project, autoimport):
+    assert len(project.prefs.dependencies) == 2
+    assert autoimport.search("pytoolconfig")

--- a/ropetest/contrib/autoimport/deptest.py
+++ b/ropetest/contrib/autoimport/deptest.py
@@ -5,8 +5,6 @@ import pytest
 from rope.contrib.autoimport.sqlite import AutoImport
 
 
-
-
 @pytest.fixture
 def autoimport(project) -> Iterable[AutoImport]:
     autoimport = AutoImport(project, memory=True)

--- a/ropetest/contrib/autoimport/deptest.py
+++ b/ropetest/contrib/autoimport/deptest.py
@@ -1,21 +1,10 @@
-from pathlib import Path
 from typing import Iterable
 
 import pytest
 
-from rope.base.project import Project
 from rope.contrib.autoimport.sqlite import AutoImport
 
 
-@pytest.fixture
-def project(request, tmp_path: Path) -> Iterable[Project]:
-    doc = request.param
-    if doc is not None:
-        file = tmp_path / "pyproject.toml"
-        file.write_text(doc, encoding="utf-8")
-    project = Project(tmp_path)
-    yield project
-    project.close()
 
 
 @pytest.fixture

--- a/ropetest/contrib/autoimport/deptest.py
+++ b/ropetest/contrib/autoimport/deptest.py
@@ -13,7 +13,6 @@ def project(request, tmp_path: Path) -> Iterable[Project]:
     if doc is not None:
         file = tmp_path / "pyproject.toml"
         file.write_text(doc, encoding="utf-8")
-        print(file, doc)
     project = Project(tmp_path)
     yield project
     project.close()

--- a/ropetest/contrib/autoimporttest.py
+++ b/ropetest/contrib/autoimporttest.py
@@ -146,9 +146,10 @@ class AutoImportTest(unittest.TestCase):
         # The single thread test takes much longer than the multithread test but is easier to debug
         single_thread = False
         self.importer.generate_modules_cache(single_thread=single_thread)
-        
+
         # Create a temporary directory and set permissions to 000
-        import tempfile, sys
+        import sys
+        import tempfile
         with tempfile.TemporaryDirectory() as dir:
             import os
             os.chmod(dir, 0o000)

--- a/ropetest/contrib/autoimporttest.py
+++ b/ropetest/contrib/autoimporttest.py
@@ -11,7 +11,7 @@ class AutoImportTest(unittest.TestCase):
         self.mod1 = testutils.create_module(self.project, "mod1")
         self.pkg = testutils.create_package(self.project, "pkg")
         self.mod2 = testutils.create_module(self.project, "mod2", self.pkg)
-        self.importer = autoimport.AutoImport(self.project, observe=False)
+        self.importer = autoimport.AutoImport(self.project, observe=False, memory=True)
 
     def tearDown(self):
         testutils.remove_project(self.project)
@@ -86,7 +86,7 @@ class AutoImportTest(unittest.TestCase):
         self.assertEqual(["mod1"], self.importer.get_modules("_myvar"))
 
     def test_caching_underlined_names_passing_to_the_constructor(self):
-        importer = autoimport.AutoImport(self.project, False, True)
+        importer = autoimport.AutoImport(self.project, False, True, memory=True)
         self.mod1.write("_myvar = None\n")
         importer.update_resource(self.mod1)
         self.assertEqual(["mod1"], importer.get_modules("_myvar"))
@@ -165,7 +165,7 @@ class AutoImportObservingTest(unittest.TestCase):
         self.mod1 = testutils.create_module(self.project, "mod1")
         self.pkg = testutils.create_package(self.project, "pkg")
         self.mod2 = testutils.create_module(self.project, "mod2", self.pkg)
-        self.importer = autoimport.AutoImport(self.project, observe=True)
+        self.importer = autoimport.AutoImport(self.project, observe=True, memory=True)
 
     def tearDown(self):
         testutils.remove_project(self.project)

--- a/ropetest/testutils.py
+++ b/ropetest/testutils.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Optional
+
 import rope.base.project
 from rope.contrib import generate
 

--- a/ropetest/testutils.py
+++ b/ropetest/testutils.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-
+from typing import Optional
 import rope.base.project
 from rope.contrib import generate
 
@@ -14,10 +14,14 @@ logging.basicConfig(format="%(levelname)s:%(funcName)s:%(message)s", level=loggi
 RUN_TMP_DIR = tempfile.mkdtemp(prefix="ropetest-run-")
 
 
-def sample_project(foldername=None, **kwds):
+def sample_project(foldername=None, pyproject: Optional[str] = None, **kwds):
     root = Path(tempfile.mkdtemp(prefix="project-", dir=RUN_TMP_DIR))
     root /= foldername if foldername else "sample_project"
     logging.debug("Using %s as root of the project.", root)
+    root.mkdir(exist_ok=True)
+    if pyproject is not None:
+        file = root / "pyproject.toml"
+        file.write_text(pyproject, encoding="utf-8")
     # Using these prefs for faster tests
     prefs = {
         "save_objectdb": False,


### PR DESCRIPTION
# Motivation
Say you have a large environment with a package (IE: Pytorch) that you mark as a dependency. While you plan to use pytorch, its dependents consume a lot of unnessecary space. Additionally, it doesn't make sense to directly import those packages (since it breaks abstraction). 
# Description

Autodetects dependencies
This makes autoimport much much faster (1.33 sec vs 0.28 sec on a large env)
Pyproject.toml support
Will deprecate setting underlined per-function/directly w/o going through prefs (feedback?) 



# Checklist (delete if not relevant):
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
- [x] I have made corresponding changes to user documentation for new features 
- [x] I have made corresponding changes to library documentation for API changes
