### PR TITLE
Implement MoveGlobal using string as destination module names

### DIFF
--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 import warnings
+from typing import Optional
 
 import rope.base.fscommands
 import rope.base.resourceobserver as resourceobserver
@@ -136,7 +137,7 @@ class _Project:
             raise ModuleNotFoundError("Module %s not found" % name)
         return self.pycore.resource_to_pyobject(module)
 
-    def find_module(self, modname, folder=None):
+    def find_module(self, modname, folder=None) -> Optional[File]:
         """Returns a resource corresponding to the given module
 
         returns None if it can not be found

--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -4,6 +4,8 @@
 based on inputs.
 
 """
+from typing import Union
+
 from rope.base import (
     pyobjects,
     codeanalyze,
@@ -13,6 +15,8 @@ from rope.base import (
     evaluate,
     worder,
     libutils,
+    resources,
+    project,
 )
 from rope.base.change import ChangeSet, ChangeContents, MoveResource
 from rope.refactor import importutils, rename, occurrences, sourceutils, functionutils
@@ -231,6 +235,8 @@ class MoveMethod:
 class MoveGlobal:
     """For moving global function and classes"""
 
+    project: project.Project
+
     def __init__(self, project, resource, offset):
         self.project = project
         this_pymodule = self.project.get_pymodule(resource)
@@ -299,8 +305,13 @@ class MoveGlobal:
         return isinstance(pyname, pynames.AssignedName)
 
     def get_changes(
-        self, dest, resources=None, task_handle=taskhandle.NullTaskHandle()
+        self,
+        dest: Union[None, str, resources.Resource],
+        resources=None,
+        task_handle=taskhandle.NullTaskHandle(),
     ):
+        if isinstance(dest, str):
+            dest = self.project.find_module(dest)
         if resources is None:
             resources = self.project.get_python_files()
         if dest is None or not dest.exists():

--- a/ropetest/refactor/movetest.py
+++ b/ropetest/refactor/movetest.py
@@ -40,6 +40,18 @@ class MoveRefactoringTest(unittest.TestCase):
         self.assertEqual("bar = 321\n", self.mod1.read())
         self.assertEqual("foo = 123\n", self.mod2.read())
 
+    def test_move_target_is_module_name(self):
+        self.mod1.write("foo = 123\n")
+        self._move(self.mod1, self.mod1.read().index("foo") + 1, "mod2")
+        self.assertEqual("", self.mod1.read())
+        self.assertEqual("foo = 123\n", self.mod2.read())
+
+    def test_move_target_is_package_name(self):
+        self.mod1.write("foo = 123\n")
+        self._move(self.mod1, self.mod1.read().index("foo") + 1, "pkg.mod4")
+        self.assertEqual("", self.mod1.read())
+        self.assertEqual("foo = 123\n", self.mod4.read())
+
     def test_move_constant_multiline(self):
         self.mod1.write(dedent("""\
             foo = (


### PR DESCRIPTION
# Description

Currently, get_changes() requires that you pass in a Resource object to `get_changes(dest)`. This change allows `get_changes(dest)` to be passed as a string.

# Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated CHANGELOG.md
- [ ] I have made corresponding changes to user documentation for new features 
- [ ] I have made corresponding changes to library documentation for API changes
