### PR TITLE
Remove .ropeproject/history and .ropeproject/objectdb compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # **Upcoming release**
 
+- #604 Fix test that sometimes leaves files behind in the current working directory (@lieryan)
 
 # Release 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # **Upcoming release**
 
 - #604 Fix test that sometimes leaves files behind in the current working directory (@lieryan)
+- #606 Deprecate compress_objectdb and compress_history
 
 # Release 1.6.0
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -13,7 +13,7 @@ Will be used if [tool.rope] is configured.
 .. code-block:: toml 
    
     [tool.rope]
-    compress_objectdb = true
+    split_imports = true
 
 config.py 
 ---------

--- a/docs/default_config.py
+++ b/docs/default_config.py
@@ -55,7 +55,6 @@ def set_prefs(prefs):
     # Should rope save object information or not.
     #
     #     prefs["save_objectdb"] = True
-    #     prefs["compress_objectdb"] = False
 
     # If `True`, rope analyzes each module when it is being saved.
     #
@@ -81,7 +80,6 @@ def set_prefs(prefs):
     # Shows whether to save history across sessions.
     #
     #     prefs["save_history"] = True
-    #     prefs["compress_history"] = False
 
     # Set the number spaces used for indenting.  According to
     # :PEP:`8`, it is best to use 4 spaces.  Since most of rope's

--- a/rope/base/history.py
+++ b/rope/base/history.py
@@ -194,7 +194,7 @@ class History:
 
     @property
     def compress(self):
-        return self.project.prefs.get("compress_history", False)
+        return False
 
     def clear(self):
         """Forget all undo and redo information"""

--- a/rope/base/history.py
+++ b/rope/base/history.py
@@ -15,9 +15,7 @@ class History:
 
     def _load_history(self):
         if self.save:
-            result = self.project.data_files.read_data(
-                "history", import_=True
-            )
+            result = self.project.data_files.read_data("history", import_=True)
             if result is not None:
                 to_change = change.DataToChange(self.project)
                 for data in result[0]:

--- a/rope/base/history.py
+++ b/rope/base/history.py
@@ -16,7 +16,7 @@ class History:
     def _load_history(self):
         if self.save:
             result = self.project.data_files.read_data(
-                "history", compress=self.compress, import_=True
+                "history", import_=True
             )
             if result is not None:
                 to_change = change.DataToChange(self.project)
@@ -152,7 +152,7 @@ class History:
             self._remove_extra_items()
             data.append([to_data(change_) for change_ in self.undo_list])
             data.append([to_data(change_) for change_ in self.redo_list])
-            self.project.data_files.write_data("history", data, compress=self.compress)
+            self.project.data_files.write_data("history", data)
 
     def get_file_undo_list(self, resource):
         return [

--- a/rope/base/history.py
+++ b/rope/base/history.py
@@ -1,4 +1,4 @@
-from rope.base import exceptions, change, taskhandle
+from rope.base import exceptions, change, taskhandle, utils
 
 
 class History:
@@ -193,6 +193,7 @@ class History:
         return self.project.prefs.get("save_history", False)
 
     @property
+    @utils.deprecated("compress_history is no longer supported")
     def compress(self):
         return False
 

--- a/rope/base/oi/memorydb.py
+++ b/rope/base/oi/memorydb.py
@@ -54,7 +54,7 @@ class MemoryDB(objectdb.FileDict):
 
     @property
     def compress(self):
-        return self.project.prefs.get("compress_objectdb", False)
+        return False
 
     @property
     def persist(self):

--- a/rope/base/oi/memorydb.py
+++ b/rope/base/oi/memorydb.py
@@ -14,7 +14,7 @@ class MemoryDB(objectdb.FileDict):
         self._files = {}
         if self.persist:
             result = self.project.data_files.read_data(
-                "objectdb", compress=self.compress, import_=True
+                "objectdb", import_=True
             )
             if result is not None:
                 self._files = result
@@ -51,7 +51,7 @@ class MemoryDB(objectdb.FileDict):
 
     def write(self):
         if self.persist:
-            self.project.data_files.write_data("objectdb", self._files, self.compress)
+            self.project.data_files.write_data("objectdb", self._files)
 
     @property
     @utils.deprecated("compress_objectdb is no longer supported")

--- a/rope/base/oi/memorydb.py
+++ b/rope/base/oi/memorydb.py
@@ -13,9 +13,7 @@ class MemoryDB(objectdb.FileDict):
     def _load_files(self):
         self._files = {}
         if self.persist:
-            result = self.project.data_files.read_data(
-                "objectdb", import_=True
-            )
+            result = self.project.data_files.read_data("objectdb", import_=True)
             if result is not None:
                 self._files = result
 

--- a/rope/base/oi/memorydb.py
+++ b/rope/base/oi/memorydb.py
@@ -1,4 +1,5 @@
 from rope.base.oi import objectdb
+from rope.base import utils
 
 
 class MemoryDB(objectdb.FileDict):
@@ -53,6 +54,7 @@ class MemoryDB(objectdb.FileDict):
             self.project.data_files.write_data("objectdb", self._files, self.compress)
 
     @property
+    @utils.deprecated("compress_objectdb is no longer supported")
     def compress(self):
         return False
 

--- a/rope/base/prefs.py
+++ b/rope/base/prefs.py
@@ -69,7 +69,9 @@ class Prefs:
     save_objectdb: bool = field(
         default=False, description="Should rope save object information or not."
     )
-    compress_objectdb: bool = False
+    compress_objectdb: bool = field(
+        default=False, description="Deprecated. This has no effect",
+    )
     automatic_soa: bool = field(
         True, "If `True`, rope analyzes each module when it is being saved."
     )
@@ -92,7 +94,9 @@ class Prefs:
     save_history: bool = field(
         default=True, description="Shows whether to save history across sessions."
     )
-    compress_history: bool = False
+    compress_history: bool = field(
+        default=False, description="Deprecated. This has no effect",
+    )
 
     indent_size: int = field(
         default=4,

--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -382,12 +382,11 @@ class _DataFiles:
     def read_data(self, name, compress=False, import_=False):
         if self.project.ropefolder is None:
             return None
-        opener = self._get_opener(compress)
         file = self._get_file(name, compress)
         if not compress and import_:
             self._import_old_files(name)
         if file.exists():
-            input = opener(file.real_path, "rb")
+            input = open(file.real_path, "rb")
             try:
                 result = []
                 try:
@@ -405,8 +404,7 @@ class _DataFiles:
     def write_data(self, name, data, compress=False):
         if self.project.ropefolder is not None:
             file = self._get_file(name, compress)
-            opener = self._get_opener(compress)
-            output = opener(file.real_path, "wb")
+            output = open(file.real_path, "wb")
             try:
                 pickle.dump(data, output, 2)
             finally:
@@ -424,16 +422,6 @@ class _DataFiles:
         new = self._get_file(name, False)
         if old.exists() and not new.exists():
             shutil.move(old.real_path, new.real_path)
-
-    def _get_opener(self, compress):
-        if compress:
-            try:
-                import gzip
-
-                return gzip.open
-            except ImportError:
-                pass
-        return open
 
     def _get_file(self, name, compress):
         path = self.project.ropefolder.path + "/" + name

--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -382,7 +382,7 @@ class _DataFiles:
     def read_data(self, name, compress=False, import_=False):
         if self.project.ropefolder is None:
             return None
-        file = self._get_file(name, compress)
+        file = self._get_file(name)
         if not compress and import_:
             self._import_old_files(name)
         if file.exists():
@@ -403,7 +403,7 @@ class _DataFiles:
 
     def write_data(self, name, data, compress=False):
         if self.project.ropefolder is not None:
-            file = self._get_file(name, compress)
+            file = self._get_file(name)
             output = open(file.real_path, "wb")
             try:
                 pickle.dump(data, output, 2)
@@ -418,15 +418,13 @@ class _DataFiles:
             hook()
 
     def _import_old_files(self, name):
-        old = self._get_file(name + ".pickle", False)
-        new = self._get_file(name, False)
+        old = self._get_file(name + ".pickle")
+        new = self._get_file(name)
         if old.exists() and not new.exists():
             shutil.move(old.real_path, new.real_path)
 
-    def _get_file(self, name, compress):
+    def _get_file(self, name):
         path = self.project.ropefolder.path + "/" + name
-        if compress:
-            path += ".gz"
         return self.project.get_file(path)
 
 

--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -379,11 +379,11 @@ class _DataFiles:
         self.project = project
         self.hooks = []
 
-    def read_data(self, name, compress=False, import_=False):
+    def read_data(self, name, import_=False):
         if self.project.ropefolder is None:
             return None
         file = self._get_file(name)
-        if not compress and import_:
+        if import_:
             self._import_old_files(name)
         if file.exists():
             input = open(file.real_path, "rb")
@@ -401,7 +401,7 @@ class _DataFiles:
             finally:
                 input.close()
 
-    def write_data(self, name, data, compress=False):
+    def write_data(self, name, data):
         if self.project.ropefolder is not None:
             file = self._get_file(name)
             output = open(file.real_path, "wb")

--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -382,7 +382,6 @@ class _DataFiles:
     def read_data(self, name, compress=False, import_=False):
         if self.project.ropefolder is None:
             return None
-        compress = compress and self._can_compress()
         opener = self._get_opener(compress)
         file = self._get_file(name, compress)
         if not compress and import_:
@@ -405,7 +404,6 @@ class _DataFiles:
 
     def write_data(self, name, data, compress=False):
         if self.project.ropefolder is not None:
-            compress = compress and self._can_compress()
             file = self._get_file(name, compress)
             opener = self._get_opener(compress)
             output = opener(file.real_path, "wb")
@@ -420,14 +418,6 @@ class _DataFiles:
     def write(self):
         for hook in self.hooks:
             hook()
-
-    def _can_compress(self):
-        try:
-            import gzip  # noqa
-
-            return True
-        except ImportError:
-            return False
 
     def _import_old_files(self, name):
         old = self._get_file(name + ".pickle", False)

--- a/rope/contrib/findit.py
+++ b/rope/contrib/findit.py
@@ -117,6 +117,18 @@ class Location:
         self.unsure = occurrence.is_unsure()
         self.lineno = occurrence.lineno
 
+    def __repr__(self):
+        pymod = self.resource.project.get_pymodule(self.resource)
+        return '<{}.{} "{}:{} ({}-{})" at {}>'.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.resource.path,
+            self.lineno,
+            self.region[0],
+            self.region[1],
+            hex(id(self)),
+        )
+
 
 def _find_locations(finder, resources, job_set):
     result = []

--- a/ropetest/projecttest.py
+++ b/ropetest/projecttest.py
@@ -1,4 +1,5 @@
 import os.path
+import pathlib
 import tempfile
 import unittest
 from textwrap import dedent
@@ -67,22 +68,23 @@ class ProjectTest(unittest.TestCase):
             self.project.root.create_file(self.sample_file)
 
     def test_making_root_folder_if_it_does_not_exist(self):
-        project = Project("sampleproject2")
-        try:
-            self.assertTrue(
-                os.path.exists("sampleproject2") and os.path.isdir("sampleproject2")
-            )
-        finally:
-            testutils.remove_project(project)
+        with tempfile.TemporaryDirectory(dir=testutils.RUN_TMP_DIR) as tmpdir:
+            project_root = pathlib.Path(tmpdir) / "sampleproject2"
+            assert not project_root.exists()
+
+            project = Project(project_root)
+
+            assert project_root.exists()
+            assert project_root.is_dir()
 
     def test_failure_when_project_root_exists_and_is_a_file(self):
-        project_root = "sampleproject2"
-        try:
-            open(project_root, "w").close()
+        with tempfile.TemporaryDirectory(dir=testutils.RUN_TMP_DIR) as tmpdir:
+            project_root = pathlib.Path(tmpdir) / "sampleproject2"
+            project_root.touch()
+            assert project_root.exists() and project_root.is_file()
+
             with self.assertRaises(RopeError):
                 Project(project_root)
-        finally:
-            testutils.remove_recursively(project_root)
 
     def test_creating_folders(self):
         folderName = "SampleFolder"

--- a/ropetest/reprtest.py
+++ b/ropetest/reprtest.py
@@ -1,10 +1,14 @@
 import pathlib
 import tempfile
+from textwrap import dedent
+from unittest.mock import MagicMock
 
 import pytest
 
 from rope.base import libutils, resources, pyobjectsdef
 from rope.base.project import Project
+from rope.contrib import findit
+from rope.refactor import occurrences
 from ropetest import testutils
 
 
@@ -122,4 +126,27 @@ def test_repr_pyobjectsdef_pycomprehension_without_associated_resource(project):
     assert isinstance(obj, pyobjectsdef.PyComprehension)
     assert repr(obj).startswith(
         '<rope.base.pyobjectsdef.PyComprehension "::<comprehension>" at 0x'
+    )
+
+
+def test_repr_findit_location(project, mod1):
+    code = dedent("""\
+        a = 10
+        b = 20
+        c = 30
+    """)
+    mod1.write(code)
+
+    occurrence = MagicMock(
+        occurrences.Occurrence,
+        resource=project.get_resource("pkg1/mod1.py"),
+        lineno=2,
+    )
+    occurrence.get_word_range.return_value = (11, 13)
+    occurrence.is_unsure.return_value = True
+
+    obj = findit.Location(occurrence=occurrence)
+
+    assert repr(obj).startswith(
+        '<rope.contrib.findit.Location "pkg1/mod1.py:2 (11-13)" at 0x'
     )


### PR DESCRIPTION
# Description

Remove compress_objectdb and compress_history config. These day and age, compressing these files are just negligible savings in disk space. 

This simplifies the DataFile mechanism in preparation for #605.

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md