### PR TITLE
PR: Remove pyflakes complaint about an unused import

### DIFF
--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import sys
 import warnings
 


### PR DESCRIPTION
Another pyflakes complaint that can't be turned off:
```console
project.py:2:1: 'shutil' imported but unused
```