### PR TITLE
PR Remove 'only_for' decorator for all python versions less than 3.7

### DIFF
--- a/ropetest/codeanalyzetest.py
+++ b/ropetest/codeanalyzetest.py
@@ -734,7 +734,6 @@ class ScopeNameFinderTest(unittest.TestCase):
         found_pyname = name_finder.get_pyname_at(code.index("afunc") + 1)
         self.assertEqual(afunc.get_object(), found_pyname.get_object())
 
-    @testutils.only_for("2.5")
     def test_relative_modules_after_from_statements(self):
         pkg1 = testutils.create_package(self.project, "pkg1")
         pkg2 = testutils.create_package(self.project, "pkg2", pkg1)

--- a/ropetest/pycoretest.py
+++ b/ropetest/pycoretest.py
@@ -569,7 +569,6 @@ class PyCoreTest(unittest.TestCase):
         c_class = pymod["C"].get_object()
         self.assertFalse("var1" in c_class)
 
-    @testutils.only_for("2.5")
     def test_with_statement_variables(self):
         code = dedent("""\
             import threading
@@ -580,7 +579,7 @@ class PyCoreTest(unittest.TestCase):
         pymod = libutils.get_string_module(self.project, code)
         self.assertTrue("var" in pymod)
 
-    @testutils.only_for("2.5")
+
     def test_with_statement_variables_and_tuple_assignment(self):
         code = dedent("""\
             class A(object):
@@ -596,7 +595,7 @@ class PyCoreTest(unittest.TestCase):
         self.assertTrue("a" in pymod)
         self.assertTrue("b" in pymod)
 
-    @testutils.only_for("2.5")
+
     def test_with_statement_variable_type(self):
         code = dedent("""\
             class A(object):
@@ -614,7 +613,7 @@ class PyCoreTest(unittest.TestCase):
         var = pymod["var"].get_object()
         self.assertEqual(a_class, var.get_type())
 
-    @testutils.only_for("2.7")
+
     def test_nested_with_statement_variable_type(self):
         code = dedent("""\
             class A(object):
@@ -641,7 +640,7 @@ class PyCoreTest(unittest.TestCase):
         var_b = pymod["var_b"].get_object()
         self.assertEqual(b_class, var_b.get_type())
 
-    @testutils.only_for("2.5")
+
     def test_with_statement_with_no_vars(self):
         code = dedent("""\
             with open("file"):    pass
@@ -1131,7 +1130,6 @@ class PyCoreInProjectsTest(unittest.TestCase):
         mod2_scope = libutils.get_string_scope(self.project, mod2.read(), mod2)
         self.assertEqual(mod1_object, mod2_scope["mod1"].get_object())
 
-    @testutils.only_for("2.5")
     def test_new_style_relative_imports(self):
         pkg = testutils.create_package(self.project, "pkg")
         mod1 = testutils.create_module(self.project, "mod1", pkg)
@@ -1141,7 +1139,6 @@ class PyCoreInProjectsTest(unittest.TestCase):
         mod2_object = self.pycore.resource_to_pyobject(mod2)
         self.assertEqual(mod1_object, mod2_object["mod1"].get_object())
 
-    @testutils.only_for("2.5")
     def test_new_style_relative_imports2(self):
         pkg = testutils.create_package(self.project, "pkg")
         mod1 = testutils.create_module(self.project, "mod1")

--- a/ropetest/pycoretest.py
+++ b/ropetest/pycoretest.py
@@ -579,7 +579,6 @@ class PyCoreTest(unittest.TestCase):
         pymod = libutils.get_string_module(self.project, code)
         self.assertTrue("var" in pymod)
 
-
     def test_with_statement_variables_and_tuple_assignment(self):
         code = dedent("""\
             class A(object):
@@ -594,7 +593,6 @@ class PyCoreTest(unittest.TestCase):
         pymod = libutils.get_string_module(self.project, code)
         self.assertTrue("a" in pymod)
         self.assertTrue("b" in pymod)
-
 
     def test_with_statement_variable_type(self):
         code = dedent("""\
@@ -612,7 +610,6 @@ class PyCoreTest(unittest.TestCase):
         a_class = pymod["A"].get_object()
         var = pymod["var"].get_object()
         self.assertEqual(a_class, var.get_type())
-
 
     def test_nested_with_statement_variable_type(self):
         code = dedent("""\
@@ -639,7 +636,6 @@ class PyCoreTest(unittest.TestCase):
         b_class = pymod["B"].get_object()
         var_b = pymod["var_b"].get_object()
         self.assertEqual(b_class, var_b.get_type())
-
 
     def test_with_statement_with_no_vars(self):
         code = dedent("""\

--- a/ropetest/pyscopestest.py
+++ b/ropetest/pyscopestest.py
@@ -407,7 +407,6 @@ class PyCoreScopesTest(unittest.TestCase):
         inner_scope = scope.get_scopes()[0]
         self.assertEqual(inner_scope, scope.get_inner_scope_for_offset(10))
 
-    @testutils.only_for("3.5")
     def test_get_scope_for_offset_for_function_scope_and_async_with_statement(self):
         scope = libutils.get_string_scope(
             self.project,

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -110,7 +110,6 @@ class ExtractMethodTest(unittest.TestCase):
         """)
         self.assertEqual(expected, refactored)
 
-    @testutils.only_for("3.5")
     def test_extract_function_containing_dict_generalized_unpacking(self):
         code = dedent("""\
             def a_func(dict1):

--- a/ropetest/refactor/importutilstest.py
+++ b/ropetest/refactor/importutilstest.py
@@ -107,7 +107,6 @@ class ImportUtilsTest(unittest.TestCase):
             "from pkg1 import *", imports[0].import_info.get_import_statement()
         )
 
-    @testutils.only_for("2.5")
     def test_get_import_statements_for_new_relatives(self):
         self.mod2.write("from .mod3 import x\n")
         pymod = self.project.get_module("pkg2.mod2")
@@ -932,7 +931,6 @@ class ImportUtilsTest(unittest.TestCase):
             self.import_tools.relatives_to_absolutes(pymod),
         )
 
-    @testutils.only_for("2.5")
     def test_transform_rel_imports_to_abs_imports_for_new_relatives(self):
         self.mod3.write(dedent("""\
             def a_func():

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -268,7 +268,7 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_children(
             "JoinedStr",
-            ["rf'", "abc", "FormattedValue", '\' f"""xxx', "FormattedValue", " ", '"""',],
+            ["rf'", "abc", "FormattedValue", '\' f"""xxx', "FormattedValue", " ", '"""'],
         )
         checker.check_children("FormattedValue", ["{", "", "Name", "", "}"])
 
@@ -727,7 +727,6 @@ class PatchedASTTest(unittest.TestCase):
         )
         checker.check_children("alias", ["y", " ", "as", " ", "z"])
 
-
     def test_from_node_whitespace_around_dots_1(self):
         source = "from . . . import y as z\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -737,7 +736,6 @@ class PatchedASTTest(unittest.TestCase):
             "ImportFrom", ["from", " ", ".", " ", ".", " ", ".", " ", "import", " ", "alias"]
         )
         checker.check_children("alias", ["y", " ", "as", " ", "z"])
-
 
     def test_from_node_whitespace_around_dots_2(self):
         source = "from . a . b import y as z\n"

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -418,7 +418,6 @@ class PatchedASTTest(unittest.TestCase):
             "Call", ["Name", "", "(", "", "Num", "", ",", " ", "*", "", "Name", "", ")"]
         )
 
-    @testutils.only_for("3.5")
     def test_call_func_and_star_argspython35(self):
         source = "f(1, *args)\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -434,7 +433,6 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_children("Call", ["Name", "", "(", "", "**", "", "Name", "", ")"])
 
-    @testutils.only_for("3.5")
     def test_call_func_and_only_dstar_args_python35(self):
         source = "f(**kwds)\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -451,7 +449,6 @@ class PatchedASTTest(unittest.TestCase):
             ["Name", "", "(", "", "*", "", "Name", "", ",", " ", "**", "", "Name", "", ")"],
         )
 
-    @testutils.only_for("3.5")
     def test_call_func_and_both_varargs_and_kwargs_python35(self):
         source = "f(*args, **kwds)\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -515,7 +512,6 @@ class PatchedASTTest(unittest.TestCase):
             ["@", "", "Name", "\n", "def", " ", "f", "", "(", "", "arguments", "", ")", "", ":", "\n    ", "Pass"],
         )
 
-    @testutils.only_for("2.6")
     def test_decorators_for_classes(self):
         source = dedent("""\
             @d
@@ -611,7 +607,6 @@ class PatchedASTTest(unittest.TestCase):
             ["{", "", "Num", "", ":", " ", "Num", "", ",", " ", "Num", "", ":", " ", "Num", "", "}"],
         )
 
-    @testutils.only_for("3.5")
     def test_dict_node_with_unpacking(self):
         source = "{**dict1, **dict2}\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -712,7 +707,6 @@ class PatchedASTTest(unittest.TestCase):
         )
         checker.check_children("alias", ["y"])
 
-    @testutils.only_for("2.5")
     def test_from_node(self):
         source = "from ..x import y as z\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -723,7 +717,6 @@ class PatchedASTTest(unittest.TestCase):
         )
         checker.check_children("alias", ["y", " ", "as", " ", "z"])
 
-    @testutils.only_for("2.5")
     def test_from_node_relative_import(self):
         source = "from . import y as z\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -734,7 +727,7 @@ class PatchedASTTest(unittest.TestCase):
         )
         checker.check_children("alias", ["y", " ", "as", " ", "z"])
 
-    @testutils.only_for("2.5")
+
     def test_from_node_whitespace_around_dots_1(self):
         source = "from . . . import y as z\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -745,7 +738,7 @@ class PatchedASTTest(unittest.TestCase):
         )
         checker.check_children("alias", ["y", " ", "as", " ", "z"])
 
-    @testutils.only_for("2.5")
+
     def test_from_node_whitespace_around_dots_2(self):
         source = "from . a . b import y as z\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -1171,7 +1164,6 @@ class PatchedASTTest(unittest.TestCase):
             ["while", " ", NameConstant, "", ":", "\n    ", "Pass", "\n", "else", "", ":", "\n    ", "Pass"],
         )
 
-    @testutils.only_for("2.5")
     def test_with_node(self):
         source = dedent("""\
             from __future__ import with_statement
@@ -1185,7 +1177,6 @@ class PatchedASTTest(unittest.TestCase):
             ["with", " ", "Name", " ", "as", " ", "Name", "", ":", "\n    ", "Pass"],
         )
 
-    @testutils.only_for("3.5")
     def test_async_with_node(self):
         source = dedent("""\
             async def afunc():
@@ -1251,7 +1242,6 @@ class PatchedASTTest(unittest.TestCase):
             ["except", " ", "Name", " ", "as", " ", expected_child, "", ":", "\n    ", "Pass"],
         )
 
-    @testutils.only_for("2.5")
     def test_try_except_and_finally_node(self):
         source = dedent("""\
             try:
@@ -1297,7 +1287,6 @@ class PatchedASTTest(unittest.TestCase):
         source = "1;\n"
         patchedast.get_patched_ast(source, True)
 
-    @testutils.only_for("2.5")
     def test_if_exp_node(self):
         source = "1 if True else 2\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -1342,7 +1331,6 @@ class PatchedASTTest(unittest.TestCase):
             ["Name", "", "(", "", "keyword", "", ",", " ", "*", "", "Name", "", ")"],
         )
 
-    @testutils.only_for("3.5")
     def test_starargs_before_keywords(self):
         source = "foo(*args, a=1)\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -1351,7 +1339,6 @@ class PatchedASTTest(unittest.TestCase):
             "Call", ["Name", "", "(", "*", "Starred", "", ",", " ", "keyword", "", ")"]
         )
 
-    @testutils.only_for("3.5")
     def test_starargs_in_keywords(self):
         source = "foo(a=1, *args, b=2)\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -1361,7 +1348,6 @@ class PatchedASTTest(unittest.TestCase):
             ["Name", "", "(", "", "keyword", "", ",", " *", "Starred", "", ",", " ", "keyword", "", ")"],
         )
 
-    @testutils.only_for("3.5")
     def test_starargs_in_positional(self):
         source = "foo(a, *b, c)\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -1371,7 +1357,6 @@ class PatchedASTTest(unittest.TestCase):
             ["Name", "", "(", "", "Name", "", ",", " *", "Starred", "", ",", " ", "Name", "", ")"],
         )
 
-    @testutils.only_for("3.5")
     def test_starargs_after_keywords(self):
         source = "foo(a=1, *args)\n"
         ast_frag = patchedast.get_patched_ast(source, True)

--- a/ropetest/refactor/renametest.py
+++ b/ropetest/refactor/renametest.py
@@ -305,7 +305,6 @@ class RenameRefactoringTest(unittest.TestCase):
         )
         self.assertEqual("is_replace = True\n'ali'.\\\nreplace\n", refactored)
 
-    @testutils.only_for("3.6")
     def test_renaming_occurrence_in_f_string(self):
         code = dedent("""\
             a_var = 20
@@ -318,7 +317,6 @@ class RenameRefactoringTest(unittest.TestCase):
         refactored = self._local_rename(code, 2, "new_var")
         self.assertEqual(expected, refactored)
 
-    @testutils.only_for("3.6")
     def test_renaming_occurrence_in_nested_f_string(self):
         code = dedent("""\
             a_var = 20
@@ -331,7 +329,6 @@ class RenameRefactoringTest(unittest.TestCase):
         refactored = self._local_rename(code, 2, "new_var")
         self.assertEqual(expected, refactored)
 
-    @testutils.only_for("3.6")
     def test_not_renaming_string_contents_in_f_string(self):
         refactored = self._local_rename(
             "a_var = 20\na_string=f'{\"a_var\"}'\n", 2, "new_var"
@@ -444,7 +441,6 @@ class RenameRefactoringTest(unittest.TestCase):
             refactored,
         )
 
-    @testutils.only_for("3.5")
     def test_renaming_async_function(self):
         code = dedent("""\
             async def a_func():
@@ -459,7 +455,6 @@ class RenameRefactoringTest(unittest.TestCase):
             refactored,
         )
 
-    @testutils.only_for("3.5")
     def test_renaming_await(self):
         code = dedent("""\
             async def b_func():
@@ -878,7 +873,6 @@ class RenameRefactoringTest(unittest.TestCase):
             refactored,
         )
 
-    @testutils.only_for("3.5")
     def test_renaming_async_for_loop_variable(self):
         code = dedent("""\
             async def func():
@@ -895,7 +889,6 @@ class RenameRefactoringTest(unittest.TestCase):
             refactored,
         )
 
-    @testutils.only_for("3.5")
     def test_renaming_async_with_context_manager(self):
         code = dedent("""\
             def a_cm(): pass
@@ -908,7 +901,6 @@ class RenameRefactoringTest(unittest.TestCase):
                 async with another_cm() as x: pass""")
         self.assertEqual(refactored, expected)
 
-    @testutils.only_for("3.5")
     def test_renaming_async_with_as_variable(self):
         code = dedent("""\
             async def func():
@@ -1422,7 +1414,6 @@ class RenameRefactoringTest(unittest.TestCase):
         )
 
     # XXX: with variables should not leak
-    @testutils.only_for("2.5")
     def xxx_test_with_statement_variables_should_not_leak(self):
         code = dedent("""\
             f = 1


### PR DESCRIPTION
Python 3.6 and below have reached the end of their lifetimes.