### PR TITLE
PR: Simplify annotations in pynames.py

### DIFF
--- a/rope/base/pynames.py
+++ b/rope/base/pynames.py
@@ -1,16 +1,17 @@
-# These imports are tricky. It's easy to cause circular imports.
-from __future__ import annotations
-
-import typing
+from typing import Any, Union, TYPE_CHECKING
 
 import rope.base.pyobjects
 from rope.base import exceptions, utils
 
 
-if typing.TYPE_CHECKING:
-    # pyobjectsdef appears only in annotations.
-    from typing import Union
+if TYPE_CHECKING:
     from rope.base import pyobjectsdef
+
+    PyModule = pyobjectsdef.PyModule
+    PyPackage = pyobjectsdef.PyPackage
+else:
+    PyModule = Any
+    PyPackage = Any
 
 
 class PyName:
@@ -109,10 +110,7 @@ class ParameterName(PyName):
 class ImportedModule(PyName):
     def __init__(
         self,
-        importing_module: Union[
-            pyobjectsdef.PyModule,
-            pyobjectsdef.PyPackage,
-        ],
+        importing_module: Union[PyModule, PyPackage],
         module_name=None,
         level=0,
         resource=None,


### PR DESCRIPTION
`pynames.py` drew my attention because of the statement `from __future__ import annotations`.

Initial attempts to simplify the imports failed because of circular references. Then I remembered the pattern I use throughout Leo:

```python
from typing import Any, TYPE_CHECKING  # And any other type constants.

if TYPE_CHECKING:
    # Import any modules used only by the annotations.
    # Define the "real" (extra) annotations.
else:
    # Set all extra annotations to Any.
    # Note: mypy seems to want each annotation to be on a separate line.
```

This pattern is guarranteed to work provided the annotations do not clash with other symbols in the file. I don't recall a single place in Leo's code base where this pattern caused any problems.