### PR TITLE
Remove functions in rope.base.ast that has functionally identical implementation in stdlib's ast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - #533 Refactoring to Remove usage of unicode type
 - #559 Improve handling of whitespace in import and from-import statements
+- #581 Remove functions in rope.base.ast that has functionally identical implementation in stdlib's ast 
 
 # Release 1.5.1
 

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -39,7 +39,3 @@ def call_for_nodes(node, callback, recursive=False):
     if recursive and not result:
         for child in ast.iter_child_nodes(node):
             call_for_nodes(child, callback, recursive)
-
-
-def get_children(node):
-    return [child for field, child in ast.iter_fields(node)]

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -34,19 +34,7 @@ def walk_visitor(node, visitor) -> None:
 
 
 def get_child_nodes(node):
-    if isinstance(node, ast.Module):
-        return node.body
-    result = []
-    if node._fields is not None:
-        for name in node._fields:
-            child = getattr(node, name)
-            if isinstance(child, list):
-                for entry in child:
-                    if isinstance(entry, ast.AST):
-                        result.append(entry)
-            if isinstance(child, ast.AST):
-                result.append(child)
-    return result
+    return list(ast.iter_child_nodes(node))
 
 
 def call_for_nodes(node, callback, recursive=False):
@@ -58,11 +46,4 @@ def call_for_nodes(node, callback, recursive=False):
 
 
 def get_children(node):
-    result = []
-    if node._fields is not None:
-        for name in node._fields:
-            if name in ["lineno", "col_offset"]:
-                continue
-            child = getattr(node, name)
-            result.append(child)
-    return result
+    return [child for field, child in ast.iter_fields(node)]

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -29,19 +29,15 @@ def walk_visitor(node, visitor) -> None:
     if method is not None:
         method(node)
         return
-    for child in get_child_nodes(node):
+    for child in ast.iter_child_nodes(node):
         walk_visitor(child, visitor)
-
-
-def get_child_nodes(node):
-    return list(ast.iter_child_nodes(node))
 
 
 def call_for_nodes(node, callback, recursive=False):
     """If callback returns `True` the child nodes are skipped"""
     result = callback(node)
     if recursive and not result:
-        for child in get_child_nodes(node):
+        for child in ast.iter_child_nodes(node):
             call_for_nodes(child, callback, recursive)
 
 

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -22,15 +22,15 @@ def parse(source, filename="<string>"):
         raise error
 
 
-def walk_visitor(node, walker) -> None:
-    """Walk the syntax tree"""
+def walk_visitor(node, visitor) -> None:
+    """Walk the syntax tree using a visitor class"""
     method_name = "_" + node.__class__.__name__
-    method = getattr(walker, method_name, None)
+    method = getattr(visitor, method_name, None)
     if method is not None:
         method(node)
         return
     for child in get_child_nodes(node):
-        walk_visitor(child, walker)
+        walk_visitor(child, visitor)
 
 
 def get_child_nodes(node):

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -22,20 +22,17 @@ def parse(source, filename="<string>"):
         raise error
 
 
-def walk_visitor(node, visitor) -> None:
-    """Walk the syntax tree using a visitor class"""
-    method_name = "_" + node.__class__.__name__
-    method = getattr(visitor, method_name, None)
-    if method is not None:
-        method(node)
-        return
-    for child in ast.iter_child_nodes(node):
-        walk_visitor(child, visitor)
-
-
 def call_for_nodes(node, callback, recursive=False):
     """If callback returns `True` the child nodes are skipped"""
     result = callback(node)
     if recursive and not result:
         for child in ast.iter_child_nodes(node):
             call_for_nodes(child, callback, recursive)
+
+
+class RopeNodeVisitor(ast.NodeVisitor):
+    def visit(self, node):
+        """Modified from ast.NodeVisitor to match rope's existing Visitor implementation"""
+        method = '_' + node.__class__.__name__
+        visitor = getattr(self, method, self.generic_visit)
+        return visitor(node)

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -33,6 +33,6 @@ def call_for_nodes(node, callback, recursive=False):
 class RopeNodeVisitor(ast.NodeVisitor):
     def visit(self, node):
         """Modified from ast.NodeVisitor to match rope's existing Visitor implementation"""
-        method = '_' + node.__class__.__name__
+        method = "_" + node.__class__.__name__
         visitor = getattr(self, method, self.generic_visit)
         return visitor(node)

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -22,7 +22,7 @@ def parse(source, filename="<string>"):
         raise error
 
 
-def walk(node, walker) -> None:
+def walk_visitor(node, walker) -> None:
     """Walk the syntax tree"""
     method_name = "_" + node.__class__.__name__
     method = getattr(walker, method_name, None)
@@ -30,7 +30,7 @@ def walk(node, walker) -> None:
         method(node)
         return
     for child in get_child_nodes(node):
-        walk(child, walker)
+        walk_visitor(child, walker)
 
 
 def get_child_nodes(node):

--- a/rope/base/astutils.py
+++ b/rope/base/astutils.py
@@ -14,7 +14,7 @@ def get_name_levels(node):
 
     """
     visitor = _NodeNameCollector()
-    ast.walk(node, visitor)
+    ast.walk_visitor(node, visitor)
     return visitor.names
 
 
@@ -50,7 +50,7 @@ class _NodeNameCollector:
         self.index += 1
         visitor = _NodeNameCollector(new_levels)
         for child in ast.get_child_nodes(node):
-            ast.walk(child, visitor)
+            ast.walk_visitor(child, visitor)
         self.names.extend(visitor.names)
 
     def _Subscript(self, node):

--- a/rope/base/astutils.py
+++ b/rope/base/astutils.py
@@ -49,7 +49,7 @@ class _NodeNameCollector:
             new_levels.append(self.index)
         self.index += 1
         visitor = _NodeNameCollector(new_levels)
-        for child in ast.get_child_nodes(node):
+        for child in ast.iter_child_nodes(node):
             ast.walk_visitor(child, visitor)
         self.names.extend(visitor.names)
 

--- a/rope/base/astutils.py
+++ b/rope/base/astutils.py
@@ -14,11 +14,11 @@ def get_name_levels(node):
 
     """
     visitor = _NodeNameCollector()
-    ast.walk_visitor(node, visitor)
+    visitor.visit(node)
     return visitor.names
 
 
-class _NodeNameCollector:
+class _NodeNameCollector(ast.RopeNodeVisitor):
     def __init__(self, levels=None):
         self.names = []
         self.levels = levels
@@ -50,7 +50,7 @@ class _NodeNameCollector:
         self.index += 1
         visitor = _NodeNameCollector(new_levels)
         for child in ast.iter_child_nodes(node):
-            ast.walk_visitor(child, visitor)
+            visitor.visit(child)
         self.names.extend(visitor.names)
 
     def _Subscript(self, node):

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -39,7 +39,7 @@ def eval_node(scope, node):
 
 def eval_node2(scope, node):
     evaluator = StatementEvaluator(scope)
-    ast.walk_visitor(node, evaluator)
+    evaluator.visit(node)
     return evaluator.old_result, evaluator.result
 
 
@@ -158,7 +158,7 @@ class ScopeNameFinder:
         )
 
 
-class StatementEvaluator:
+class StatementEvaluator(ast.RopeNodeVisitor):
     def __init__(self, scope):
         self.scope = scope
         self.result = None

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -39,7 +39,7 @@ def eval_node(scope, node):
 
 def eval_node2(scope, node):
     evaluator = StatementEvaluator(scope)
-    ast.walk(node, evaluator)
+    ast.walk_visitor(node, evaluator)
     return evaluator.old_result, evaluator.result
 
 

--- a/rope/base/oi/soa.py
+++ b/rope/base/oi/soa.py
@@ -34,7 +34,7 @@ def _analyze_node(pycore, pydefined, should_analyze, search_subscopes, followed_
             _follow = None
         visitor = SOAVisitor(pycore, pydefined, _follow)
         for child in rope.base.ast.get_child_nodes(pydefined.get_ast()):
-            rope.base.ast.walk(child, visitor)
+            rope.base.ast.walk_visitor(child, visitor)
 
 
 class SOAVisitor:
@@ -52,7 +52,7 @@ class SOAVisitor:
 
     def _Call(self, node):
         for child in rope.base.ast.get_child_nodes(node):
-            rope.base.ast.walk(child, self)
+            rope.base.ast.walk_visitor(child, self)
         primary, pyname = evaluate.eval_node2(self.scope, node.func)
         if pyname is None:
             return
@@ -100,22 +100,22 @@ class SOAVisitor:
 
     def _AnnAssign(self, node):
         for child in rope.base.ast.get_child_nodes(node):
-            rope.base.ast.walk(child, self)
+            rope.base.ast.walk_visitor(child, self)
         visitor = _SOAAssignVisitor()
         nodes = []
 
-        rope.base.ast.walk(node.target, visitor)
+        rope.base.ast.walk_visitor(node.target, visitor)
         nodes.extend(visitor.nodes)
 
         self._evaluate_assign_value(node, nodes, type_hint=node.annotation)
 
     def _Assign(self, node):
         for child in rope.base.ast.get_child_nodes(node):
-            rope.base.ast.walk(child, self)
+            rope.base.ast.walk_visitor(child, self)
         visitor = _SOAAssignVisitor()
         nodes = []
         for child in node.targets:
-            rope.base.ast.walk(child, visitor)
+            rope.base.ast.walk_visitor(child, visitor)
             nodes.extend(visitor.nodes)
         self._evaluate_assign_value(node, nodes)
 

--- a/rope/base/oi/soa.py
+++ b/rope/base/oi/soa.py
@@ -34,10 +34,10 @@ def _analyze_node(pycore, pydefined, should_analyze, search_subscopes, followed_
             _follow = None
         visitor = SOAVisitor(pycore, pydefined, _follow)
         for child in rope.base.ast.iter_child_nodes(pydefined.get_ast()):
-            rope.base.ast.walk_visitor(child, visitor)
+            visitor.visit(child)
 
 
-class SOAVisitor:
+class SOAVisitor(rope.base.ast.RopeNodeVisitor):
     def __init__(self, pycore, pydefined, follow_callback=None):
         self.pycore = pycore
         self.pymodule = pydefined.get_module()
@@ -52,7 +52,7 @@ class SOAVisitor:
 
     def _Call(self, node):
         for child in rope.base.ast.iter_child_nodes(node):
-            rope.base.ast.walk_visitor(child, self)
+            self.visit(child)
         primary, pyname = evaluate.eval_node2(self.scope, node.func)
         if pyname is None:
             return
@@ -100,22 +100,22 @@ class SOAVisitor:
 
     def _AnnAssign(self, node):
         for child in rope.base.ast.iter_child_nodes(node):
-            rope.base.ast.walk_visitor(child, self)
+            self.visit(child)
         visitor = _SOAAssignVisitor()
         nodes = []
 
-        rope.base.ast.walk_visitor(node.target, visitor)
+        visitor.visit(node.target)
         nodes.extend(visitor.nodes)
 
         self._evaluate_assign_value(node, nodes, type_hint=node.annotation)
 
     def _Assign(self, node):
         for child in rope.base.ast.iter_child_nodes(node):
-            rope.base.ast.walk_visitor(child, self)
+            self.visit(child)
         visitor = _SOAAssignVisitor()
         nodes = []
         for child in node.targets:
-            rope.base.ast.walk_visitor(child, visitor)
+            visitor.visit(child)
             nodes.extend(visitor.nodes)
         self._evaluate_assign_value(node, nodes)
 

--- a/rope/base/oi/soa.py
+++ b/rope/base/oi/soa.py
@@ -33,7 +33,7 @@ def _analyze_node(pycore, pydefined, should_analyze, search_subscopes, followed_
         if not followed_calls:
             _follow = None
         visitor = SOAVisitor(pycore, pydefined, _follow)
-        for child in rope.base.ast.get_child_nodes(pydefined.get_ast()):
+        for child in rope.base.ast.iter_child_nodes(pydefined.get_ast()):
             rope.base.ast.walk_visitor(child, visitor)
 
 
@@ -51,7 +51,7 @@ class SOAVisitor:
         pass
 
     def _Call(self, node):
-        for child in rope.base.ast.get_child_nodes(node):
+        for child in rope.base.ast.iter_child_nodes(node):
             rope.base.ast.walk_visitor(child, self)
         primary, pyname = evaluate.eval_node2(self.scope, node.func)
         if pyname is None:
@@ -99,7 +99,7 @@ class SOAVisitor:
         ]
 
     def _AnnAssign(self, node):
-        for child in rope.base.ast.get_child_nodes(node):
+        for child in rope.base.ast.iter_child_nodes(node):
             rope.base.ast.walk_visitor(child, self)
         visitor = _SOAAssignVisitor()
         nodes = []
@@ -110,7 +110,7 @@ class SOAVisitor:
         self._evaluate_assign_value(node, nodes, type_hint=node.annotation)
 
     def _Assign(self, node):
-        for child in rope.base.ast.get_child_nodes(node):
+        for child in rope.base.ast.iter_child_nodes(node):
             rope.base.ast.walk_visitor(child, self)
         visitor = _SOAAssignVisitor()
         nodes = []

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -244,7 +244,7 @@ class PyDefinedObject:
             return {}
         new_visitor = self.visitor_class(self.pycore, self)
         for child in ast.iter_child_nodes(self.ast_node):
-            ast.walk_visitor(child, new_visitor)
+            new_visitor.visit(child)
         self.defineds = new_visitor.defineds
         return new_visitor.names
 

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -243,7 +243,7 @@ class PyDefinedObject:
         if self.visitor_class is None:
             return {}
         new_visitor = self.visitor_class(self.pycore, self)
-        for child in ast.get_child_nodes(self.ast_node):
+        for child in ast.iter_child_nodes(self.ast_node):
             ast.walk_visitor(child, new_visitor)
         self.defineds = new_visitor.defineds
         return new_visitor.names

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -244,7 +244,7 @@ class PyDefinedObject:
             return {}
         new_visitor = self.visitor_class(self.pycore, self)
         for child in ast.get_child_nodes(self.ast_node):
-            ast.walk(child, new_visitor)
+            ast.walk_visitor(child, new_visitor)
         self.defineds = new_visitor.defineds
         return new_visitor.names
 

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -599,7 +599,7 @@ class _ClassVisitor(_ScopeVisitor):
             if isinstance(first, ast.arg):
                 new_visitor = _ClassInitVisitor(self, first.arg)
             if new_visitor is not None:
-                for child in ast.get_child_nodes(node):
+                for child in ast.iter_child_nodes(node):
                     ast.walk_visitor(child, new_visitor)
 
 
@@ -642,7 +642,7 @@ class _ClassInitVisitor(_AssignVisitor):
     def _Tuple(self, node):
         if not isinstance(node.ctx, ast.Store):
             return
-        for child in ast.get_child_nodes(node):
+        for child in ast.iter_child_nodes(node):
             ast.walk_visitor(child, self)
 
     def _Name(self, node):

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -301,7 +301,7 @@ class _AnnAssignVisitor:
         self.assigned_ast = node.value
         self.type_hint = node.annotation
 
-        ast.walk(node.target, self)
+        ast.walk_visitor(node.target, self)
 
     def _assigned(self, name, assignment=None):
         self.scope_visitor._assigned(name, assignment)
@@ -356,8 +356,8 @@ class _ExpressionVisitor:
         self._GeneratorExp(node)
 
     def _NamedExpr(self, node):
-        ast.walk(node.target, _AssignVisitor(self))
-        ast.walk(node.value, self)
+        ast.walk_visitor(node.target, _AssignVisitor(self))
+        ast.walk_visitor(node.value, self)
 
 
 class _AssignVisitor:
@@ -368,8 +368,8 @@ class _AssignVisitor:
     def _Assign(self, node):
         self.assigned_ast = node.value
         for child_node in node.targets:
-            ast.walk(child_node, self)
-        ast.walk(node.value, _ExpressionVisitor(self.scope_visitor))
+            ast.walk_visitor(child_node, self)
+        ast.walk_visitor(node.value, _ExpressionVisitor(self.scope_visitor))
 
     def _assigned(self, name, assignment=None):
         self.scope_visitor._assigned(name, assignment)
@@ -446,10 +446,10 @@ class _ScopeVisitor(_ExpressionVisitor):
         return self._FunctionDef(node)
 
     def _Assign(self, node):
-        ast.walk(node, _AssignVisitor(self))
+        ast.walk_visitor(node, _AssignVisitor(self))
 
     def _AnnAssign(self, node):
-        ast.walk(node, _AnnAssignVisitor(self))
+        ast.walk_visitor(node, _AnnAssignVisitor(self))
 
     def _AugAssign(self, node):
         pass
@@ -457,7 +457,7 @@ class _ScopeVisitor(_ExpressionVisitor):
     def _For(self, node):
         self._update_evaluated(node.target, node.iter, ".__iter__().next()")
         for child in node.body + node.orelse:
-            ast.walk(child, self)
+            ast.walk_visitor(child, self)
 
     def _AsyncFor(self, node):
         return self._For(node)
@@ -494,7 +494,7 @@ class _ScopeVisitor(_ExpressionVisitor):
                     item.optional_vars, item.context_expr, ".__enter__()"
                 )
         for child in node.body:
-            ast.walk(child, self)
+            ast.walk_visitor(child, self)
 
     def _AsyncWith(self, node):
         return self._With(node)
@@ -508,7 +508,7 @@ class _ScopeVisitor(_ExpressionVisitor):
             self._update_evaluated(node.name, type_node, eval_type=True)
 
         for child in node.body:
-            ast.walk(child, self)
+            ast.walk_visitor(child, self)
 
     def _ExceptHandler(self, node):
         self._excepthandler(node)
@@ -571,8 +571,8 @@ class _ScopeVisitor(_ExpressionVisitor):
 
 class _ComprehensionVisitor(_ScopeVisitor):
     def _comprehension(self, node):
-        ast.walk(node.target, self)
-        ast.walk(node.iter, self)
+        ast.walk_visitor(node.target, self)
+        ast.walk_visitor(node.iter, self)
 
     def _Name(self, node):
         if isinstance(node.ctx, ast.Store):
@@ -600,7 +600,7 @@ class _ClassVisitor(_ScopeVisitor):
                 new_visitor = _ClassInitVisitor(self, first.arg)
             if new_visitor is not None:
                 for child in ast.get_child_nodes(node):
-                    ast.walk(child, new_visitor)
+                    ast.walk_visitor(child, new_visitor)
 
 
 class _FunctionVisitor(_ScopeVisitor):
@@ -643,7 +643,7 @@ class _ClassInitVisitor(_AssignVisitor):
         if not isinstance(node.ctx, ast.Store):
             return
         for child in ast.get_child_nodes(node):
-            ast.walk(child, self)
+            ast.walk_visitor(child, self)
 
     def _Name(self, node):
         pass

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -356,7 +356,7 @@ class _ExpressionVisitor(ast.RopeNodeVisitor):
         self._GeneratorExp(node)
 
     def _NamedExpr(self, node):
-        _AssignVisitor(self).visit(node.target, )
+        _AssignVisitor(self).visit(node.target)
         self.visit(node.value)
 
 
@@ -369,7 +369,7 @@ class _AssignVisitor(ast.RopeNodeVisitor):
         self.assigned_ast = node.value
         for child_node in node.targets:
             self.visit(child_node)
-        _ExpressionVisitor(self.scope_visitor).visit(node.value, )
+        _ExpressionVisitor(self.scope_visitor).visit(node.value)
 
     def _assigned(self, name, assignment=None):
         self.scope_visitor._assigned(name, assignment)

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -291,7 +291,7 @@ class PyPackage(pyobjects.PyPackage):
         return rope.base.libutils.modname(self.resource) if self.resource else ""
 
 
-class _AnnAssignVisitor:
+class _AnnAssignVisitor(ast.RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
         self.assigned_ast = None
@@ -301,7 +301,7 @@ class _AnnAssignVisitor:
         self.assigned_ast = node.value
         self.type_hint = node.annotation
 
-        ast.walk_visitor(node.target, self)
+        self.visit(node.target)
 
     def _assigned(self, name, assignment=None):
         self.scope_visitor._assigned(name, assignment)
@@ -333,7 +333,7 @@ class _AnnAssignVisitor:
         pass
 
 
-class _ExpressionVisitor:
+class _ExpressionVisitor(ast.RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
 
@@ -356,11 +356,11 @@ class _ExpressionVisitor:
         self._GeneratorExp(node)
 
     def _NamedExpr(self, node):
-        ast.walk_visitor(node.target, _AssignVisitor(self))
-        ast.walk_visitor(node.value, self)
+        _AssignVisitor(self).visit(node.target, )
+        self.visit(node.value)
 
 
-class _AssignVisitor:
+class _AssignVisitor(ast.RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
         self.assigned_ast = None
@@ -368,8 +368,8 @@ class _AssignVisitor:
     def _Assign(self, node):
         self.assigned_ast = node.value
         for child_node in node.targets:
-            ast.walk_visitor(child_node, self)
-        ast.walk_visitor(node.value, _ExpressionVisitor(self.scope_visitor))
+            self.visit(child_node)
+        _ExpressionVisitor(self.scope_visitor).visit(node.value, )
 
     def _assigned(self, name, assignment=None):
         self.scope_visitor._assigned(name, assignment)
@@ -446,10 +446,10 @@ class _ScopeVisitor(_ExpressionVisitor):
         return self._FunctionDef(node)
 
     def _Assign(self, node):
-        ast.walk_visitor(node, _AssignVisitor(self))
+        _AssignVisitor(self).visit(node)
 
     def _AnnAssign(self, node):
-        ast.walk_visitor(node, _AnnAssignVisitor(self))
+        _AnnAssignVisitor(self).visit(node)
 
     def _AugAssign(self, node):
         pass
@@ -457,7 +457,7 @@ class _ScopeVisitor(_ExpressionVisitor):
     def _For(self, node):
         self._update_evaluated(node.target, node.iter, ".__iter__().next()")
         for child in node.body + node.orelse:
-            ast.walk_visitor(child, self)
+            self.visit(child)
 
     def _AsyncFor(self, node):
         return self._For(node)
@@ -494,7 +494,7 @@ class _ScopeVisitor(_ExpressionVisitor):
                     item.optional_vars, item.context_expr, ".__enter__()"
                 )
         for child in node.body:
-            ast.walk_visitor(child, self)
+            self.visit(child)
 
     def _AsyncWith(self, node):
         return self._With(node)
@@ -508,7 +508,7 @@ class _ScopeVisitor(_ExpressionVisitor):
             self._update_evaluated(node.name, type_node, eval_type=True)
 
         for child in node.body:
-            ast.walk_visitor(child, self)
+            self.visit(child)
 
     def _ExceptHandler(self, node):
         self._excepthandler(node)
@@ -571,8 +571,8 @@ class _ScopeVisitor(_ExpressionVisitor):
 
 class _ComprehensionVisitor(_ScopeVisitor):
     def _comprehension(self, node):
-        ast.walk_visitor(node.target, self)
-        ast.walk_visitor(node.iter, self)
+        self.visit(node.target)
+        self.visit(node.iter)
 
     def _Name(self, node):
         if isinstance(node.ctx, ast.Store):
@@ -600,7 +600,7 @@ class _ClassVisitor(_ScopeVisitor):
                 new_visitor = _ClassInitVisitor(self, first.arg)
             if new_visitor is not None:
                 for child in ast.iter_child_nodes(node):
-                    ast.walk_visitor(child, new_visitor)
+                    new_visitor.visit(child)
 
 
 class _FunctionVisitor(_ScopeVisitor):
@@ -643,7 +643,7 @@ class _ClassInitVisitor(_AssignVisitor):
         if not isinstance(node.ctx, ast.Store):
             return
         for child in ast.iter_child_nodes(node):
-            ast.walk_visitor(child, self)
+            self.visit(child)
 
     def _Name(self, node):
         pass

--- a/rope/base/pyscopes.py
+++ b/rope/base/pyscopes.py
@@ -187,7 +187,7 @@ class ComprehensionScope(Scope):
         if self.names is None:
             new_visitor = self.visitor(self.pycore, self.pyobject)
             for node in ast.iter_child_nodes(self.pyobject.get_ast()):
-                ast.walk_visitor(node, new_visitor)
+                new_visitor.visit(node)
             self.names = dict(self.parent.get_names())
             self.names.update(new_visitor.names)
             self.defineds = new_visitor.defineds
@@ -219,7 +219,7 @@ class FunctionScope(Scope):
         if self.names is None:
             new_visitor = self.visitor(self.pycore, self.pyobject)
             for n in ast.iter_child_nodes(self.pyobject.get_ast()):
-                ast.walk_visitor(n, new_visitor)
+                new_visitor.visit(n)
             self.names = new_visitor.names
             self.names.update(self.pyobject.get_parameters())
             self.returned_asts = new_visitor.returned_asts

--- a/rope/base/pyscopes.py
+++ b/rope/base/pyscopes.py
@@ -187,7 +187,7 @@ class ComprehensionScope(Scope):
         if self.names is None:
             new_visitor = self.visitor(self.pycore, self.pyobject)
             for node in ast.get_child_nodes(self.pyobject.get_ast()):
-                ast.walk(node, new_visitor)
+                ast.walk_visitor(node, new_visitor)
             self.names = dict(self.parent.get_names())
             self.names.update(new_visitor.names)
             self.defineds = new_visitor.defineds
@@ -219,7 +219,7 @@ class FunctionScope(Scope):
         if self.names is None:
             new_visitor = self.visitor(self.pycore, self.pyobject)
             for n in ast.get_child_nodes(self.pyobject.get_ast()):
-                ast.walk(n, new_visitor)
+                ast.walk_visitor(n, new_visitor)
             self.names = new_visitor.names
             self.names.update(self.pyobject.get_parameters())
             self.returned_asts = new_visitor.returned_asts

--- a/rope/base/pyscopes.py
+++ b/rope/base/pyscopes.py
@@ -186,7 +186,7 @@ class ComprehensionScope(Scope):
     def _visit_comprehension(self):
         if self.names is None:
             new_visitor = self.visitor(self.pycore, self.pyobject)
-            for node in ast.get_child_nodes(self.pyobject.get_ast()):
+            for node in ast.iter_child_nodes(self.pyobject.get_ast()):
                 ast.walk_visitor(node, new_visitor)
             self.names = dict(self.parent.get_names())
             self.names.update(new_visitor.names)
@@ -218,7 +218,7 @@ class FunctionScope(Scope):
     def _visit_function(self):
         if self.names is None:
             new_visitor = self.visitor(self.pycore, self.pyobject)
-            for n in ast.get_child_nodes(self.pyobject.get_ast()):
+            for n in ast.iter_child_nodes(self.pyobject.get_ast()):
                 ast.walk_visitor(n, new_visitor)
             self.names = new_visitor.names
             self.names.update(self.pyobject.get_parameters())

--- a/rope/contrib/finderrors.py
+++ b/rope/contrib/finderrors.py
@@ -33,7 +33,7 @@ def find_errors(project, resource):
     """
     pymodule = project.get_pymodule(resource)
     finder = _BadAccessFinder(pymodule)
-    ast.walk(pymodule.get_ast(), finder)
+    ast.walk_visitor(pymodule.get_ast(), finder)
     return finder.errors
 
 
@@ -60,7 +60,7 @@ class _BadAccessFinder:
             if pyname is not None and pyname.get_object() != pyobjects.get_unknown():
                 if node.attr not in pyname.get_object():
                     self._add_error(node, "Unresolved attribute")
-        ast.walk(node.value, self)
+        ast.walk_visitor(node.value, self)
 
     def _add_error(self, node, msg):
         if isinstance(node, ast.Attribute):

--- a/rope/contrib/finderrors.py
+++ b/rope/contrib/finderrors.py
@@ -33,11 +33,11 @@ def find_errors(project, resource):
     """
     pymodule = project.get_pymodule(resource)
     finder = _BadAccessFinder(pymodule)
-    ast.walk_visitor(pymodule.get_ast(), finder)
+    finder.visit(pymodule.get_ast())
     return finder.errors
 
 
-class _BadAccessFinder:
+class _BadAccessFinder(ast.RopeNodeVisitor):
     def __init__(self, pymodule):
         self.pymodule = pymodule
         self.scope = pymodule.get_scope()
@@ -60,7 +60,7 @@ class _BadAccessFinder:
             if pyname is not None and pyname.get_object() != pyobjects.get_unknown():
                 if node.attr not in pyname.get_object():
                     self._add_error(node, "Unresolved attribute")
-        ast.walk_visitor(node.value, self)
+        self.visit(node.value)
 
     def _add_error(self, node, msg):
         if isinstance(node, ast.Attribute):

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -882,7 +882,7 @@ class _FunctionInformationCollector:
         written = OrderedSet(self.written)
         maybe_written = OrderedSet(self.maybe_written)
 
-        for child in ast.get_child_nodes(node):
+        for child in ast.iter_child_nodes(node):
             ast.walk_visitor(child, self)
 
         comp_names = list(
@@ -924,7 +924,7 @@ class _FunctionInformationCollector:
 
     def _handle_conditional_node(self, node):
         with self._handle_conditional_context(node):
-            for child in ast.get_child_nodes(node):
+            for child in ast.iter_child_nodes(node):
                 ast.walk_visitor(child, self)
 
     @contextmanager
@@ -969,7 +969,7 @@ class _VariableReadsAndWritesFinder:
     def _FunctionDef(self, node):
         self.written.add(node.name)
         visitor = _VariableReadsAndWritesFinder()
-        for child in ast.get_child_nodes(node):
+        for child in ast.iter_child_nodes(node):
             ast.walk_visitor(child, visitor)
         self.read.update(visitor.read - visitor.written)
 

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -427,7 +427,7 @@ class _UnboundNameFinder:
             .pyobject
         )
         visitor = _LocalUnboundNameFinder(pyobject, self)
-        for child in ast.get_child_nodes(node):
+        for child in ast.iter_child_nodes(node):
             ast.walk_visitor(child, visitor)
 
     def _FunctionDef(self, node):

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -26,7 +26,7 @@ class ModuleImports:
 
     def _get_unbound_names(self, defined_pyobject):
         visitor = _GlobalUnboundNameFinder(self.pymodule, defined_pyobject)
-        ast.walk_visitor(self.pymodule.get_ast(), visitor)
+        visitor.visit(self.pymodule.get_ast())
         return visitor.unbound
 
     def _get_all_star_list(self, pymodule):
@@ -415,7 +415,7 @@ class _OneTimeSelector:
         return False
 
 
-class _UnboundNameFinder:
+class _UnboundNameFinder(ast.RopeNodeVisitor):
     def __init__(self, pyobject):
         self.pyobject = pyobject
 
@@ -428,7 +428,7 @@ class _UnboundNameFinder:
         )
         visitor = _LocalUnboundNameFinder(pyobject, self)
         for child in ast.iter_child_nodes(node):
-            ast.walk_visitor(child, visitor)
+            visitor.visit(child)
 
     def _FunctionDef(self, node):
         self._visit_child_scope(node)
@@ -453,7 +453,7 @@ class _UnboundNameFinder:
             ):
                 self.add_unbound(primary)
         else:
-            ast.walk_visitor(node, self)
+            self.visit(node)
 
     def _get_root(self):
         pass

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -26,7 +26,7 @@ class ModuleImports:
 
     def _get_unbound_names(self, defined_pyobject):
         visitor = _GlobalUnboundNameFinder(self.pymodule, defined_pyobject)
-        ast.walk(self.pymodule.get_ast(), visitor)
+        ast.walk_visitor(self.pymodule.get_ast(), visitor)
         return visitor.unbound
 
     def _get_all_star_list(self, pymodule):
@@ -428,7 +428,7 @@ class _UnboundNameFinder:
         )
         visitor = _LocalUnboundNameFinder(pyobject, self)
         for child in ast.get_child_nodes(node):
-            ast.walk(child, visitor)
+            ast.walk_visitor(child, visitor)
 
     def _FunctionDef(self, node):
         self._visit_child_scope(node)
@@ -453,7 +453,7 @@ class _UnboundNameFinder:
             ):
                 self.add_unbound(primary)
         else:
-            ast.walk(node, self)
+            ast.walk_visitor(node, self)
 
     def _get_root(self):
         pass

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -90,7 +90,7 @@ class _PatchingASTWalker:
         )
         node.region = (self.source.offset, self.source.offset)
         if self.children:
-            node.sorted_children = ast.get_children(node)
+            node.sorted_children = [child for field, child in ast.iter_fields(node)]
 
     def _handle(self, node, base_children, eat_parens=False, eat_spaces=False):
         if hasattr(node, "region"):

--- a/rope/refactor/restructure.py
+++ b/rope/refactor/restructure.py
@@ -310,7 +310,7 @@ class _ChangeComputer:
     def _get_nearest_roots(self, node):
         if node not in self._nearest_roots:
             result = []
-            for child in ast.get_child_nodes(node):
+            for child in ast.iter_child_nodes(node):
                 if child in self.matched_asts:
                     result.append(child)
                 else:

--- a/rope/refactor/similarfinder.py
+++ b/rope/refactor/similarfinder.py
@@ -2,8 +2,7 @@
 import re
 
 import rope.refactor.wildcards
-from rope.base import libutils
-from rope.base import codeanalyze, exceptions, ast, builtins
+from rope.base import libutils, codeanalyze, exceptions, ast, builtins
 from rope.refactor import patchedast, wildcards
 
 from rope.refactor.patchedast import MismatchedTokenError
@@ -169,7 +168,7 @@ class _ASTMatcher:
             self.matches.append(ExpressionMatch(node, mapping))
 
     def _check_statements(self, node):
-        for child in ast.get_children(node):
+        for field, child in ast.iter_fields(node):
             if isinstance(child, (list, tuple)):
                 self.__check_stmt_list(child)
 
@@ -211,8 +210,11 @@ class _ASTMatcher:
 
     def _get_children(self, node):
         """Return not `ast.expr_context` children of `node`"""
-        children = ast.get_children(node)
-        return [child for child in children if not isinstance(child, ast.expr_context)]
+        return [
+            child
+            for field, child in ast.iter_fields(node)
+            if not isinstance(child, ast.expr_context)
+        ]
 
     def _match_stmts(self, current_stmts, mapping):
         if len(current_stmts) != len(self.pattern):

--- a/rope/refactor/suites.py
+++ b/rope/refactor/suites.py
@@ -71,7 +71,7 @@ class Suite:
         if self._children is None:
             walker = _SuiteWalker(self)
             for child in self.child_nodes:
-                ast.walk(child, walker)
+                ast.walk_visitor(child, walker)
             self._children = walker.suites
         return self._children
 

--- a/rope/refactor/suites.py
+++ b/rope/refactor/suites.py
@@ -71,7 +71,7 @@ class Suite:
         if self._children is None:
             walker = _SuiteWalker(self)
             for child in self.child_nodes:
-                ast.walk_visitor(child, walker)
+                walker.visit(child)
             self._children = walker.suites
         return self._children
 
@@ -98,7 +98,7 @@ class Suite:
         return self.parent._get_level() + 1
 
 
-class _SuiteWalker:
+class _SuiteWalker(ast.RopeNodeVisitor):
     def __init__(self, suite):
         self.suite = suite
         self.suites = []

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -199,4 +199,4 @@ class _ReturnOrYieldFinder:
         if isinstance(node, ast.FunctionDef):
             nodes = ast.get_child_nodes(node)
         for child in nodes:
-            ast.walk(child, self)
+            ast.walk_visitor(child, self)

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -173,7 +173,7 @@ def _named_expr_count(node):
     return visitor.named_expression
 
 
-class _ReturnOrYieldFinder:
+class _ReturnOrYieldFinder(ast.RopeNodeVisitor):
     def __init__(self):
         self.returns = 0
         self.named_expression = 0
@@ -199,4 +199,4 @@ class _ReturnOrYieldFinder:
         if isinstance(node, ast.FunctionDef):
             nodes = list(ast.iter_child_nodes(node))
         for child in nodes:
-            ast.walk_visitor(child, self)
+            self.visit(child)

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -197,6 +197,6 @@ class _ReturnOrYieldFinder:
     def start_walking(self, node):
         nodes = [node]
         if isinstance(node, ast.FunctionDef):
-            nodes = ast.get_child_nodes(node)
+            nodes = list(ast.iter_child_nodes(node))
         for child in nodes:
             ast.walk_visitor(child, self)


### PR DESCRIPTION
# Description

- Remove `rope.base.ast.walk()`
- Remove `rope.base.ast.get_children()`
- Remove `rope.base.ast.get_child_nodes()`

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
