### PR TITLE
PR: Remove a pyflakes nit and a flake8 suppression

### DIFF
--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -922,7 +922,7 @@ class _Source:
                     break
                 else:
                     self._skip_comment()
-        except (ValueError, TypeError) as e:  # noqa
+        except (ValueError, TypeError):
             raise MismatchedTokenError(
                 f"Token <{token}> at {self._get_location()} cannot be matched"
             )


### PR DESCRIPTION
We all know the pattern:
```python
except SomeException as e:
    ...
```
In this case, however, `e` isn't used. The existing code adds a `# noqa` comment, but there is no way to turn off the pyflakes complaint:
```console
patchedast.py:925:9: local variable 'e' is assigned to but never used
```
Imo, there is no need to fussily add the `as e:  # noqa`. 

@lieryan I'll be happy to add any comment you like just below the changed line.

