### PR TITLE
dynamic versioning, reformat pyproject.toml, switch pytest.ini to pyproject.toml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,74 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+  schedule:
+    - cron: '38 14 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # **Upcoming release**
 
+## Improvement
+
 - #492, Feat: Global configuration support
+- #519, dynamic versioning and move pytest to pyproject.toml
 
 # Release 1.4.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ target-version = ['py36', 'py37', 'py38', 'py39']
 include = 'rope/.*\.pyi?$'
 force-exclude = 'ropetest|rope/base/prefs.py'
 
+[tool.pytest.ini_options]
+
+python_files = ["*test.py", "__init__.py"]
+markers = ["time_limit: sets a maximum amount of time the test can run"]
+
 [build-system]
 requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Topic :: Software Development',
 ]
-version = '1.4.0'
+dynamic = ["version"]
 dependencies = ['pytoolconfig >= 1.2.2']
 
 [[project.authors]]
@@ -44,11 +44,7 @@ doc = [
     "sphinx-autodoc-typehints>=1.18.1",
     "sphinx-rtd-theme>=1.0.0",
 ]
-dev = [
-    'pytest>=7.0.1',
-    'pytest-timeout>=2.1.0',
-    'build>=0.7.0',
-]
+dev = ['pytest>=7.0.1', 'pytest-timeout>=2.1.0', 'build>=0.7.0']
 [tool.setuptools]
 packages = [
     'rope',
@@ -63,20 +59,12 @@ packages = [
     'rope.refactor',
     'rope.refactor.importutils',
 ]
-
+[tool.setuptools_scm]
 [tool.black]
-target-version = [
-    'py36',
-    'py37',
-    'py38',
-    'py39',
-]
+target-version = ['py36', 'py37', 'py38', 'py39']
 include = 'rope/.*\.pyi?$'
 force-exclude = 'ropetest|rope/base/prefs.py'
 
 [build-system]
-requires = [
-    'setuptools',
-    'setuptools-scm',
-]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 build-backend = 'setuptools.build_meta'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-python_files = 
-   *test.py
-   __init__.py
-
-markers =
-    time_limit: sets a maximum amount of time the test can run


### PR DESCRIPTION
Pulls versioning from PR + git - necessary for automatic DB upgrades
We need the tags to work first. Also reformatted the pyproject.toml. Please try versioning it yourself first and let me know if you want me to update CI to match.
replaces #450 
closes #414 