### PR TITLE
Clean the walk function in rope.base.ast

### DIFF
--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -22,7 +22,7 @@ def parse(source, filename="<string>"):
         raise error
 
 
-def walk(node, walker):
+def walk(node, walker) -> None:
     """Walk the syntax tree"""
     method_name = "_" + node.__class__.__name__
     method = getattr(walker, method_name, None)
@@ -31,7 +31,8 @@ def walk(node, walker):
             # In python < 2.7 ``node.module == ''`` for relative imports
             # but for python 2.7 it is None. Generalizing it to ''.
             node.module = ""
-        return method(node)
+        method(node)
+        return
     for child in get_child_nodes(node):
         walk(child, walker)
 


### PR DESCRIPTION
The walk function should not appear to return a value.

The legacy code generates (valid) errors from pylint and mypy.

- [x] All unit tests pass.