### PR TITLE
Fix #522. Implement patchedast parsing of MatchMapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - #492 Feat: Global configuration support
 - #509 Fix read/write analysis of the left-hand side of an augmented assignment
+- #522 Implement patchedast parsing of MatchMapping
 
 # Release 1.4.0
 

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -903,6 +903,16 @@ class _PatchingASTWalker:
     def _MatchValue(self, node):
         self._handle(node, [node.value])
 
+    def _MatchMapping(self, node):
+        children = []
+        children.append("{")
+        for index, (key, value) in enumerate(zip(node.keys, node.patterns)):
+            children.extend([key, ":", value])
+            if index < len(node.keys) - 1:
+                children.append(",")
+        children.append("}")
+        self._handle(node, children)
+
 
 class _Source:
     def __init__(self, source):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1565,6 +1565,36 @@ class PatchedASTTest(unittest.TestCase):
         ])
 
 
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_mapping_match_as(self):
+        source = dedent("""\
+            match x:
+                case {"a": b} as c:
+                    print(x)
+        """)
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchAs")
+        checker.check_children("MatchAs", [
+            "MatchMapping",
+            " ",
+            "as",
+            " ",
+            "c",
+        ])
+        checker.check_children("MatchMapping", [
+            "{",
+            "",
+            "Constant",
+            "",
+            ":",
+            " ",
+            "MatchAs",
+            "",
+            "}",
+        ])
+
+
 class _ResultChecker:
     def __init__(self, test_case, ast):
         self.test_case = test_case


### PR DESCRIPTION
# Description

Somehow, this was missed back when the rest of `match` statement was implemented.

Fixes #522

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
