### PR TITLE
Fix posonlyargs and kwonlyargs when extracting method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - #559 Improve handling of whitespace in import and from-import statements
 - #581 Remove functions in rope.base.ast that has functionally identical implementation in stdlib's ast 
 - #589 Fix issue with `sample_project()` creating directories where it shouldn't when running tests
+- #566, #567 Fix variables in kwonlyargs and posonlyargs not being correctly passed to extracted methods
 
 # Release 1.5.1
 

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -947,7 +947,10 @@ class _FunctionInformationCollector(ast.RopeNodeVisitor):
 
 
 def _get_argnames(arguments):
-    result = [node.arg for node in arguments.args if isinstance(node, ast.arg)]
+    result = []
+    if arguments.posonlyargs:
+        result.extend(node.arg for node in arguments.posonlyargs)
+    result.extend(node.arg for node in arguments.args if isinstance(node, ast.arg))
     if arguments.vararg:
         result.append(arguments.vararg.arg)
     if arguments.kwarg:

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -952,6 +952,8 @@ def _get_argnames(arguments):
         result.append(arguments.vararg.arg)
     if arguments.kwarg:
         result.append(arguments.kwarg.arg)
+    if arguments.kwonlyargs:
+        result.extend(node.arg for node in arguments.kwonlyargs)
     return result
 
 

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -204,6 +204,24 @@ class ExtractMethodTest(unittest.TestCase):
         """)
         self.assertEqual(expected, refactored)
 
+    def test_extract_function_with_kwonlyargs(self):
+        code = dedent("""\
+            def a_func(b, *, a_var):
+                another_var = 20
+                third_var = a_var + another_var
+        """)
+        start, end = self._convert_line_range_to_offset(code, 3, 3)
+        refactored = self.do_extract_method(code, start, end, "new_func")
+        expected = dedent("""\
+            def a_func(b, *, a_var):
+                another_var = 20
+                new_func(a_var, another_var)
+
+            def new_func(a_var, another_var):
+                third_var = a_var + another_var
+        """)
+        self.assertEqual(expected, refactored)
+
     def test_extract_function_with_multiple_return_values(self):
         code = dedent("""\
             def a_func():

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -222,6 +222,24 @@ class ExtractMethodTest(unittest.TestCase):
         """)
         self.assertEqual(expected, refactored)
 
+    def test_extract_function_with_posonlyargs(self):
+        code = dedent("""\
+            def a_func(a_var, /, b):
+                another_var = 20
+                third_var = a_var + another_var
+        """)
+        start, end = self._convert_line_range_to_offset(code, 3, 3)
+        refactored = self.do_extract_method(code, start, end, "new_func")
+        expected = dedent("""\
+            def a_func(a_var, /, b):
+                another_var = 20
+                new_func(a_var, another_var)
+
+            def new_func(a_var, another_var):
+                third_var = a_var + another_var
+        """)
+        self.assertEqual(expected, refactored)
+
     def test_extract_function_with_multiple_return_values(self):
         code = dedent("""\
             def a_func():


### PR DESCRIPTION
# Description

Fixes #566, #567

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
