### PR TITLE
Fix read/write analysis of the left-hand side of an augmented assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # **Upcoming release**
 
-- #492, Feat: Global configuration support
+- #492 Feat: Global configuration support
+- #509 Fix read/write analysis of the left-hand side of an augmented assignment
 
 # Release 1.4.0
 

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -856,12 +856,12 @@ class _FunctionInformationCollector:
 
     def _AugAssign(self, node):
         ast.walk(node.value, self)
-        if isinstance(node.target, ast.Subscript):
-            target_id = node.target.value.id
-        else:
+        if isinstance(node.target, ast.Name):
             target_id = node.target.id
-        self._read_variable(target_id, node.target.lineno)
-        self._written_variable(target_id, node.target.lineno)
+            self._read_variable(target_id, node.target.lineno)
+            self._written_variable(target_id, node.target.lineno)
+        else:
+            ast.walk(node.target, self)
 
     def _ClassDef(self, node):
         self._written_variable(node.name, node.lineno)

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1762,7 +1762,69 @@ class ExtractMethodTest(unittest.TestCase):
         """)
         self.assertEqual(expected, refactored)
 
-    def test_extract_method_and_augmentedj_assignment_in_try_block(self):
+    def test_extract_method_and_augmented_assignment_nested_1(self):
+        code = dedent("""\
+            def f():
+                my_var = [[0], [1], [2]]
+                my_var[0][0] += 1
+                print(1)
+        """)
+        start, end = self._convert_line_range_to_offset(code, 4, 4)
+        refactored = self.do_extract_method(code, start, end, "g")
+        expected = dedent("""\
+            def f():
+                my_var = [[0], [1], [2]]
+                my_var[0][0] += 1
+                g()
+
+            def g():
+                print(1)
+        """)
+        self.assertEqual(expected, refactored)
+
+    def test_extract_method_and_augmented_assignment_nested_2(self):
+        code = dedent("""\
+            def f():
+                my_var = [[0], [1], [2]]
+                my_var[0][0] += 1
+                print(my_var)
+        """)
+        start, end = self._convert_line_range_to_offset(code, 3, 3)
+        refactored = self.do_extract_method(code, start, end, "g")
+        expected = dedent("""\
+            def f():
+                my_var = [[0], [1], [2]]
+                g(my_var)
+                print(my_var)
+
+            def g(my_var):
+                my_var[0][0] += 1
+        """)
+        self.assertEqual(expected, refactored)
+
+    def test_extract_method_and_augmented_assignment_var_to_read_in_lhs(self):
+        code = dedent("""\
+            def f():
+                var_to_read = 0
+                my_var = [0, 1, 2]
+                my_var[var_to_read] += 1
+                print(my_var)
+        """)
+        start, end = self._convert_line_range_to_offset(code, 4, 4)
+        refactored = self.do_extract_method(code, start, end, "g")
+        expected = dedent("""\
+            def f():
+                var_to_read = 0
+                my_var = [0, 1, 2]
+                g(my_var, var_to_read)
+                print(my_var)
+
+            def g(my_var, var_to_read):
+                my_var[var_to_read] += 1
+        """)
+        self.assertEqual(expected, refactored)
+
+    def test_extract_method_and_augmented_assignment_in_try_block(self):
         code = dedent("""\
             def f():
                 any_subscriptable = [0]


### PR DESCRIPTION
# Description

`_AugAssign` now recursively walk the left hand expression (i.e. node.target) for it to handle these more complex expressions.

Fixes #509 

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md