### PR TITLE
PR: Remove useless/confusing comments re stdlib.annotations

### DIFF
--- a/rope/base/pynames.py
+++ b/rope/base/pynames.py
@@ -1,6 +1,4 @@
-# These imports are tricky. It's easy to cause circular imports.
 from __future__ import annotations
-
 import typing
 
 import rope.base.pyobjects
@@ -8,7 +6,6 @@ from rope.base import exceptions, utils
 
 
 if typing.TYPE_CHECKING:
-    # pyobjectsdef appears only in annotations.
     from typing import Union
     from rope.base import pyobjectsdef
 


### PR DESCRIPTION
This PR undoes the useless comments re annotations in pynames.py that sneaked in recently.

These comments might well confuse or annoy devs who understand how to use postponed annotations, [PEP 563](https://peps.python.org/pep-0563/).