### PR TITLE
Remove _DataFiles._import_old_files()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - #604 Fix test that sometimes leaves files behind in the current working directory (@lieryan)
 - #606 Deprecate compress_objectdb and compress_history
+- #607 Remove importing from legacy files with `.pickle` suffix
 
 # Release 1.6.0
 

--- a/rope/base/history.py
+++ b/rope/base/history.py
@@ -15,7 +15,7 @@ class History:
 
     def _load_history(self):
         if self.save:
-            result = self.project.data_files.read_data("history", import_=True)
+            result = self.project.data_files.read_data("history")
             if result is not None:
                 to_change = change.DataToChange(self.project)
                 for data in result[0]:

--- a/rope/base/oi/memorydb.py
+++ b/rope/base/oi/memorydb.py
@@ -13,7 +13,7 @@ class MemoryDB(objectdb.FileDict):
     def _load_files(self):
         self._files = {}
         if self.persist:
-            result = self.project.data_files.read_data("objectdb", import_=True)
+            result = self.project.data_files.read_data("objectdb")
             if result is not None:
                 self._files = result
 

--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -379,12 +379,10 @@ class _DataFiles:
         self.project = project
         self.hooks = []
 
-    def read_data(self, name, import_=False):
+    def read_data(self, name):
         if self.project.ropefolder is None:
             return None
         file = self._get_file(name)
-        if import_:
-            self._import_old_files(name)
         if file.exists():
             input = open(file.real_path, "rb")
             try:
@@ -416,12 +414,6 @@ class _DataFiles:
     def write(self):
         for hook in self.hooks:
             hook()
-
-    def _import_old_files(self, name):
-        old = self._get_file(name + ".pickle")
-        new = self._get_file(name)
-        if old.exists() and not new.exists():
-            shutil.move(old.real_path, new.real_path)
 
     def _get_file(self, name):
         path = self.project.ropefolder.path + "/" + name


### PR DESCRIPTION
# Description

Remove compress_objectdb and compress_history config. Rope has never generated these files for a very long time, it's very unlikely someone still have a data file from ten years ago and want to open them.

This simplifies the DataFile mechanism in preparation for https://github.com/python-rope/rope/issues/605.

# Checklist (delete if not relevant):

- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ the legacy import code was never tested
- [x] I have updated CHANGELOG.md