### PR TITLE
Fix #589 Cleanup testutils.sample_project()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - #533 Refactoring to Remove usage of unicode type
 - #559 Improve handling of whitespace in import and from-import statements
 - #581 Remove functions in rope.base.ast that has functionally identical implementation in stdlib's ast 
+- #589 Fix issue with `sample_project()` creating directories where it shouldn't when running tests
 
 # Release 1.5.1
 

--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -212,6 +212,7 @@ class Project(_Project):
         """
         if projectroot != "/":
             projectroot = _realpath(projectroot).rstrip("/\\")
+        assert isinstance(projectroot, str)
         self._address = projectroot
         self._ropefolder_name = ropefolder
         if not os.path.exists(self._address):

--- a/ropetest/projecttest.py
+++ b/ropetest/projecttest.py
@@ -1,7 +1,7 @@
 import os.path
-import shutil
-from textwrap import dedent
+import tempfile
 import unittest
+from textwrap import dedent
 
 from rope.base.exceptions import RopeError, ResourceNotFoundError
 from rope.base.fscommands import FileSystemCommands
@@ -222,17 +222,15 @@ class ProjectTest(unittest.TestCase):
         )
 
     def test_does_not_fail_for_permission_denied(self):
-        bad_dir = os.path.join(self.sample_folder, "bad_dir")
-        os.makedirs(bad_dir)
-        self.addCleanup(shutil.rmtree, bad_dir)
-        os.chmod(bad_dir, 0o000)
-        try:
-            parent = self.project.get_resource(self.sample_folder)
+        with tempfile.TemporaryDirectory(suffix="bad_dir") as bad_dir:
+            os.chmod(bad_dir, 0o000)
+            try:
+                parent = self.project.get_resource(self.sample_folder)
 
-            parent.get_children()
+                parent.get_children()
 
-        finally:
-            os.chmod(bad_dir, 0o755)
+            finally:
+                os.chmod(bad_dir, 0o755)
 
     def test_getting_files(self):
         files = self.project.root.get_files()

--- a/ropetest/projecttest.py
+++ b/ropetest/projecttest.py
@@ -1005,7 +1005,7 @@ class RopeFolderTest(unittest.TestCase):
         self.assertTrue(self.project.ropefolder is None)
 
     def test_getting_project_rope_folder(self):
-        self.project = testutils.sample_project(ropefolder=".ropeproject")
+        self.project = testutils.sample_project()
         self.assertTrue(self.project.ropefolder.exists())
         self.assertEqual(".ropeproject", self.project.ropefolder.path)
 
@@ -1083,7 +1083,7 @@ class RopeFolderTest(unittest.TestCase):
         self.assertFalse(self.project.is_ignored(myfile))
 
     def test_loading_config_dot_py(self):
-        self.project = testutils.sample_project(ropefolder=".ropeproject")
+        self.project = testutils.sample_project()
         config = self.project.get_file(".ropeproject/config.py")
         if not config.exists():
             config.create()
@@ -1094,13 +1094,13 @@ class RopeFolderTest(unittest.TestCase):
                 project.root.create_file("loaded")
         """))
         self.project.close()
-        self.project = Project(self.project.address, ropefolder=".ropeproject")
+        self.project = Project(self.project.address)
         self.assertTrue(self.project.get_file("loaded").exists())
         myfile = self.project.get_file("myfile.txt")
         self.assertTrue(self.project.is_ignored(myfile))
 
     def test_loading_pyproject(self):
-        self.project = testutils.sample_project(ropefolder=".ropeproject")
+        self.project = testutils.sample_project()
         config = self.project.get_file("pyproject.toml")
         if not config.exists():
             config.create()
@@ -1109,23 +1109,23 @@ class RopeFolderTest(unittest.TestCase):
             ignored_resources=["pyproject.py"]
         """))
         self.project.close()
-        self.project = Project(self.project.address, ropefolder=".ropeproject")
+        self.project = Project(self.project.address)
         myfile = self.project.get_file("pyproject.py")
         self.assertTrue(self.project.is_ignored(myfile))
 
     def test_loading_pyproject_empty_file(self):
-        self.project = testutils.sample_project(ropefolder=".ropeproject")
+        self.project = testutils.sample_project()
         config = self.project.get_file("pyproject.toml")
         if not config.exists():
             config.create()
         config.write("")
         self.project.close()
-        self.project = Project(self.project.address, ropefolder=".ropeproject")
+        self.project = Project(self.project.address)
         myfile = self.project.get_file("pyproject.py")
         self.assertFalse(self.project.is_ignored(myfile))
 
     def test_loading_pyproject_no_tool_section(self):
-        self.project = testutils.sample_project(ropefolder=".ropeproject")
+        self.project = testutils.sample_project()
         config = self.project.get_file("pyproject.toml")
         if not config.exists():
             config.create()
@@ -1134,12 +1134,12 @@ class RopeFolderTest(unittest.TestCase):
             name = 'testproject'
         """))
         self.project.close()
-        self.project = Project(self.project.address, ropefolder=".ropeproject")
+        self.project = Project(self.project.address)
         myfile = self.project.get_file("pyproject.py")
         self.assertFalse(self.project.is_ignored(myfile))
 
     def test_loading_pyproject_no_tool_rope_section(self):
-        self.project = testutils.sample_project(ropefolder=".ropeproject")
+        self.project = testutils.sample_project()
         config = self.project.get_file("pyproject.toml")
         if not config.exists():
             config.create()
@@ -1148,7 +1148,7 @@ class RopeFolderTest(unittest.TestCase):
             name = 'testproject'
         """))
         self.project.close()
-        self.project = Project(self.project.address, ropefolder=".ropeproject")
+        self.project = Project(self.project.address)
         myfile = self.project.get_file("pyproject.py")
         self.assertFalse(self.project.is_ignored(myfile))
 

--- a/ropetest/testutils.py
+++ b/ropetest/testutils.py
@@ -11,11 +11,12 @@ from rope.contrib import generate
 
 logging.basicConfig(format="%(levelname)s:%(funcName)s:%(message)s", level=logging.INFO)
 
+RUN_TMP_DIR = tempfile.mkdtemp(prefix="ropetest-run-")
 
-def sample_project(root=None, foldername=None, **kwds):
-    if root is None:
-        root = tempfile.mkdtemp(prefix="ropetest-")
-        root = os.path.join(root, foldername if foldername else "sample_project")
+
+def sample_project(foldername=None, **kwds):
+    root = tempfile.mkdtemp(prefix="project-", dir=RUN_TMP_DIR)
+    root = os.path.join(root, foldername if foldername else "sample_project")
     logging.debug("Using %s as root of the project.", root)
     # Using these prefs for faster tests
     prefs = {

--- a/ropetest/testutils.py
+++ b/ropetest/testutils.py
@@ -4,6 +4,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 
 import rope.base.project
 from rope.contrib import generate
@@ -15,8 +16,8 @@ RUN_TMP_DIR = tempfile.mkdtemp(prefix="ropetest-run-")
 
 
 def sample_project(foldername=None, **kwds):
-    root = tempfile.mkdtemp(prefix="project-", dir=RUN_TMP_DIR)
-    root = os.path.join(root, foldername if foldername else "sample_project")
+    root = Path(tempfile.mkdtemp(prefix="project-", dir=RUN_TMP_DIR))
+    root /= foldername if foldername else "sample_project"
     logging.debug("Using %s as root of the project.", root)
     # Using these prefs for faster tests
     prefs = {

--- a/ropetest/testutils.py
+++ b/ropetest/testutils.py
@@ -29,7 +29,6 @@ def sample_project(foldername=None, **kwds):
         "import_dynload_stdmods": False,
     }
     prefs.update(kwds)
-    remove_recursively(root)
     project = rope.base.project.Project(root, **prefs)
     return project
 

--- a/ropetest/testutils.py
+++ b/ropetest/testutils.py
@@ -1,26 +1,21 @@
+import logging
 import os.path
 import shutil
 import sys
-import logging
-
-logging.basicConfig(format="%(levelname)s:%(funcName)s:%(message)s", level=logging.INFO)
+import tempfile
 import unittest
 
 import rope.base.project
 from rope.contrib import generate
 
 
+logging.basicConfig(format="%(levelname)s:%(funcName)s:%(message)s", level=logging.INFO)
+
+
 def sample_project(root=None, foldername=None, **kwds):
     if root is None:
-        root = "sample_project"
-        if foldername:
-            root = foldername
-        # HACK: Using ``/dev/shm/`` for faster tests
-        if os.name == "posix":
-            if os.path.isdir("/dev/shm") and os.access("/dev/shm", os.W_OK):
-                root = "/dev/shm/" + root
-            elif os.path.isdir("/tmp") and os.access("/tmp", os.W_OK):
-                root = "/tmp/" + root
+        root = tempfile.mkdtemp(prefix="ropetest-")
+        root = os.path.join(root, foldername if foldername else "sample_project")
     logging.debug("Using %s as root of the project.", root)
     # Using these prefs for faster tests
     prefs = {


### PR DESCRIPTION
- Remove redundant testutils.sample_project(ropefolder) arguments
- Simplify implementation of sample_project()
- Remove root argument
- Change testutils.py to use pathlib
- Rewrite test that creates errant sample_folder directory
- Remove unnecessary remove_recursively() when creatings sample_project()

Fixes #589 