### PR TITLE
PR for #553: Fix potential crasher in _getarguments

### DIFF
--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -949,7 +949,7 @@ class _FunctionInformationCollector:
 def _get_argnames(arguments):
     result = [node.arg for node in arguments.args if isinstance(node, ast.arg)]
     if arguments.vararg:
-        result.append(vararg.arg)
+        result.append(arguments.vararg.arg)
     if arguments.kwarg:
         result.append(arguments.kwarg.arg)
     return result

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -271,6 +271,22 @@ class ExtractMethodTest(unittest.TestCase):
         """)
         self.assertEqual(expected, refactored)
 
+    def test_extract_method_args_and_kwargs(self):
+        code = dedent("""\
+            def a_func(a, *args, **kwargs):
+                print(a, args, kwargs)
+        """)
+        start, end = self._convert_line_range_to_offset(code, 2, 2)
+        refactored = self.do_extract_method(code, start, end, "new_func")
+        expected = dedent("""\
+            def a_func(a, *args, **kwargs):
+                new_func(a, args, kwargs)
+
+            def new_func(a, args, kwargs):
+                print(a, args, kwargs)
+        """)
+        self.assertEqual(expected, refactored)
+
     def test_extract_method_with_self_as_argument(self):
         code = dedent("""\
             class AClass(object):


### PR DESCRIPTION
See #553. This PR could be called an emergency fix.

flake8 reported the error. Unit tests did not.

Still unresolved: creating a unit test that should have failed :-)  See #545, which suggest better test coverage.