### PR TITLE
PR: Again!  Disambiguate rope.base.ast and stdlib.ast

### DIFF
--- a/rope/base/arguments.py
+++ b/rope/base/arguments.py
@@ -1,5 +1,6 @@
+import ast
+
 import rope.base.evaluate
-from rope.base import ast
 
 
 class Arguments:

--- a/rope/base/builtins.py
+++ b/rope/base/builtins.py
@@ -1,11 +1,11 @@
 """This module tries to support builtin types and functions."""
+import ast
 import inspect
 import io
 
 import rope.base.evaluate
 from rope.base import (
     arguments,
-    ast,
     pynames,
     pyobjects,
     utils,

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -1,3 +1,4 @@
+import ast
 from operator import itemgetter
 from typing import Optional, Tuple
 
@@ -6,11 +7,11 @@ import rope.base.pynames
 import rope.base.pyobjects
 from rope.base import (
     arguments,
-    ast,
     nameanalyze,
     exceptions,
     pyobjects,
     pyobjectsdef,
+    rast,
     worder,
 )
 
@@ -50,7 +51,7 @@ def eval_str(holding_scope, name):
 def eval_str2(holding_scope, name):
     try:
         # parenthesizing for handling cases like 'a_var.\nattr'
-        node = ast.parse("(%s)" % name)
+        node = rast.parse("(%s)" % name)
     except SyntaxError:
         raise BadIdentifierError("Not a resolvable python identifier selected.")
     return eval_node2(holding_scope, node)
@@ -158,7 +159,7 @@ class ScopeNameFinder:
         )
 
 
-class StatementEvaluator(ast.RopeNodeVisitor):
+class StatementEvaluator(rast.RopeNodeVisitor):
     def __init__(self, scope):
         self.scope = scope
         self.result = None

--- a/rope/base/nameanalyze.py
+++ b/rope/base/nameanalyze.py
@@ -1,4 +1,6 @@
-from rope.base import ast
+import ast
+
+from rope.base import rast
 
 
 def get_name_levels(node):
@@ -18,7 +20,7 @@ def get_name_levels(node):
     return visitor.names
 
 
-class _NodeNameCollector(ast.RopeNodeVisitor):
+class _NodeNameCollector(rast.RopeNodeVisitor):
     def __init__(self, levels=None):
         self.names = []
         self.levels = levels

--- a/rope/base/oi/soa.py
+++ b/rope/base/oi/soa.py
@@ -32,7 +32,7 @@ def _analyze_node(pycore, pydefined, should_analyze, search_subscopes, followed_
             )
 
         visitor = SOAVisitor(pycore, pydefined, _follow if followed_calls else None)
-        for child in rope.base.ast.iter_child_nodes(pydefined.get_ast()):
+        for child in ast.iter_child_nodes(pydefined.get_ast()):
             visitor.visit(child)
 
 

--- a/rope/base/oi/type_hinting/providers/numpydocstrings.py
+++ b/rope/base/oi/type_hinting/providers/numpydocstrings.py
@@ -3,7 +3,7 @@ Some code extracted (or based on code) from:
 https://github.com/davidhalter/jedi/blob/b489019f5bd5750051122b94cc767df47751ecb7/jedi/evaluate/docstrings.py
 Thanks to @davidhalter for this utils under MIT License.
 """
-from ast import literal_eval
+import ast
 import re
 
 from rope.base.oi.type_hinting.providers import docstrings
@@ -27,7 +27,7 @@ class NumPyDocstringParamParser(docstrings.IParamParser):
                     p_type = m.group(1)
 
                 if p_type.startswith("{"):
-                    types = {type(x).__name__ for x in literal_eval(p_type)}
+                    types = {type(x).__name__ for x in ast.literal_eval(p_type)}
                     return list(types)
                 else:
                     return [p_type]

--- a/rope/base/oi/type_hinting/providers/numpydocstrings.py
+++ b/rope/base/oi/type_hinting/providers/numpydocstrings.py
@@ -3,8 +3,9 @@ Some code extracted (or based on code) from:
 https://github.com/davidhalter/jedi/blob/b489019f5bd5750051122b94cc767df47751ecb7/jedi/evaluate/docstrings.py
 Thanks to @davidhalter for this utils under MIT License.
 """
+from ast import literal_eval
 import re
-from rope.base.ast import literal_eval
+
 from rope.base.oi.type_hinting.providers import docstrings
 
 try:

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -1,6 +1,7 @@
+import ast
 from typing import Optional
 
-from rope.base import ast, exceptions, utils
+from rope.base import exceptions, utils
 
 
 class PyObject:

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -1,3 +1,5 @@
+import ast
+
 import rope.base.builtins
 import rope.base.codeanalyze
 import rope.base.evaluate
@@ -7,7 +9,7 @@ import rope.base.pyscopes
 from rope.base import (
     pynamesdef,
     exceptions,
-    ast,
+    rast,
     nameanalyze,
     pyobjects,
     fscommands,
@@ -177,7 +179,7 @@ class PyModule(pyobjects.PyModule):
                 raise
             else:
                 source = "\n"
-                node = ast.parse("\n")
+                node = rast.parse("\n")
         self.source_code = source
         self.star_imports = []
         self.visitor_class = _GlobalVisitor
@@ -197,7 +199,7 @@ class PyModule(pyobjects.PyModule):
                     source_bytes = fscommands.unicode_to_file_data(source_code)
                 else:
                     source_bytes = source_code
-            ast_node = ast.parse(source_bytes, filename=filename)
+            ast_node = rast.parse(source_bytes, filename=filename)
         except SyntaxError as e:
             raise exceptions.ModuleSyntaxError(filename, e.lineno, e.msg)
         except UnicodeDecodeError as e:
@@ -239,7 +241,7 @@ class PyPackage(pyobjects.PyPackage):
                 init_dot_py, force_errors=force_errors
             ).get_ast()
         else:
-            ast_node = ast.parse("\n")
+            ast_node = rast.parse("\n")
         super().__init__(pycore, ast_node, resource)
 
     def _create_structural_attributes(self):
@@ -291,7 +293,7 @@ class PyPackage(pyobjects.PyPackage):
         return rope.base.libutils.modname(self.resource) if self.resource else ""
 
 
-class _AnnAssignVisitor(ast.RopeNodeVisitor):
+class _AnnAssignVisitor(rast.RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
         self.assigned_ast = None
@@ -333,7 +335,7 @@ class _AnnAssignVisitor(ast.RopeNodeVisitor):
         pass
 
 
-class _ExpressionVisitor(ast.RopeNodeVisitor):
+class _ExpressionVisitor(rast.RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
 
@@ -360,7 +362,7 @@ class _ExpressionVisitor(ast.RopeNodeVisitor):
         self.visit(node.value)
 
 
-class _AssignVisitor(ast.RopeNodeVisitor):
+class _AssignVisitor(rast.RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
         self.assigned_ast = None

--- a/rope/base/pyscopes.py
+++ b/rope/base/pyscopes.py
@@ -1,6 +1,7 @@
+import ast
+
 import rope.base.builtins  # Use full qualification for clarity.
 from rope.base import (
-    ast,
     codeanalyze,
     exceptions,
     pynames,

--- a/rope/base/rast.py
+++ b/rope/base/rast.py
@@ -1,5 +1,4 @@
 import ast
-from ast import *  # noqa: F401,F403
 
 from rope.base import fscommands
 

--- a/rope/contrib/autoimport/parse.py
+++ b/rope/contrib/autoimport/parse.py
@@ -4,6 +4,7 @@ Functions to find importable names.
 Can extract names from source code of a python file, .so object, or builtin module.
 """
 
+import ast
 import inspect
 import logging
 import pathlib
@@ -20,7 +21,6 @@ from .defs import (
     PartialName,
     Source,
 )
-from rope.base import ast
 
 
 logger = logging.getLogger(__name__)

--- a/rope/contrib/finderrors.py
+++ b/rope/contrib/finderrors.py
@@ -23,7 +23,9 @@ TODO:
 * ... ;-)
 
 """
-from rope.base import ast, evaluate, pyobjects
+import ast
+
+from rope.base import evaluate, pyobjects, rast
 
 
 def find_errors(project, resource):
@@ -37,7 +39,7 @@ def find_errors(project, resource):
     return finder.errors
 
 
-class _BadAccessFinder(ast.RopeNodeVisitor):
+class _BadAccessFinder(rast.RopeNodeVisitor):
     def __init__(self, pymodule):
         self.pymodule = pymodule
         self.scope = pymodule.get_scope()

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -1,8 +1,9 @@
+import ast
 import re
 from contextlib import contextmanager
 from itertools import chain
 
-from rope.base import ast, codeanalyze
+from rope.base import codeanalyze, rast
 from rope.base.change import ChangeSet, ChangeContents
 from rope.base.exceptions import RefactoringError
 from rope.base.utils.datastructures import OrderedSet
@@ -514,7 +515,7 @@ class _ExceptionalConditionChecker:
         return next.isalnum() or next == "_"
 
 
-class _ExtractMethodParts(ast.RopeNodeVisitor):
+class _ExtractMethodParts(rast.RopeNodeVisitor):
     def __init__(self, info):
         self.info = info
         self.info_collector = self._create_info_collector()
@@ -777,7 +778,7 @@ class _ExtractVariableParts:
         return {}
 
 
-class _FunctionInformationCollector(ast.RopeNodeVisitor):
+class _FunctionInformationCollector(rast.RopeNodeVisitor):
     def __init__(self, start, end, is_global):
         self.start = start
         self.end = end
@@ -955,7 +956,7 @@ def _get_argnames(arguments):
     return result
 
 
-class _VariableReadsAndWritesFinder(ast.RopeNodeVisitor):
+class _VariableReadsAndWritesFinder(rast.RopeNodeVisitor):
     def __init__(self):
         self.written = set()
         self.read = set()
@@ -995,7 +996,7 @@ class _VariableReadsAndWritesFinder(ast.RopeNodeVisitor):
         return visitor.read
 
 
-class _BaseErrorFinder(ast.RopeNodeVisitor):
+class _BaseErrorFinder(rast.RopeNodeVisitor):
     @classmethod
     def has_errors(cls, code):
         if code.strip() == "":
@@ -1063,7 +1064,7 @@ class _AsyncStatementFinder(_BaseErrorFinder):
         pass
 
 
-class _GlobalFinder(ast.RopeNodeVisitor):
+class _GlobalFinder(rast.RopeNodeVisitor):
     def __init__(self):
         self.globals_ = OrderedSet()
 

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -1,10 +1,11 @@
+import ast
 from typing import Union, List
 
 from rope.base import (
-    ast,
     exceptions,
     pynames,
     pynamesdef,
+    rast,
     utils,
 )
 from rope.refactor.importutils import actions, importinfo
@@ -421,7 +422,7 @@ class _OneTimeSelector:
         return False
 
 
-class _UnboundNameFinder(ast.RopeNodeVisitor):
+class _UnboundNameFinder(rast.RopeNodeVisitor):
     def __init__(self, pyobject):
         self.pyobject = pyobject
 
@@ -560,7 +561,7 @@ class _GlobalImportFinder:
         if node.level:
             level = node.level
         import_info = importinfo.FromImport(
-            node.module or "",  # see comment at rope.base.ast.walk
+            node.module or "",  ### Huh? see comment at rope.base.ast.walk
             level,
             self._get_names(node.names),
         )

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -561,7 +561,7 @@ class _GlobalImportFinder:
         if node.level:
             level = node.level
         import_info = importinfo.FromImport(
-            node.module or "",  ### Huh? see comment at rope.base.ast.walk
+            node.module or "",
             level,
             self._get_names(node.names),
         )

--- a/rope/refactor/occurrences.py
+++ b/rope/refactor/occurrences.py
@@ -35,9 +35,9 @@ calling the `create_finder()` function.
     arguments
 """
 
+import ast
 import re
 
-from rope.base import ast
 from rope.base import codeanalyze
 from rope.base import evaluate
 from rope.base import exceptions

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -1,10 +1,11 @@
+import ast
 import collections
 import numbers
 import re
 import warnings
 from itertools import chain
 
-from rope.base import ast, codeanalyze, exceptions
+from rope.base import codeanalyze, exceptions, rast
 
 
 COMMA_IN_WITH_PATTERN = re.compile(r"\(.*?\)|(,)")
@@ -35,7 +36,7 @@ def patch_ast(node, source, sorted_children=False):
     if hasattr(node, "region"):
         return node
     walker = _PatchingASTWalker(source, children=sorted_children)
-    ast.call_for_nodes(node, walker)
+    rast.call_for_nodes(node, walker)
     return node
 
 
@@ -115,7 +116,7 @@ class _PatchingASTWalker:
                 continue
             offset = self.source.offset
             if isinstance(child, ast.AST):
-                ast.call_for_nodes(child, self)
+                rast.call_for_nodes(child, self)
                 token_start = child.region[0]
             else:
                 if child is self.String:

--- a/rope/refactor/restructure.py
+++ b/rope/refactor/restructure.py
@@ -1,6 +1,7 @@
+import ast
 import warnings
 
-from rope.base import change, taskhandle, builtins, ast, codeanalyze
+from rope.base import change, taskhandle, builtins, codeanalyze
 from rope.base import libutils
 from rope.refactor import patchedast, similarfinder, sourceutils
 from rope.refactor.importutils import module_imports

--- a/rope/refactor/similarfinder.py
+++ b/rope/refactor/similarfinder.py
@@ -1,13 +1,14 @@
 """This module can be used for finding similar code"""
+import ast
 import re
 
 import rope.base.builtins  # Use full qualification for clarity.
 import rope.refactor.wildcards  # Use full qualification for clarity.
 from rope.base import (
-    ast,
     codeanalyze,
     exceptions,
     libutils,
+    rast,
 )
 from rope.refactor import patchedast
 from rope.refactor.patchedast import MismatchedTokenError
@@ -158,7 +159,7 @@ class _ASTMatcher:
     def find_matches(self):
         if self.matches is None:
             self.matches = []
-            ast.call_for_nodes(self.body, self._check_node, recursive=True)
+            rast.call_for_nodes(self.body, self._check_node, recursive=True)
         return self.matches
 
     def _check_node(self, node):

--- a/rope/refactor/suites.py
+++ b/rope/refactor/suites.py
@@ -1,6 +1,7 @@
+import ast
 from itertools import chain
 
-from rope.base import ast
+from rope.base import rast
 
 
 def find_visible(node, lines):
@@ -98,7 +99,7 @@ class Suite:
         return self.parent._get_level() + 1
 
 
-class _SuiteWalker(ast.RopeNodeVisitor):
+class _SuiteWalker(rast.RopeNodeVisitor):
     def __init__(self, suite):
         self.suite = suite
         self.suites = []

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -1,11 +1,13 @@
+import ast
+
 from rope.base import (
-    ast,
     change,
     evaluate,
     exceptions,
     libutils,
     pynames,
     pyobjects,
+    rast,
     taskhandle,
 )
 from rope.refactor import restructure, sourceutils, similarfinder
@@ -181,7 +183,7 @@ def _named_expr_count(node):
     return visitor.named_expression
 
 
-class _ReturnOrYieldFinder(ast.RopeNodeVisitor):
+class _ReturnOrYieldFinder(rast.RopeNodeVisitor):
     def __init__(self):
         self.returns = 0
         self.named_expression = 0

--- a/rope/refactor/wildcards.py
+++ b/rope/refactor/wildcards.py
@@ -1,4 +1,5 @@
-from rope.base import ast, evaluate, builtins, pyobjects
+import ast
+from rope.base import builtins, evaluate, pyobjects
 from rope.refactor import patchedast, occurrences
 
 

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1,8 +1,9 @@
-import unittest
+import ast
 import sys
 from textwrap import dedent
+import unittest
 
-from rope.base import ast
+from rope.base import rast
 from rope.refactor import patchedast
 from ropetest import testutils
 
@@ -1651,7 +1652,7 @@ class _ResultChecker:
                 return self.result is not None
 
         search = Search()
-        ast.call_for_nodes(self.ast, search, recursive=True)
+        rast.call_for_nodes(self.ast, search, recursive=True)
         return search.result
 
     def check_children(self, text, children):

--- a/ropetest/refactor/suitestest.py
+++ b/ropetest/refactor/suitestest.py
@@ -1,8 +1,7 @@
+import ast
 from textwrap import dedent
-
 import unittest
 
-from rope.base import ast
 from rope.refactor import suites
 from ropetest import testutils
 


### PR DESCRIPTION
See Issue #570 for previous discussions.

This PR disambiguates rope.base.ast and stdlib.ast with small, easily understood, diffs.

- [x] Rename `rope.base.ast` to `rope.base.rast`.
- [x] Remove `from ast import *` from rast.py.
- [x] Use `rast` *only* to access `rast.parse`, `rast.call_for_nodes`, and class `rast.RopeNodeVisitor(ast.NodeVisitor)`
- [x] Add `import ast` statements as needed.
- [x] In numpydocstrings.py, add `ast` qualifier to `literal_eval`.
- [x] In `module_imports`, temporarily mark a dubious comment with `###`.

**Advantages**

- The code makes clear *from immediate context alone* which names come from `stdlib.ast`
    and which names come from `rope.base.rast`.
- The diffs show that there is no cost to this new clarity.
- This PR removes misdirections (lies) based on `rope.base.ast`.
    For example, `rope.base.ast.iter_child_nodes` actually means `ast.iter_child_nodes`!
    This mistake was another legacy of `from ast import *`.
- This PR distinguishes `rast.parse` from `ast.parse`.
- This PR makes it *easier* to wrap `stdlib.ast` should that ever become desirable.
- Eliminating `from ast import *` helps all checker tools.

*Note*: Several of these advantages became clear only after looking at the diffs!

*Note*: It took longer to write this comment than it did to change the code.