### PR TITLE
PR: ekr-grand-reorg: disambiguate class names and simplify qualifiers

### DIFF
--- a/rope/base/arguments.py
+++ b/rope/base/arguments.py
@@ -100,7 +100,8 @@ def _is_method_call(primary, pyfunction):
     pyobject = primary.get_object()
     if (
         isinstance(pyobject.get_type(), rope.base.pyobjects.PyClass)
-        and isinstance(pyfunction, rope.base.pyobjects.PyFunction)
+        # ### and isinstance(pyfunction, rope.base.pyobjects.PyFunction)
+        and isinstance(pyfunction, rope.base.pyobjects.PyFunctionStub)
         and isinstance(pyfunction.parent, rope.base.pyobjects.PyClass)
     ):
         return True

--- a/rope/base/arguments.py
+++ b/rope/base/arguments.py
@@ -100,7 +100,6 @@ def _is_method_call(primary, pyfunction):
     pyobject = primary.get_object()
     if (
         isinstance(pyobject.get_type(), rope.base.pyobjects.PyClass)
-        # ### and isinstance(pyfunction, rope.base.pyobjects.PyFunction)
         and isinstance(pyfunction, rope.base.pyobjects.PyFunctionStub)
         and isinstance(pyfunction.parent, rope.base.pyobjects.PyClass)
     ):

--- a/rope/base/builtins.py
+++ b/rope/base/builtins.py
@@ -7,6 +7,7 @@ from rope.base import (
     arguments,
     ast,
     pynames,
+    pynamesdef,
     pyobjects,
     utils,
 )
@@ -172,7 +173,7 @@ class _CallContext:
         self.args = args
 
     def _get_scope_and_pyname(self, pyname):
-        if pyname is not None and isinstance(pyname, pynames.AssignedName):
+        if pyname is not None and isinstance(pyname, pynamesdef.AssignedName):
             pymodule, lineno = pyname.get_definition_location()
             if pymodule is None:
                 return None, None

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -9,6 +9,7 @@ from rope.base import (
     ast,
     nameanalyze,
     exceptions,
+    pynamesdef,
     pyobjects,
     pyobjectsdef,
     worder,
@@ -367,7 +368,7 @@ def _get_evaluated_names(targets, assigned, module, evaluation, lineno):
     for name, levels in nameanalyze.get_name_levels(targets):
         assignment = rope.base.pynames.AssignmentValue(assigned, levels, evaluation)
         # XXX: this module should not access `rope.base.pynamesdef`!
-        pyname = rope.base.pynames.AssignedName(lineno, module)
+        pyname = pynamesdef.AssignedName(lineno, module)
         pyname.assignments.append(assignment)
         result[name] = pyname
     return result

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -102,7 +102,6 @@ class ScopeNameFinder:
                 parameter_name = pyobject.get_parameters().get(keyword_name, None)
                 return (None, parameter_name)
             elif isinstance(pyobject, pyobjects.AbstractFunction):
-                # ### parameter_name = rope.base.pynames.ParameterName()
                 parameter_name = rope.base.pynames.ParameterNameStub()
                 return (None, parameter_name)
         # class body
@@ -368,7 +367,6 @@ def _get_evaluated_names(targets, assigned, module, evaluation, lineno):
     for name, levels in nameanalyze.get_name_levels(targets):
         assignment = rope.base.pynames.AssignmentValue(assigned, levels, evaluation)
         # XXX: this module should not access `rope.base.pynamesdef`!
-        # ### pyname = rope.base.pynamesdef.AssignedName(lineno, module)
         pyname = rope.base.pynames.AssignedName(lineno, module)
         pyname.assignments.append(assignment)
         result[name] = pyname

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -102,7 +102,8 @@ class ScopeNameFinder:
                 parameter_name = pyobject.get_parameters().get(keyword_name, None)
                 return (None, parameter_name)
             elif isinstance(pyobject, pyobjects.AbstractFunction):
-                parameter_name = rope.base.pynames.ParameterName()
+                # ### parameter_name = rope.base.pynames.ParameterName()
+                parameter_name = rope.base.pynames.ParameterNameStub()
                 return (None, parameter_name)
         # class body
         if self._is_defined_in_class_body(holding_scope, offset, lineno):
@@ -367,7 +368,8 @@ def _get_evaluated_names(targets, assigned, module, evaluation, lineno):
     for name, levels in nameanalyze.get_name_levels(targets):
         assignment = rope.base.pynames.AssignmentValue(assigned, levels, evaluation)
         # XXX: this module should not access `rope.base.pynamesdef`!
-        pyname = rope.base.pynamesdef.AssignedName(lineno, module)
+        # ### pyname = rope.base.pynamesdef.AssignedName(lineno, module)
+        pyname = rope.base.pynames.AssignedName(lineno, module)
         pyname.assignments.append(assignment)
         result[name] = pyname
     return result

--- a/rope/base/oi/soa.py
+++ b/rope/base/oi/soa.py
@@ -75,7 +75,8 @@ class SOAVisitor(rope.base.ast.RopeNodeVisitor):
         return arguments.MixedArguments(self_pyname, base_args, self.scope)
 
     def _call(self, pyfunction, args):
-        if isinstance(pyfunction, pyobjects.PyFunction):
+        # ### if isinstance(pyfunction, pyobjects.PyFunction):
+        if isinstance(pyfunction, pyobjects.PyFunctionStub):
             if self.follow is not None:
                 before = self._parameter_objects(pyfunction)
             self.pycore.object_info.function_called(

--- a/rope/base/oi/soa.py
+++ b/rope/base/oi/soa.py
@@ -75,7 +75,6 @@ class SOAVisitor(rope.base.ast.RopeNodeVisitor):
         return arguments.MixedArguments(self_pyname, base_args, self.scope)
 
     def _call(self, pyfunction, args):
-        # ### if isinstance(pyfunction, pyobjects.PyFunction):
         if isinstance(pyfunction, pyobjects.PyFunctionStub):
             if self.follow is not None:
                 before = self._parameter_objects(pyfunction)

--- a/rope/base/oi/transform.py
+++ b/rope/base/oi/transform.py
@@ -271,7 +271,7 @@ class DOITextualToPyObject(TextualToPyObject):
                 result = self._function_to_pyobject(textual)
             else:
                 result = self._class_to_pyobject(textual)
-            if not isinstance(result, rope.base.pyobjects.PyModule):
+            if not isinstance(result, rope.base.pyobjects.PyModuleStub):
                 return result
 
     def _find_occurrence(self, name, source):

--- a/rope/base/oi/type_hinting/utils.py
+++ b/rope/base/oi/type_hinting/utils.py
@@ -4,7 +4,8 @@ from typing import Union, Optional
 import rope.base.utils as base_utils
 from rope.base import evaluate
 from rope.base.exceptions import AttributeNotFoundError
-from rope.base.pyobjects import PyClass, PyDefinedObject, PyFunction, PyObject
+from rope.base.pyobjects import PyClass, PyDefinedObject, PyObject  # ###
+from rope.base.pyobjects import PyFunctionStub  # ###
 
 
 def get_super_func(pyfunc):
@@ -18,7 +19,8 @@ def get_super_func(pyfunc):
         except AttributeNotFoundError:
             pass
         else:
-            if isinstance(superfunc, PyFunction):
+            # ### if isinstance(superfunc, PyFunction):
+            if isinstance(superfunc, PyFunctionStub):
                 return superfunc
 
 
@@ -48,7 +50,8 @@ def get_class_with_attr_name(pyname):
     pyobject = holding_scope.pyobject
     if isinstance(pyobject, PyClass):
         pyclass = pyobject
-    elif isinstance(pyobject, PyFunction) and isinstance(pyobject.parent, PyClass):
+    # ### elif isinstance(pyobject, PyFunction) and isinstance(pyobject.parent, PyClass):
+    elif isinstance(pyobject, PyFunctionStub) and isinstance(pyobject.parent, PyClass):
         pyclass = pyobject.parent
     else:
         return

--- a/rope/base/oi/type_hinting/utils.py
+++ b/rope/base/oi/type_hinting/utils.py
@@ -4,8 +4,7 @@ from typing import Union, Optional
 import rope.base.utils as base_utils
 from rope.base import evaluate
 from rope.base.exceptions import AttributeNotFoundError
-from rope.base.pyobjects import PyClass, PyDefinedObject, PyObject  # ###
-from rope.base.pyobjects import PyFunctionStub  # ###
+from rope.base.pyobjects import PyClass, PyDefinedObject, PyFunctionStub, PyObject
 
 
 def get_super_func(pyfunc):
@@ -19,7 +18,6 @@ def get_super_func(pyfunc):
         except AttributeNotFoundError:
             pass
         else:
-            # ### if isinstance(superfunc, PyFunction):
             if isinstance(superfunc, PyFunctionStub):
                 return superfunc
 
@@ -50,7 +48,6 @@ def get_class_with_attr_name(pyname):
     pyobject = holding_scope.pyobject
     if isinstance(pyobject, PyClass):
         pyclass = pyobject
-    # ### elif isinstance(pyobject, PyFunction) and isinstance(pyobject.parent, PyClass):
     elif isinstance(pyobject, PyFunctionStub) and isinstance(pyobject.parent, PyClass):
         pyclass = pyobject.parent
     else:

--- a/rope/base/pynames.py
+++ b/rope/base/pynames.py
@@ -20,39 +20,6 @@ class PyName:
         """Return a (module, lineno) tuple"""
 
 
-class AssignedName(PyName):
-    def __init__(self, lineno=None, module=None, pyobject=None):
-        self.lineno = lineno
-        self.module = module
-        self.assignments = []
-        self.pyobject = _Inferred(
-            self._get_inferred,
-            _get_concluded_data(module),
-        )
-        self.pyobject.set(pyobject)
-
-    @utils.prevent_recursion(lambda: None)
-    def _get_inferred(self):
-        if self.module is not None:
-            return rope.base.oi.soi.infer_assigned_object(self)
-
-    def get_object(self):
-        return self.pyobject.get()
-
-    def get_definition_location(self):
-        """Returns a (module, lineno) tuple"""
-        if self.lineno is None and self.assignments:
-            try:
-                self.lineno = self.assignments[0].get_lineno()
-            except AttributeError:
-                pass
-        return (self.module, self.lineno)
-
-    def invalidate(self):
-        """Forget the `PyObject` this `PyName` holds"""
-        self.pyobject.set(None)
-
-
 class DefinedName(PyName):
     def __init__(self, pyobject):
         self.pyobject = pyobject
@@ -67,10 +34,8 @@ class DefinedName(PyName):
         return (self.pyobject.get_module(), lineno)
 
 
-if 0:
-
-    class AssignedNameStub(PyName):
-        """Only a placeholder"""
+class AssignedNameStub(PyName):
+    """Only a placeholder"""
 
 
 class UnboundName(PyName):
@@ -136,25 +101,6 @@ class EvaluatedName(PyName):
 
 class ParameterNameStub(PyName):
     """Only a placeholder"""
-
-
-class ParameterName(PyName):
-    def __init__(self, pyfunction, index):
-        self.pyfunction = pyfunction
-        self.index = index
-
-    def get_object(self):
-        result = self.pyfunction.get_parameter(self.index)
-        if result is None:
-            result = rope.base.pyobjects.get_unknown()
-        return result
-
-    def get_objects(self):
-        """Returns the list of objects passed as this parameter"""
-        return rope.base.oi.soi.get_passed_objects(self.pyfunction, self.index)
-
-    def get_definition_location(self):
-        return (self.pyfunction.get_module(), self.pyfunction.get_ast().lineno)
 
 
 class ImportedModule(PyName):

--- a/rope/base/pynames.py
+++ b/rope/base/pynames.py
@@ -20,6 +20,40 @@ class PyName:
         """Return a (module, lineno) tuple"""
 
 
+class AssignedName(PyName):  # ### (pynames.AssignedName):
+    def __init__(self, lineno=None, module=None, pyobject=None):
+        self.lineno = lineno
+        self.module = module
+        self.assignments = []
+        self.pyobject = _Inferred(
+            # ### self._get_inferred, pynames._get_concluded_data(module)
+            self._get_inferred,
+            _get_concluded_data(module),
+        )
+        self.pyobject.set(pyobject)
+
+    @utils.prevent_recursion(lambda: None)
+    def _get_inferred(self):
+        if self.module is not None:
+            return rope.base.oi.soi.infer_assigned_object(self)
+
+    def get_object(self):
+        return self.pyobject.get()
+
+    def get_definition_location(self):
+        """Returns a (module, lineno) tuple"""
+        if self.lineno is None and self.assignments:
+            try:
+                self.lineno = self.assignments[0].get_lineno()
+            except AttributeError:
+                pass
+        return (self.module, self.lineno)
+
+    def invalidate(self):
+        """Forget the `PyObject` this `PyName` holds"""
+        self.pyobject.set(None)
+
+
 class DefinedName(PyName):
     def __init__(self, pyobject):
         self.pyobject = pyobject
@@ -34,8 +68,10 @@ class DefinedName(PyName):
         return (self.pyobject.get_module(), lineno)
 
 
-class AssignedName(PyName):
-    """Only a placeholder"""
+if 0:
+
+    class AssignedNameStub(PyName):
+        """Only a placeholder"""
 
 
 class UnboundName(PyName):
@@ -99,8 +135,27 @@ class EvaluatedName(PyName):
         self.pyobject.set(None)
 
 
-class ParameterName(PyName):
+class ParameterNameStub(PyName):
     """Only a placeholder"""
+
+
+class ParameterName(PyName):  # ### (pynames.ParameterName):
+    def __init__(self, pyfunction, index):
+        self.pyfunction = pyfunction
+        self.index = index
+
+    def get_object(self):
+        result = self.pyfunction.get_parameter(self.index)
+        if result is None:
+            result = rope.base.pyobjects.get_unknown()
+        return result
+
+    def get_objects(self):
+        """Returns the list of objects passed as this parameter"""
+        return rope.base.oi.soi.get_passed_objects(self.pyfunction, self.index)
+
+    def get_definition_location(self):
+        return (self.pyfunction.get_module(), self.pyfunction.get_ast().lineno)
 
 
 class ImportedModule(PyName):

--- a/rope/base/pynames.py
+++ b/rope/base/pynames.py
@@ -20,13 +20,12 @@ class PyName:
         """Return a (module, lineno) tuple"""
 
 
-class AssignedName(PyName):  # ### (pynames.AssignedName):
+class AssignedName(PyName):
     def __init__(self, lineno=None, module=None, pyobject=None):
         self.lineno = lineno
         self.module = module
         self.assignments = []
         self.pyobject = _Inferred(
-            # ### self._get_inferred, pynames._get_concluded_data(module)
             self._get_inferred,
             _get_concluded_data(module),
         )
@@ -139,7 +138,7 @@ class ParameterNameStub(PyName):
     """Only a placeholder"""
 
 
-class ParameterName(PyName):  # ### (pynames.ParameterName):
+class ParameterName(PyName):
     def __init__(self, pyfunction, index):
         self.pyfunction = pyfunction
         self.index = index

--- a/rope/base/pynamesdef.py
+++ b/rope/base/pynamesdef.py
@@ -1,0 +1,55 @@
+import rope.base
+from rope.base import pynames, utils
+from rope.base.pynames import _get_concluded_data, _Inferred
+
+
+class AssignedName(pynames.AssignedNameStub):
+    def __init__(self, lineno=None, module=None, pyobject=None):
+        self.lineno = lineno
+        self.module = module
+        self.assignments = []
+        self.pyobject = _Inferred(
+            self._get_inferred,
+            _get_concluded_data(module),
+        )
+        self.pyobject.set(pyobject)
+
+    @utils.prevent_recursion(lambda: None)
+    def _get_inferred(self):
+        if self.module is not None:
+            return rope.base.oi.soi.infer_assigned_object(self)
+
+    def get_object(self):
+        return self.pyobject.get()
+
+    def get_definition_location(self):
+        """Returns a (module, lineno) tuple"""
+        if self.lineno is None and self.assignments:
+            try:
+                self.lineno = self.assignments[0].get_lineno()
+            except AttributeError:
+                pass
+        return (self.module, self.lineno)
+
+    def invalidate(self):
+        """Forget the `PyObject` this `PyName` holds"""
+        self.pyobject.set(None)
+
+
+class ParameterName(pynames.ParameterNameStub):
+    def __init__(self, pyfunction, index):
+        self.pyfunction = pyfunction
+        self.index = index
+
+    def get_object(self):
+        result = self.pyfunction.get_parameter(self.index)
+        if result is None:
+            result = rope.base.pyobjects.get_unknown()
+        return result
+
+    def get_objects(self):
+        """Returns the list of objects passed as this parameter"""
+        return rope.base.oi.soi.get_passed_objects(self.pyfunction, self.index)
+
+    def get_definition_location(self):
+        return (self.pyfunction.get_module(), self.pyfunction.get_ast().lineno)

--- a/rope/base/pynamesdef.py
+++ b/rope/base/pynamesdef.py
@@ -1,57 +1,7 @@
-import rope.base.oi.soi
-from rope.base import pynames
-from rope.base.pynames import *
+# ### import rope.base.oi.soi
+# ### from rope.base import pynames
+# ### from rope.base.pynames import *
+# ### from rope.base pynames import _Inferred
 
 
-class AssignedName(pynames.AssignedName):
-    def __init__(self, lineno=None, module=None, pyobject=None):
-        self.lineno = lineno
-        self.module = module
-        self.assignments = []
-        self.pyobject = _Inferred(
-            self._get_inferred, pynames._get_concluded_data(module)
-        )
-        self.pyobject.set(pyobject)
-
-    @utils.prevent_recursion(lambda: None)
-    def _get_inferred(self):
-        if self.module is not None:
-            return rope.base.oi.soi.infer_assigned_object(self)
-
-    def get_object(self):
-        return self.pyobject.get()
-
-    def get_definition_location(self):
-        """Returns a (module, lineno) tuple"""
-        if self.lineno is None and self.assignments:
-            try:
-                self.lineno = self.assignments[0].get_lineno()
-            except AttributeError:
-                pass
-        return (self.module, self.lineno)
-
-    def invalidate(self):
-        """Forget the `PyObject` this `PyName` holds"""
-        self.pyobject.set(None)
-
-
-class ParameterName(pynames.ParameterName):
-    def __init__(self, pyfunction, index):
-        self.pyfunction = pyfunction
-        self.index = index
-
-    def get_object(self):
-        result = self.pyfunction.get_parameter(self.index)
-        if result is None:
-            result = rope.base.pyobjects.get_unknown()
-        return result
-
-    def get_objects(self):
-        """Returns the list of objects passed as this parameter"""
-        return rope.base.oi.soi.get_passed_objects(self.pyfunction, self.index)
-
-    def get_definition_location(self):
-        return (self.pyfunction.get_module(), self.pyfunction.get_ast().lineno)
-
-
-_Inferred = pynames._Inferred
+# ### _Inferred = pynames._Inferred

--- a/rope/base/pynamesdef.py
+++ b/rope/base/pynamesdef.py
@@ -1,7 +1,0 @@
-# ### import rope.base.oi.soi
-# ### from rope.base import pynames
-# ### from rope.base.pynames import *
-# ### from rope.base pynames import _Inferred
-
-
-# ### _Inferred = pynames._Inferred

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -262,7 +262,7 @@ class PyFunctionStub(PyDefinedObject, AbstractFunction):
     """Only a placeholder"""
 
 
-class PyComprehension(PyDefinedObject, PyObject):
+class PyComprehensionBase(PyDefinedObject, PyObject):
     """Only a placeholder"""
 
     def get_name(self):

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -316,7 +316,7 @@ class _PyModule(PyDefinedObject, AbstractModule):
         return self.resource
 
 
-class PyModule(_PyModule):
+class PyModuleStub(_PyModule):
     """Only a placeholder"""
 
 

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -320,7 +320,7 @@ class PyModuleStub(_PyModule):
     """Only a placeholder"""
 
 
-class PyPackage(_PyModule):
+class PyPackageStub(_PyModule):
     """Only a placeholder"""
 
 

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -258,7 +258,7 @@ class PyDefinedObject:
         pass
 
 
-class PyFunction(PyDefinedObject, AbstractFunction):
+class PyFunctionStub(PyDefinedObject, AbstractFunction):
     """Only a placeholder"""
 
 

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -6,6 +6,7 @@ import rope.base.oi.soi
 import rope.base.pyscopes
 from rope.base import (
     pynames,
+    pynamesdef,
     exceptions,
     ast,
     nameanalyze,
@@ -61,7 +62,7 @@ class PyFunction(pyobjects.PyFunctionStub):
             result = {}
             for index, name in enumerate(self.get_param_names()):
                 # TODO: handle tuple parameters
-                result[name] = pynames.ParameterName(self, index)
+                result[name] = pynamesdef.ParameterName(self, index)
             self.parameter_pynames = result
         return self.parameter_pynames
 
@@ -465,8 +466,8 @@ class _ScopeVisitor(_ExpressionVisitor):
     def _assigned(self, name, assignment):
         pyname = self.names.get(name, None)
         if pyname is None:
-            pyname = pynames.AssignedName(module=self.get_module())
-        if isinstance(pyname, pynames.AssignedName):
+            pyname = pynamesdef.AssignedName(module=self.get_module())
+        if isinstance(pyname, pynamesdef.AssignedName):
             if assignment is not None:
                 pyname.assignments.append(assignment)
             self.names[name] = pyname
@@ -565,7 +566,7 @@ class _ScopeVisitor(_ExpressionVisitor):
                 try:
                     pyname = module[name]
                 except exceptions.AttributeNotFoundError:
-                    pyname = pynames.AssignedName(node.lineno)
+                    pyname = pynamesdef.AssignedName(node.lineno)
             self.names[name] = pyname
 
 
@@ -579,7 +580,7 @@ class _ComprehensionVisitor(_ScopeVisitor):
             self.names[node.id] = self._get_pyobject(node)
 
     def _get_pyobject(self, node):
-        return pynames.AssignedName(lineno=node.lineno, module=self.get_module())
+        return pynamesdef.AssignedName(lineno=node.lineno, module=self.get_module())
 
 
 class _GlobalVisitor(_ScopeVisitor):
@@ -629,12 +630,12 @@ class _ClassInitVisitor(_AssignVisitor):
             return
         if isinstance(node.value, ast.Name) and node.value.id == self.self_name:
             if node.attr not in self.scope_visitor.names:
-                self.scope_visitor.names[node.attr] = pynames.AssignedName(
+                self.scope_visitor.names[node.attr] = pynamesdef.AssignedName(
                     lineno=node.lineno, module=self.scope_visitor.get_module()
                 )
             if self.assigned_ast is not None:
                 pyname = self.scope_visitor.names[node.attr]
-                if isinstance(pyname, pynames.AssignedName):
+                if isinstance(pyname, pynamesdef.AssignedName):
                     pyname.assignments.append(
                         pynames.AssignmentValue(self.assigned_ast)
                     )

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -5,7 +5,8 @@ import rope.base.libutils
 import rope.base.oi.soi
 import rope.base.pyscopes
 from rope.base import (
-    pynamesdef,
+    pynames,  # ###
+    ### pynamesdef,
     exceptions,
     ast,
     nameanalyze,
@@ -16,15 +17,18 @@ from rope.base import (
 )
 
 
-class PyFunction(pyobjects.PyFunction):
+# ### class PyFunction(pyobjects.PyFunction):
+class PyFunction(pyobjects.PyFunctionStub):
     def __init__(self, pycore, ast_node, parent):
         rope.base.pyobjects.AbstractFunction.__init__(self)
         rope.base.pyobjects.PyDefinedObject.__init__(self, pycore, ast_node, parent)
         self.arguments = self.ast_node.args
-        self.parameter_pyobjects = pynamesdef._Inferred(
+        # ### self.parameter_pyobjects = pynamesdef._Inferred(
+        self.parameter_pyobjects = pynames._Inferred(
             self._infer_parameters, self.get_module()._get_concluded_data()
         )
-        self.returned = pynamesdef._Inferred(self._infer_returned)
+        # ### self.returned = pynamesdef._Inferred(self._infer_returned)
+        self.returned = pynames._Inferred(self._infer_returned)
         self.parameter_pynames = None
 
     def _create_structural_attributes(self):
@@ -61,7 +65,8 @@ class PyFunction(pyobjects.PyFunction):
             result = {}
             for index, name in enumerate(self.get_param_names()):
                 # TODO: handle tuple parameters
-                result[name] = pynamesdef.ParameterName(self, index)
+                # ### result[name] = pynamesdef.ParameterName(self, index)
+                result[name] = pynames.ParameterName(self, index)
             self.parameter_pynames = result
         return self.parameter_pynames
 
@@ -251,7 +256,8 @@ class PyPackage(pyobjects.PyPackage):
         if self.resource is None:
             return result
         for name, resource in self._get_child_resources().items():
-            result[name] = pynamesdef.ImportedModule(self, resource=resource)
+            # ### result[name] = pynamesdef.ImportedModule(self, resource=resource)
+            result[name] = pynames.ImportedModule(self, resource=resource)
         return result
 
     def _create_concluded_attributes(self):
@@ -307,7 +313,8 @@ class _AnnAssignVisitor(ast.RopeNodeVisitor):
         self.scope_visitor._assigned(name, assignment)
 
     def _Name(self, node):
-        assignment = pynamesdef.AssignmentValue(
+        # ### assignment = pynamesdef.AssignmentValue(
+        assignment = pynames.AssignmentValue(
             self.assigned_ast, assign_type=True, type_hint=self.type_hint
         )
         self._assigned(node.id, assignment)
@@ -317,7 +324,8 @@ class _AnnAssignVisitor(ast.RopeNodeVisitor):
         for name, levels in names:
             assignment = None
             if self.assigned_ast is not None:
-                assignment = pynamesdef.AssignmentValue(self.assigned_ast, levels)
+                # ### assignment = pynamesdef.AssignmentValue(self.assigned_ast, levels)
+                assignment = pynames.AssignmentValue(self.assigned_ast, levels)
             self._assigned(name, assignment)
 
     def _Annotation(self, node):
@@ -377,7 +385,8 @@ class _AssignVisitor(ast.RopeNodeVisitor):
     def _Name(self, node):
         assignment = None
         if self.assigned_ast is not None:
-            assignment = pynamesdef.AssignmentValue(self.assigned_ast)
+            # ### assignment = pynamesdef.AssignmentValue(self.assigned_ast)
+            assignment = pynames.AssignmentValue(self.assigned_ast)
         self._assigned(node.id, assignment)
 
     def _Tuple(self, node):
@@ -385,7 +394,8 @@ class _AssignVisitor(ast.RopeNodeVisitor):
         for name, levels in names:
             assignment = None
             if self.assigned_ast is not None:
-                assignment = pynamesdef.AssignmentValue(self.assigned_ast, levels)
+                # ### assignment = pynamesdef.AssignmentValue(self.assigned_ast, levels)
+                assignment = pynames.AssignmentValue(self.assigned_ast, levels)
             self._assigned(name, assignment)
 
     def _Attribute(self, node):
@@ -414,7 +424,8 @@ class _ScopeVisitor(_ExpressionVisitor):
 
     def _ClassDef(self, node):
         pyclass = PyClass(self.pycore, node, self.owner_object)
-        self.names[node.name] = pynamesdef.DefinedName(pyclass)
+        # ### self.names[node.name] = pynamesdef.DefinedName(pyclass)
+        self.names[node.name] = pynames.DefinedName(pyclass)
         self.defineds.append(pyclass)
 
     def _FunctionDef(self, node):
@@ -423,7 +434,8 @@ class _ScopeVisitor(_ExpressionVisitor):
             if isinstance(decorator, ast.Name) and decorator.id == "property":
                 if isinstance(self, _ClassVisitor):
                     type_ = rope.base.builtins.Property(pyfunction)
-                    arg = pynamesdef.UnboundName(
+                    # ### arg = pynamesdef.UnboundName(
+                    arg = pynames.UnboundName(
                         rope.base.pyobjects.PyObject(self.owner_object)
                     )
 
@@ -434,12 +446,14 @@ class _ScopeVisitor(_ExpressionVisitor):
 
                     lineno = utils.guess_def_lineno(self.get_module(), node)
 
-                    self.names[node.name] = pynamesdef.EvaluatedName(
+                    # ### self.names[node.name] = pynamesdef.EvaluatedName(
+                    self.names[node.name] = pynames.EvaluatedName(
                         _eval, module=self.get_module(), lineno=lineno
                     )
                     break
         else:
-            self.names[node.name] = pynamesdef.DefinedName(pyfunction)
+            # ### self.names[node.name] = pynamesdef.DefinedName(pyfunction)
+            self.names[node.name] = pynames.DefinedName(pyfunction)
         self.defineds.append(pyfunction)
 
     def _AsyncFunctionDef(self, node):
@@ -465,8 +479,10 @@ class _ScopeVisitor(_ExpressionVisitor):
     def _assigned(self, name, assignment):
         pyname = self.names.get(name, None)
         if pyname is None:
-            pyname = pynamesdef.AssignedName(module=self.get_module())
-        if isinstance(pyname, pynamesdef.AssignedName):
+            # ### pyname = pynamesdef.AssignedName(module=self.get_module())
+            pyname = pynames.AssignedName(module=self.get_module())
+        # ### if isinstance(pyname, pynamesdef.AssignedName):
+        if isinstance(pyname, pynames.AssignedName):
             if assignment is not None:
                 pyname.assignments.append(assignment)
             self.names[name] = pyname
@@ -476,12 +492,14 @@ class _ScopeVisitor(_ExpressionVisitor):
     ):
         result = {}
         if isinstance(targets, str):
-            assignment = pynamesdef.AssignmentValue(assigned, [], evaluation, eval_type)
+            # ### assignment = pynamesdef.AssignmentValue(assigned, [], evaluation, eval_type)
+            assignment = pynames.AssignmentValue(assigned, [], evaluation, eval_type)
             self._assigned(targets, assignment)
         else:
             names = nameanalyze.get_name_levels(targets)
             for name, levels in names:
-                assignment = pynamesdef.AssignmentValue(
+                # ### assignment = pynamesdef.AssignmentValue(
+                assignment = pynames.AssignmentValue(
                     assigned, levels, evaluation, eval_type
                 )
                 self._assigned(name, assignment)
@@ -519,11 +537,13 @@ class _ScopeVisitor(_ExpressionVisitor):
             alias = import_pair.asname
             first_package = module_name.split(".")[0]
             if alias is not None:
-                imported = pynamesdef.ImportedModule(self.get_module(), module_name)
+                # ### imported = pynamesdef.ImportedModule(self.get_module(), module_name)
+                imported = pynames.ImportedModule(self.get_module(), module_name)
                 if not self._is_ignored_import(imported):
                     self.names[alias] = imported
             else:
-                imported = pynamesdef.ImportedModule(self.get_module(), first_package)
+                # ### imported = pynamesdef.ImportedModule(self.get_module(), first_package)
+                imported = pynames.ImportedModule(self.get_module(), first_package)
                 if not self._is_ignored_import(imported):
                     self.names[first_package] = imported
 
@@ -531,7 +551,8 @@ class _ScopeVisitor(_ExpressionVisitor):
         level = 0
         if node.level:
             level = node.level
-        imported_module = pynamesdef.ImportedModule(
+        # ### imported_module = pynamesdef.ImportedModule(
+        imported_module = pynames.ImportedModule(
             self.get_module(),
             node.module or "",
             level,
@@ -547,7 +568,8 @@ class _ScopeVisitor(_ExpressionVisitor):
                 alias = imported_name.asname
                 if alias is not None:
                     imported = alias
-                self.names[imported] = pynamesdef.ImportedName(
+                # ### self.names[imported] = pynamesdef.ImportedName(
+                self.names[imported] = pynames.ImportedName(
                     imported_module, imported_name.name
                 )
 
@@ -565,7 +587,8 @@ class _ScopeVisitor(_ExpressionVisitor):
                 try:
                     pyname = module[name]
                 except exceptions.AttributeNotFoundError:
-                    pyname = pynamesdef.AssignedName(node.lineno)
+                    # ### pyname = pynamesdef.AssignedName(node.lineno)
+                    pyname = pynames.AssignedName(node.lineno)
             self.names[name] = pyname
 
 
@@ -579,7 +602,8 @@ class _ComprehensionVisitor(_ScopeVisitor):
             self.names[node.id] = self._get_pyobject(node)
 
     def _get_pyobject(self, node):
-        return pynamesdef.AssignedName(lineno=node.lineno, module=self.get_module())
+        # ### return pynamesdef.AssignedName(lineno=node.lineno, module=self.get_module())
+        return pynames.AssignedName(lineno=node.lineno, module=self.get_module())
 
 
 class _GlobalVisitor(_ScopeVisitor):
@@ -629,14 +653,17 @@ class _ClassInitVisitor(_AssignVisitor):
             return
         if isinstance(node.value, ast.Name) and node.value.id == self.self_name:
             if node.attr not in self.scope_visitor.names:
-                self.scope_visitor.names[node.attr] = pynamesdef.AssignedName(
+                # ### self.scope_visitor.names[node.attr] = pynamesdef.AssignedName(
+                self.scope_visitor.names[node.attr] = pynames.AssignedName(
                     lineno=node.lineno, module=self.scope_visitor.get_module()
                 )
             if self.assigned_ast is not None:
                 pyname = self.scope_visitor.names[node.attr]
-                if isinstance(pyname, pynamesdef.AssignedName):
+                # ### if isinstance(pyname, pynamesdef.AssignedName):
+                if isinstance(pyname, pynames.AssignedName):
                     pyname.assignments.append(
-                        pynamesdef.AssignmentValue(self.assigned_ast)
+                        # ### pynamesdef.AssignmentValue(self.assigned_ast)
+                        pynames.AssignmentValue(self.assigned_ast)
                     )
 
     def _Tuple(self, node):
@@ -670,5 +697,6 @@ class StarImport:
         imported = self.imported_module.get_object()
         for name in imported:
             if not name.startswith("_"):
-                result[name] = pynamesdef.ImportedName(self.imported_module, name)
+                # ### result[name] = pynamesdef.ImportedName(self.imported_module, name)
+                result[name] = pynames.ImportedName(self.imported_module, name)
         return result

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -230,7 +230,7 @@ class PyModule(pyobjects.PyModuleStub):
         return rope.base.libutils.modname(self.resource) if self.resource else ""
 
 
-class PyPackage(pyobjects.PyPackage):
+class PyPackage(pyobjects.PyPackageStub):
     def __init__(self, pycore, resource=None, force_errors=False):
         self.resource = resource
         init_dot_py = self._get_init_dot_py()

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -112,7 +112,7 @@ class PyFunction(pyobjects.PyFunctionStub):
             return getattr(self.ast_node, "decorators", None)
 
 
-class PyComprehension(pyobjects.PyComprehension):
+class PyComprehension(pyobjects.PyComprehensionBase):
     def __init__(self, pycore, ast_node, parent):
         self.visitor_class = _ComprehensionVisitor
         rope.base.pyobjects.PyObject.__init__(self, type_="Comp")

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -5,8 +5,7 @@ import rope.base.libutils
 import rope.base.oi.soi
 import rope.base.pyscopes
 from rope.base import (
-    pynames,  # ###
-    ### pynamesdef,
+    pynames,
     exceptions,
     ast,
     nameanalyze,
@@ -17,17 +16,14 @@ from rope.base import (
 )
 
 
-# ### class PyFunction(pyobjects.PyFunction):
 class PyFunction(pyobjects.PyFunctionStub):
     def __init__(self, pycore, ast_node, parent):
         rope.base.pyobjects.AbstractFunction.__init__(self)
         rope.base.pyobjects.PyDefinedObject.__init__(self, pycore, ast_node, parent)
         self.arguments = self.ast_node.args
-        # ### self.parameter_pyobjects = pynamesdef._Inferred(
         self.parameter_pyobjects = pynames._Inferred(
             self._infer_parameters, self.get_module()._get_concluded_data()
         )
-        # ### self.returned = pynamesdef._Inferred(self._infer_returned)
         self.returned = pynames._Inferred(self._infer_returned)
         self.parameter_pynames = None
 
@@ -65,7 +61,6 @@ class PyFunction(pyobjects.PyFunctionStub):
             result = {}
             for index, name in enumerate(self.get_param_names()):
                 # TODO: handle tuple parameters
-                # ### result[name] = pynamesdef.ParameterName(self, index)
                 result[name] = pynames.ParameterName(self, index)
             self.parameter_pynames = result
         return self.parameter_pynames
@@ -256,7 +251,6 @@ class PyPackage(pyobjects.PyPackage):
         if self.resource is None:
             return result
         for name, resource in self._get_child_resources().items():
-            # ### result[name] = pynamesdef.ImportedModule(self, resource=resource)
             result[name] = pynames.ImportedModule(self, resource=resource)
         return result
 
@@ -313,7 +307,6 @@ class _AnnAssignVisitor(ast.RopeNodeVisitor):
         self.scope_visitor._assigned(name, assignment)
 
     def _Name(self, node):
-        # ### assignment = pynamesdef.AssignmentValue(
         assignment = pynames.AssignmentValue(
             self.assigned_ast, assign_type=True, type_hint=self.type_hint
         )
@@ -324,7 +317,6 @@ class _AnnAssignVisitor(ast.RopeNodeVisitor):
         for name, levels in names:
             assignment = None
             if self.assigned_ast is not None:
-                # ### assignment = pynamesdef.AssignmentValue(self.assigned_ast, levels)
                 assignment = pynames.AssignmentValue(self.assigned_ast, levels)
             self._assigned(name, assignment)
 
@@ -385,7 +377,6 @@ class _AssignVisitor(ast.RopeNodeVisitor):
     def _Name(self, node):
         assignment = None
         if self.assigned_ast is not None:
-            # ### assignment = pynamesdef.AssignmentValue(self.assigned_ast)
             assignment = pynames.AssignmentValue(self.assigned_ast)
         self._assigned(node.id, assignment)
 
@@ -394,7 +385,6 @@ class _AssignVisitor(ast.RopeNodeVisitor):
         for name, levels in names:
             assignment = None
             if self.assigned_ast is not None:
-                # ### assignment = pynamesdef.AssignmentValue(self.assigned_ast, levels)
                 assignment = pynames.AssignmentValue(self.assigned_ast, levels)
             self._assigned(name, assignment)
 
@@ -424,7 +414,6 @@ class _ScopeVisitor(_ExpressionVisitor):
 
     def _ClassDef(self, node):
         pyclass = PyClass(self.pycore, node, self.owner_object)
-        # ### self.names[node.name] = pynamesdef.DefinedName(pyclass)
         self.names[node.name] = pynames.DefinedName(pyclass)
         self.defineds.append(pyclass)
 
@@ -434,7 +423,6 @@ class _ScopeVisitor(_ExpressionVisitor):
             if isinstance(decorator, ast.Name) and decorator.id == "property":
                 if isinstance(self, _ClassVisitor):
                     type_ = rope.base.builtins.Property(pyfunction)
-                    # ### arg = pynamesdef.UnboundName(
                     arg = pynames.UnboundName(
                         rope.base.pyobjects.PyObject(self.owner_object)
                     )
@@ -446,13 +434,11 @@ class _ScopeVisitor(_ExpressionVisitor):
 
                     lineno = utils.guess_def_lineno(self.get_module(), node)
 
-                    # ### self.names[node.name] = pynamesdef.EvaluatedName(
                     self.names[node.name] = pynames.EvaluatedName(
                         _eval, module=self.get_module(), lineno=lineno
                     )
                     break
         else:
-            # ### self.names[node.name] = pynamesdef.DefinedName(pyfunction)
             self.names[node.name] = pynames.DefinedName(pyfunction)
         self.defineds.append(pyfunction)
 
@@ -479,9 +465,7 @@ class _ScopeVisitor(_ExpressionVisitor):
     def _assigned(self, name, assignment):
         pyname = self.names.get(name, None)
         if pyname is None:
-            # ### pyname = pynamesdef.AssignedName(module=self.get_module())
             pyname = pynames.AssignedName(module=self.get_module())
-        # ### if isinstance(pyname, pynamesdef.AssignedName):
         if isinstance(pyname, pynames.AssignedName):
             if assignment is not None:
                 pyname.assignments.append(assignment)
@@ -492,13 +476,11 @@ class _ScopeVisitor(_ExpressionVisitor):
     ):
         result = {}
         if isinstance(targets, str):
-            # ### assignment = pynamesdef.AssignmentValue(assigned, [], evaluation, eval_type)
             assignment = pynames.AssignmentValue(assigned, [], evaluation, eval_type)
             self._assigned(targets, assignment)
         else:
             names = nameanalyze.get_name_levels(targets)
             for name, levels in names:
-                # ### assignment = pynamesdef.AssignmentValue(
                 assignment = pynames.AssignmentValue(
                     assigned, levels, evaluation, eval_type
                 )
@@ -537,12 +519,10 @@ class _ScopeVisitor(_ExpressionVisitor):
             alias = import_pair.asname
             first_package = module_name.split(".")[0]
             if alias is not None:
-                # ### imported = pynamesdef.ImportedModule(self.get_module(), module_name)
                 imported = pynames.ImportedModule(self.get_module(), module_name)
                 if not self._is_ignored_import(imported):
                     self.names[alias] = imported
             else:
-                # ### imported = pynamesdef.ImportedModule(self.get_module(), first_package)
                 imported = pynames.ImportedModule(self.get_module(), first_package)
                 if not self._is_ignored_import(imported):
                     self.names[first_package] = imported
@@ -551,7 +531,6 @@ class _ScopeVisitor(_ExpressionVisitor):
         level = 0
         if node.level:
             level = node.level
-        # ### imported_module = pynamesdef.ImportedModule(
         imported_module = pynames.ImportedModule(
             self.get_module(),
             node.module or "",
@@ -568,7 +547,6 @@ class _ScopeVisitor(_ExpressionVisitor):
                 alias = imported_name.asname
                 if alias is not None:
                     imported = alias
-                # ### self.names[imported] = pynamesdef.ImportedName(
                 self.names[imported] = pynames.ImportedName(
                     imported_module, imported_name.name
                 )
@@ -587,7 +565,6 @@ class _ScopeVisitor(_ExpressionVisitor):
                 try:
                     pyname = module[name]
                 except exceptions.AttributeNotFoundError:
-                    # ### pyname = pynamesdef.AssignedName(node.lineno)
                     pyname = pynames.AssignedName(node.lineno)
             self.names[name] = pyname
 
@@ -602,7 +579,6 @@ class _ComprehensionVisitor(_ScopeVisitor):
             self.names[node.id] = self._get_pyobject(node)
 
     def _get_pyobject(self, node):
-        # ### return pynamesdef.AssignedName(lineno=node.lineno, module=self.get_module())
         return pynames.AssignedName(lineno=node.lineno, module=self.get_module())
 
 
@@ -653,16 +629,13 @@ class _ClassInitVisitor(_AssignVisitor):
             return
         if isinstance(node.value, ast.Name) and node.value.id == self.self_name:
             if node.attr not in self.scope_visitor.names:
-                # ### self.scope_visitor.names[node.attr] = pynamesdef.AssignedName(
                 self.scope_visitor.names[node.attr] = pynames.AssignedName(
                     lineno=node.lineno, module=self.scope_visitor.get_module()
                 )
             if self.assigned_ast is not None:
                 pyname = self.scope_visitor.names[node.attr]
-                # ### if isinstance(pyname, pynamesdef.AssignedName):
                 if isinstance(pyname, pynames.AssignedName):
                     pyname.assignments.append(
-                        # ### pynamesdef.AssignmentValue(self.assigned_ast)
                         pynames.AssignmentValue(self.assigned_ast)
                     )
 
@@ -697,6 +670,5 @@ class StarImport:
         imported = self.imported_module.get_object()
         for name in imported:
             if not name.startswith("_"):
-                # ### result[name] = pynamesdef.ImportedName(self.imported_module, name)
                 result[name] = pynames.ImportedName(self.imported_module, name)
         return result

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -164,7 +164,7 @@ class PyClass(pyobjects.PyClass):
         return rope.base.pyscopes.ClassScope(self.pycore, self)
 
 
-class PyModule(pyobjects.PyModule):
+class PyModule(pyobjects.PyModuleStub):
     def __init__(self, pycore, source=None, resource=None, force_errors=False):
         ignore = pycore.project.prefs.get("ignore_syntax_errors", False)
         syntax_errors = force_errors or not ignore

--- a/rope/base/pyscopes.py
+++ b/rope/base/pyscopes.py
@@ -4,6 +4,7 @@ from rope.base import (
     codeanalyze,
     exceptions,
     pynames,
+    pynamesdef,
     utils,
 )
 from rope.refactor import patchedast
@@ -253,7 +254,7 @@ class FunctionScope(Scope):
 
     def invalidate_data(self):
         for pyname in self.get_names().values():
-            if isinstance(pyname, (pynames.AssignedName, pynames.EvaluatedName)):
+            if isinstance(pyname, (pynamesdef.AssignedName, pynames.EvaluatedName)):
                 pyname.invalidate()
 
 

--- a/rope/contrib/autoimport/pickle.py
+++ b/rope/contrib/autoimport/pickle.py
@@ -17,6 +17,7 @@ from rope.base import (
     exceptions,
     libutils,
     pynames,
+    pynamesdef,
     pyobjects,
     resourceobserver,
     resources,
@@ -196,7 +197,7 @@ class AutoImport:
         for name, pyname in attributes.items():
             if not underlined and name.startswith("_"):
                 continue
-            if isinstance(pyname, (pynames.AssignedName, pynames.DefinedName)):
+            if isinstance(pyname, (pynamesdef.AssignedName, pynames.DefinedName)):
                 globals.append(name)
             if isinstance(pymodule, builtins.BuiltinModule):
                 globals.append(name)

--- a/rope/contrib/codeassist.py
+++ b/rope/contrib/codeassist.py
@@ -423,7 +423,7 @@ class _PythonCodeAssist:
         if found_pyname is not None:
             element = found_pyname.get_object()
             compl_scope = "attribute"
-            if isinstance(element, (pyobjects.PyModule, pyobjects.PyPackage)):
+            if isinstance(element, (pyobjects.PyModuleStub, pyobjects.PyPackage)):
                 compl_scope = "imported"
             for name, pyname in element.get_attributes().items():
                 if name.startswith(self.starting):

--- a/rope/contrib/codeassist.py
+++ b/rope/contrib/codeassist.py
@@ -8,7 +8,6 @@ from rope.base import (
     exceptions,
     libutils,
     pynames,
-    # ### pynamesdef,
     pyobjects,
     pyobjectsdef,
     pyscopes,
@@ -187,10 +186,8 @@ def get_canonical_path(project, resource, offset):
 
     # Start with the name of the object we're interested in.
     names = []
-    # ### if isinstance(pyname, pynamesdef.ParameterName):
     if isinstance(pyname, pynames.ParameterName):
         names = [(worder.get_name_at(pymod.get_resource(), offset), "PARAMETER")]
-    # ### elif isinstance(pyname, pynamesdef.AssignedName):
     elif isinstance(pyname, pynames.AssignedName):
         names = [(worder.get_name_at(pymod.get_resource(), offset), "VARIABLE")]
 
@@ -426,7 +423,6 @@ class _PythonCodeAssist:
         if found_pyname is not None:
             element = found_pyname.get_object()
             compl_scope = "attribute"
-            # ### if isinstance(element, (pyobjectsdef.PyModule, pyobjectsdef.PyPackage)):
             if isinstance(element, (pyobjects.PyModule, pyobjects.PyPackage)):
                 compl_scope = "imported"
             for name, pyname in element.get_attributes().items():
@@ -609,7 +605,6 @@ class PyDocExtractor:
                 pyobject = pyobject["__call__"].get_object()
         except exceptions.AttributeNotFoundError:
             return None
-        # ### if ignore_unknown and not isinstance(pyobject, pyobjects.PyFunction):
         if ignore_unknown and not isinstance(pyobject, pyobjects.PyFunctionStub):
             return
         if isinstance(pyobject, pyobjects.AbstractFunction):
@@ -669,7 +664,6 @@ class PyDocExtractor:
 
     def _get_function_signature(self, pyfunction, add_module=False):
         location = self._location(pyfunction, add_module)
-        # ### if isinstance(pyfunction, pyobjects.PyFunction):
         if isinstance(pyfunction, pyobjects.PyFunctionStub):
             info = functionutils.DefinitionInfo.read(pyfunction)
             return location + info.to_string()
@@ -687,7 +681,6 @@ class PyDocExtractor:
             location.append(".")
             parent = parent.parent
         if add_module:
-            # ### if isinstance(pyobject, pyobjects.PyFunction):
             if isinstance(pyobject, pyobjects.PyFunctionStub):
                 location.insert(0, self._get_module(pyobject))
             if isinstance(parent, builtins.BuiltinModule):

--- a/rope/contrib/codeassist.py
+++ b/rope/contrib/codeassist.py
@@ -8,6 +8,7 @@ from rope.base import (
     exceptions,
     libutils,
     pynames,
+    pynamesdef,
     pyobjects,
     pyobjectsdef,
     pyscopes,
@@ -186,9 +187,9 @@ def get_canonical_path(project, resource, offset):
 
     # Start with the name of the object we're interested in.
     names = []
-    if isinstance(pyname, pynames.ParameterName):
+    if isinstance(pyname, pynamesdef.ParameterName):
         names = [(worder.get_name_at(pymod.get_resource(), offset), "PARAMETER")]
-    elif isinstance(pyname, pynames.AssignedName):
+    elif isinstance(pyname, pynamesdef.AssignedName):
         names = [(worder.get_name_at(pymod.get_resource(), offset), "VARIABLE")]
 
     # Collect scope names.

--- a/rope/contrib/codeassist.py
+++ b/rope/contrib/codeassist.py
@@ -423,7 +423,7 @@ class _PythonCodeAssist:
         if found_pyname is not None:
             element = found_pyname.get_object()
             compl_scope = "attribute"
-            if isinstance(element, (pyobjects.PyModuleStub, pyobjects.PyPackage)):
+            if isinstance(element, (pyobjects.PyModuleStub, pyobjects.PyPackageStub)):
                 compl_scope = "imported"
             for name, pyname in element.get_attributes().items():
                 if name.startswith(self.starting):

--- a/rope/contrib/codeassist.py
+++ b/rope/contrib/codeassist.py
@@ -8,7 +8,7 @@ from rope.base import (
     exceptions,
     libutils,
     pynames,
-    pynamesdef,
+    # ### pynamesdef,
     pyobjects,
     pyobjectsdef,
     pyscopes,
@@ -187,9 +187,11 @@ def get_canonical_path(project, resource, offset):
 
     # Start with the name of the object we're interested in.
     names = []
-    if isinstance(pyname, pynamesdef.ParameterName):
+    # ### if isinstance(pyname, pynamesdef.ParameterName):
+    if isinstance(pyname, pynames.ParameterName):
         names = [(worder.get_name_at(pymod.get_resource(), offset), "PARAMETER")]
-    elif isinstance(pyname, pynamesdef.AssignedName):
+    # ### elif isinstance(pyname, pynamesdef.AssignedName):
+    elif isinstance(pyname, pynames.AssignedName):
         names = [(worder.get_name_at(pymod.get_resource(), offset), "VARIABLE")]
 
     # Collect scope names.
@@ -424,7 +426,8 @@ class _PythonCodeAssist:
         if found_pyname is not None:
             element = found_pyname.get_object()
             compl_scope = "attribute"
-            if isinstance(element, (pyobjectsdef.PyModule, pyobjectsdef.PyPackage)):
+            # ### if isinstance(element, (pyobjectsdef.PyModule, pyobjectsdef.PyPackage)):
+            if isinstance(element, (pyobjects.PyModule, pyobjects.PyPackage)):
                 compl_scope = "imported"
             for name, pyname in element.get_attributes().items():
                 if name.startswith(self.starting):
@@ -606,7 +609,8 @@ class PyDocExtractor:
                 pyobject = pyobject["__call__"].get_object()
         except exceptions.AttributeNotFoundError:
             return None
-        if ignore_unknown and not isinstance(pyobject, pyobjects.PyFunction):
+        # ### if ignore_unknown and not isinstance(pyobject, pyobjects.PyFunction):
+        if ignore_unknown and not isinstance(pyobject, pyobjects.PyFunctionStub):
             return
         if isinstance(pyobject, pyobjects.AbstractFunction):
             result = self._get_function_signature(pyobject, add_module=True)
@@ -644,7 +648,7 @@ class PyDocExtractor:
         )
 
     def _is_method(self, pyfunction):
-        return isinstance(pyfunction, pyobjects.PyFunction) and isinstance(
+        return isinstance(pyfunction, pyobjectsdef.PyFunction) and isinstance(
             pyfunction.parent, pyobjects.PyClass
         )
 
@@ -665,7 +669,8 @@ class PyDocExtractor:
 
     def _get_function_signature(self, pyfunction, add_module=False):
         location = self._location(pyfunction, add_module)
-        if isinstance(pyfunction, pyobjects.PyFunction):
+        # ### if isinstance(pyfunction, pyobjects.PyFunction):
+        if isinstance(pyfunction, pyobjects.PyFunctionStub):
             info = functionutils.DefinitionInfo.read(pyfunction)
             return location + info.to_string()
         else:
@@ -682,7 +687,8 @@ class PyDocExtractor:
             location.append(".")
             parent = parent.parent
         if add_module:
-            if isinstance(pyobject, pyobjects.PyFunction):
+            # ### if isinstance(pyobject, pyobjects.PyFunction):
+            if isinstance(pyobject, pyobjects.PyFunctionStub):
                 location.insert(0, self._get_module(pyobject))
             if isinstance(parent, builtins.BuiltinModule):
                 location.insert(0, parent.get_name() + ".")

--- a/rope/contrib/findit.py
+++ b/rope/contrib/findit.py
@@ -62,7 +62,8 @@ def find_implementations(
     if pyname is not None:
         pyobject = pyname.get_object()
         if (
-            not isinstance(pyobject, pyobjects.PyFunction)
+            # ### not isinstance(pyobject, pyobjects.PyFunction)
+            not isinstance(pyobject, pyobjects.PyFunctionStub)
             or pyobject.get_kind() != "method"
         ):
             raise exceptions.BadIdentifierError("Not a method!")

--- a/rope/contrib/findit.py
+++ b/rope/contrib/findit.py
@@ -62,7 +62,6 @@ def find_implementations(
     if pyname is not None:
         pyobject = pyname.get_object()
         if (
-            # ### not isinstance(pyobject, pyobjects.PyFunction)
             not isinstance(pyobject, pyobjects.PyFunctionStub)
             or pyobject.get_kind() != "method"
         ):

--- a/rope/contrib/generate.py
+++ b/rope/contrib/generate.py
@@ -299,7 +299,7 @@ class _GenerationInfo:
         primary = self.primary
         if self.primary is None:
             return self.pycore.project.get_source_folders()[0]
-        if isinstance(primary.get_object(), pyobjects.PyPackage):
+        if isinstance(primary.get_object(), pyobjects.PyPackageStub):
             return primary.get_object().get_resource()
         raise exceptions.RefactoringError(
             "A module/package can be only created in a package."

--- a/rope/refactor/change_signature.py
+++ b/rope/refactor/change_signature.py
@@ -22,7 +22,6 @@ class ChangeSignature:
         if (
             self.pyname is None
             or self.pyname.get_object() is None
-            # ### or not isinstance(self.pyname.get_object(), pyobjects.PyFunction)
             or not isinstance(self.pyname.get_object(), pyobjects.PyFunctionStub)
         ):
             raise rope.base.exceptions.RefactoringError(
@@ -43,7 +42,6 @@ class ChangeSignature:
         self.others = None
         if (
             self.name == "__init__"
-            # ### and isinstance(pyobject, pyobjects.PyFunction)
             and isinstance(pyobject, pyobjects.PyFunctionStub)
             and isinstance(pyobject.parent, pyobjects.PyClass)
         ):

--- a/rope/refactor/change_signature.py
+++ b/rope/refactor/change_signature.py
@@ -22,7 +22,8 @@ class ChangeSignature:
         if (
             self.pyname is None
             or self.pyname.get_object() is None
-            or not isinstance(self.pyname.get_object(), pyobjects.PyFunction)
+            # ### or not isinstance(self.pyname.get_object(), pyobjects.PyFunction)
+            or not isinstance(self.pyname.get_object(), pyobjects.PyFunctionStub)
         ):
             raise rope.base.exceptions.RefactoringError(
                 "Change method signature should be performed on functions"
@@ -42,7 +43,8 @@ class ChangeSignature:
         self.others = None
         if (
             self.name == "__init__"
-            and isinstance(pyobject, pyobjects.PyFunction)
+            # ### and isinstance(pyobject, pyobjects.PyFunction)
+            and isinstance(pyobject, pyobjects.PyFunctionStub)
             and isinstance(pyobject.parent, pyobjects.PyClass)
         ):
             pyclass = pyobject.parent

--- a/rope/refactor/encapsulate_field.py
+++ b/rope/refactor/encapsulate_field.py
@@ -2,7 +2,7 @@ from rope.base import (
     evaluate,
     exceptions,
     libutils,
-    pynames,
+    pynamesdef,
     taskhandle,
     utils,
     worder,
@@ -70,7 +70,7 @@ class EncapsulateField:
         return self.name
 
     def _is_an_attribute(self, pyname):
-        if pyname is not None and isinstance(pyname, pynames.AssignedName):
+        if pyname is not None and isinstance(pyname, pynamesdef.AssignedName):
             pymodule, lineno = self.pyname.get_definition_location()
             scope = pymodule.get_scope().get_inner_scope_for_line(lineno)
             if scope.get_kind() == "Class":

--- a/rope/refactor/functionutils.py
+++ b/rope/refactor/functionutils.py
@@ -144,7 +144,6 @@ class CallInfo:
 
     @staticmethod
     def _is_method(pyname):
-        # ### if pyname is not None and isinstance(pyname.get_object(), pyobjects.PyFunction):
         if pyname is not None and isinstance(
             pyname.get_object(), pyobjects.PyFunctionStub
         ):
@@ -153,7 +152,6 @@ class CallInfo:
 
     @staticmethod
     def _is_classmethod(pyname):
-        # ### if pyname is not None and isinstance(pyname.get_object(), pyobjects.PyFunction):
         if pyname is not None and isinstance(
             pyname.get_object(), pyobjects.PyFunctionStub
         ):

--- a/rope/refactor/functionutils.py
+++ b/rope/refactor/functionutils.py
@@ -144,13 +144,19 @@ class CallInfo:
 
     @staticmethod
     def _is_method(pyname):
-        if pyname is not None and isinstance(pyname.get_object(), pyobjects.PyFunction):
+        # ### if pyname is not None and isinstance(pyname.get_object(), pyobjects.PyFunction):
+        if pyname is not None and isinstance(
+            pyname.get_object(), pyobjects.PyFunctionStub
+        ):
             return pyname.get_object().get_kind() == "method"
         return False
 
     @staticmethod
     def _is_classmethod(pyname):
-        if pyname is not None and isinstance(pyname.get_object(), pyobjects.PyFunction):
+        # ### if pyname is not None and isinstance(pyname.get_object(), pyobjects.PyFunction):
+        if pyname is not None and isinstance(
+            pyname.get_object(), pyobjects.PyFunctionStub
+        ):
             return pyname.get_object().get_kind() == "classmethod"
         return False
 

--- a/rope/refactor/importutils/actions.py
+++ b/rope/refactor/importutils/actions.py
@@ -257,7 +257,7 @@ class SelfImportVisitor(ImportInfoVisitor):
             try:
                 result = pymodule[name].get_object()
                 if (
-                    isinstance(result, pyobjects.PyModule)
+                    isinstance(result, pyobjects.PyModuleStub)
                     and result.get_resource() == self.resource
                 ):
                     imported = name

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -4,7 +4,6 @@ from rope.base import (
     ast,
     exceptions,
     pynames,
-    ### pynamesdef,
     utils,
 )
 from rope.refactor.importutils import actions, importinfo
@@ -37,7 +36,6 @@ class ModuleImports:
 
     def _get_all_star_list(self, pymodule):
         def _resolve_name(
-            # ### name: Union[pynamesdef.AssignedName, pynames.ImportedName]
             name: Union[pynames.AssignedName, pynames.ImportedName]
         ) -> List:
             while isinstance(name, pynames.ImportedName):
@@ -47,7 +45,6 @@ class ModuleImports:
                     )
                 except exceptions.AttributeNotFoundError:
                     return []
-            # ### assert isinstance(name, pynamesdef.AssignedName)
             assert isinstance(name, pynames.AssignedName)
             return name.assignments
 

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -4,7 +4,7 @@ from rope.base import (
     ast,
     exceptions,
     pynames,
-    pynamesdef,
+    ### pynamesdef,
     utils,
 )
 from rope.refactor.importutils import actions, importinfo
@@ -37,7 +37,8 @@ class ModuleImports:
 
     def _get_all_star_list(self, pymodule):
         def _resolve_name(
-            name: Union[pynamesdef.AssignedName, pynames.ImportedName]
+            # ### name: Union[pynamesdef.AssignedName, pynames.ImportedName]
+            name: Union[pynames.AssignedName, pynames.ImportedName]
         ) -> List:
             while isinstance(name, pynames.ImportedName):
                 try:
@@ -46,7 +47,8 @@ class ModuleImports:
                     )
                 except exceptions.AttributeNotFoundError:
                     return []
-            assert isinstance(name, pynamesdef.AssignedName)
+            # ### assert isinstance(name, pynamesdef.AssignedName)
+            assert isinstance(name, pynames.AssignedName)
             return name.assignments
 
         result = set()

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -4,6 +4,7 @@ from rope.base import (
     ast,
     exceptions,
     pynames,
+    pynamesdef,
     utils,
 )
 from rope.refactor.importutils import actions, importinfo
@@ -36,7 +37,7 @@ class ModuleImports:
 
     def _get_all_star_list(self, pymodule):
         def _resolve_name(
-            name: Union[pynames.AssignedName, pynames.ImportedName]
+            name: Union[pynamesdef.AssignedName, pynames.ImportedName]
         ) -> List:
             while isinstance(name, pynames.ImportedName):
                 try:
@@ -45,7 +46,7 @@ class ModuleImports:
                     )
                 except exceptions.AttributeNotFoundError:
                     return []
-            assert isinstance(name, pynames.AssignedName)
+            assert isinstance(name, pynamesdef.AssignedName)
             return name.assignments
 
         result = set()

--- a/rope/refactor/inline.py
+++ b/rope/refactor/inline.py
@@ -70,7 +70,6 @@ def create_inline(project, resource, offset):
         return InlineVariable(project, resource, offset)
     if isinstance(pyname, pynames.ParameterName):
         return InlineParameter(project, resource, offset)
-    # ### if isinstance(pyname.get_object(), pyobjects.PyFunction):
     if isinstance(pyname.get_object(), pyobjects.PyFunctionStub):
         return InlineMethod(project, resource, offset)
     else:

--- a/rope/refactor/inline.py
+++ b/rope/refactor/inline.py
@@ -26,6 +26,7 @@ from rope.base import (
     exceptions,
     libutils,
     pynames,
+    pynamesdef,
     pyobjects,
     taskhandle,
     utils,
@@ -66,9 +67,9 @@ def create_inline(project, resource, offset):
         raise exceptions.RefactoringError(message)
     if isinstance(pyname, pynames.ImportedName):
         pyname = pyname._get_imported_pyname()
-    if isinstance(pyname, pynames.AssignedName):
+    if isinstance(pyname, pynamesdef.AssignedName):
         return InlineVariable(project, resource, offset)
-    if isinstance(pyname, pynames.ParameterName):
+    if isinstance(pyname, pynamesdef.ParameterName):
         return InlineParameter(project, resource, offset)
     if isinstance(pyname.get_object(), pyobjects.PyFunctionStub):
         return InlineMethod(project, resource, offset)

--- a/rope/refactor/inline.py
+++ b/rope/refactor/inline.py
@@ -70,7 +70,8 @@ def create_inline(project, resource, offset):
         return InlineVariable(project, resource, offset)
     if isinstance(pyname, pynames.ParameterName):
         return InlineParameter(project, resource, offset)
-    if isinstance(pyname.get_object(), pyobjects.PyFunction):
+    # ### if isinstance(pyname.get_object(), pyobjects.PyFunction):
+    if isinstance(pyname.get_object(), pyobjects.PyFunctionStub):
         return InlineMethod(project, resource, offset)
     else:
         raise exceptions.RefactoringError(message)

--- a/rope/refactor/localtofield.py
+++ b/rope/refactor/localtofield.py
@@ -1,7 +1,7 @@
 from rope.base import (
     evaluate,
     exceptions,
-    pynames,
+    pynamesdef,
     worder,
 )
 from rope.refactor.rename import Rename
@@ -49,7 +49,7 @@ class LocalToField:
         holding_scope = pymodule.get_scope().get_inner_scope_for_line(lineno)
         parent = holding_scope.parent
         return (
-            isinstance(pyname, pynames.AssignedName)
+            isinstance(pyname, pynamesdef.AssignedName)
             and pyname in holding_scope.get_names().values()
             and holding_scope.get_kind() == "Function"
             and parent is not None

--- a/rope/refactor/method_object.py
+++ b/rope/refactor/method_object.py
@@ -16,7 +16,6 @@ class MethodObject:
         self.project = project
         this_pymodule = self.project.get_pymodule(resource)
         pyname = evaluate.eval_location(this_pymodule, offset)
-        # ### if pyname is None or not isinstance(pyname.get_object(), pyobjects.PyFunction):
         if pyname is None or not isinstance(
             pyname.get_object(), pyobjects.PyFunctionStub
         ):

--- a/rope/refactor/method_object.py
+++ b/rope/refactor/method_object.py
@@ -16,7 +16,10 @@ class MethodObject:
         self.project = project
         this_pymodule = self.project.get_pymodule(resource)
         pyname = evaluate.eval_location(this_pymodule, offset)
-        if pyname is None or not isinstance(pyname.get_object(), pyobjects.PyFunction):
+        # ### if pyname is None or not isinstance(pyname.get_object(), pyobjects.PyFunction):
+        if pyname is None or not isinstance(
+            pyname.get_object(), pyobjects.PyFunctionStub
+        ):
             raise exceptions.RefactoringError(
                 "Replace method with method object refactoring should be "
                 "performed on a function."

--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -38,7 +38,8 @@ def create_move(project, resource, offset=None):
             pyobject, pyobjects.PyPackage
         ):
             return MoveModule(project, pyobject.get_resource())
-        if isinstance(pyobject, pyobjects.PyFunction) and isinstance(
+        # ### if isinstance(pyobject, pyobjects.PyFunction) and isinstance(
+        if isinstance(pyobject, pyobjects.PyFunctionStub) and isinstance(
             pyobject.parent, pyobjects.PyClass
         ):
             return MoveMethod(project, resource, offset)

--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -35,7 +35,7 @@ def create_move(project, resource, offset=None):
     if pyname is not None:
         pyobject = pyname.get_object()
         if isinstance(pyobject, pyobjects.PyModuleStub) or isinstance(
-            pyobject, pyobjects.PyPackage
+            pyobject, pyobjects.PyPackageStub
         ):
             return MoveModule(project, pyobject.get_resource())
         if isinstance(pyobject, pyobjects.PyFunctionStub) and isinstance(

--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -34,7 +34,7 @@ def create_move(project, resource, offset=None):
     pyname = evaluate.eval_location(this_pymodule, offset)
     if pyname is not None:
         pyobject = pyname.get_object()
-        if isinstance(pyobject, pyobjects.PyModule) or isinstance(
+        if isinstance(pyobject, pyobjects.PyModuleStub) or isinstance(
             pyobject, pyobjects.PyPackage
         ):
             return MoveModule(project, pyobject.get_resource())
@@ -44,7 +44,7 @@ def create_move(project, resource, offset=None):
             return MoveMethod(project, resource, offset)
         if (
             isinstance(pyobject, pyobjects.PyDefinedObject)
-            and isinstance(pyobject.parent, pyobjects.PyModule)
+            and isinstance(pyobject.parent, pyobjects.PyModuleStub)
             or isinstance(pyname, pynames.AssignedName)
         ):
             return MoveGlobal(project, resource, offset)

--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -10,6 +10,7 @@ from rope.base import (
     exceptions,
     libutils,
     pynames,
+    pynamesdef,
     pyobjects,
     taskhandle,
     worder,
@@ -45,7 +46,7 @@ def create_move(project, resource, offset=None):
         if (
             isinstance(pyobject, pyobjects.PyDefinedObject)
             and isinstance(pyobject.parent, pyobjects.PyModuleStub)
-            or isinstance(pyname, pynames.AssignedName)
+            or isinstance(pyname, pynamesdef.AssignedName)
         ):
             return MoveGlobal(project, resource, offset)
     raise exceptions.RefactoringError(
@@ -296,7 +297,7 @@ class MoveGlobal:
         return pyobject.get_scope().parent == pyobject.get_module().get_scope()
 
     def _is_variable(self, pyname):
-        return isinstance(pyname, pynames.AssignedName)
+        return isinstance(pyname, pynamesdef.AssignedName)
 
     def get_changes(
         self, dest, resources=None, task_handle=taskhandle.NullTaskHandle()

--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -38,7 +38,6 @@ def create_move(project, resource, offset=None):
             pyobject, pyobjects.PyPackage
         ):
             return MoveModule(project, pyobject.get_resource())
-        # ### if isinstance(pyobject, pyobjects.PyFunction) and isinstance(
         if isinstance(pyobject, pyobjects.PyFunctionStub) and isinstance(
             pyobject.parent, pyobjects.PyClass
         ):

--- a/rope/refactor/occurrences.py
+++ b/rope/refactor/occurrences.py
@@ -42,6 +42,7 @@ from rope.base import codeanalyze
 from rope.base import evaluate
 from rope.base import exceptions
 from rope.base import pynames
+from rope.base import pynamesdef
 from rope.base import pyobjects
 from rope.base import utils
 from rope.base import worder
@@ -112,7 +113,7 @@ def create_finder(
         filters.append(NoImportsFilter())
     if not keywords:
         filters.append(NoKeywordsFilter())
-    if isinstance(instance, pynames.ParameterName):
+    if isinstance(instance, pynamesdef.ParameterName):
         for pyobject in instance.get_objects():
             try:
                 pynames_.add(pyobject[name])

--- a/rope/refactor/rename.py
+++ b/rope/refactor/rename.py
@@ -144,7 +144,6 @@ class Rename:
         pyname = self.old_pyname
         return (
             isinstance(pyname, pynames.DefinedName)
-            # ### and isinstance(pyname.get_object(), pyobjects.PyFunction)
             and isinstance(pyname.get_object(), pyobjects.PyFunctionStub)
             and isinstance(pyname.get_object().parent, pyobjects.PyClass)
         )

--- a/rope/refactor/rename.py
+++ b/rope/refactor/rename.py
@@ -4,6 +4,7 @@ from rope.base import (
     exceptions,
     pyobjects,
     pynames,
+    pynamesdef,
     taskhandle,
     evaluate,
     worder,
@@ -257,5 +258,5 @@ def _is_local(pyname):
     return (
         scope.get_kind() == "Function"
         and pyname in scope.get_names().values()
-        and isinstance(pyname, pynames.AssignedName)
+        and isinstance(pyname, pynamesdef.AssignedName)
     )

--- a/rope/refactor/rename.py
+++ b/rope/refactor/rename.py
@@ -144,7 +144,8 @@ class Rename:
         pyname = self.old_pyname
         return (
             isinstance(pyname, pynames.DefinedName)
-            and isinstance(pyname.get_object(), pyobjects.PyFunction)
+            # ### and isinstance(pyname.get_object(), pyobjects.PyFunction)
+            and isinstance(pyname.get_object(), pyobjects.PyFunctionStub)
             and isinstance(pyname.get_object().parent, pyobjects.PyClass)
         )
 

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -22,7 +22,8 @@ class UseFunction:
         if pyname is None:
             raise exceptions.RefactoringError("Unresolvable name selected")
         self.pyfunction = pyname.get_object()
-        if not isinstance(self.pyfunction, pyobjects.PyFunction) or not isinstance(
+        # ### if not isinstance(self.pyfunction, pyobjects.PyFunction) or not isinstance(
+        if not isinstance(self.pyfunction, pyobjects.PyFunctionStub) or not isinstance(
             self.pyfunction.parent, pyobjects.PyModule
         ):
             raise exceptions.RefactoringError(

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -23,7 +23,7 @@ class UseFunction:
             raise exceptions.RefactoringError("Unresolvable name selected")
         self.pyfunction = pyname.get_object()
         if not isinstance(self.pyfunction, pyobjects.PyFunctionStub) or not isinstance(
-            self.pyfunction.parent, pyobjects.PyModule
+            self.pyfunction.parent, pyobjects.PyModuleStub
         ):
             raise exceptions.RefactoringError(
                 "Use function works for global functions, only."

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -4,7 +4,7 @@ from rope.base import (
     evaluate,
     exceptions,
     libutils,
-    pynames,
+    pynamesdef,
     pyobjects,
     taskhandle,
 )
@@ -144,7 +144,7 @@ def find_temps(project, code):
     result = []
     function_scope = pymodule.get_scope().get_scopes()[0]
     for name, pyname in function_scope.get_names().items():
-        if isinstance(pyname, pynames.AssignedName):
+        if isinstance(pyname, pynamesdef.AssignedName):
             result.append(name)
     return result
 

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -22,7 +22,6 @@ class UseFunction:
         if pyname is None:
             raise exceptions.RefactoringError("Unresolvable name selected")
         self.pyfunction = pyname.get_object()
-        # ### if not isinstance(self.pyfunction, pyobjects.PyFunction) or not isinstance(
         if not isinstance(self.pyfunction, pyobjects.PyFunctionStub) or not isinstance(
             self.pyfunction.parent, pyobjects.PyModule
         ):

--- a/ropetest/pycoretest.py
+++ b/ropetest/pycoretest.py
@@ -6,8 +6,7 @@ from rope.base import exceptions, libutils
 from rope.base.builtins import File, BuiltinClass
 from rope.base.pycore import _TextChangeDetector
 from rope.base.pyobjects import get_base_type, AbstractFunction
-# ### from rope.base.pynamesdef import AssignedName
-from rope.base.pynames import AssignedName  # ###
+from rope.base.pynames import AssignedName
 from ropetest import testutils
 
 

--- a/ropetest/pycoretest.py
+++ b/ropetest/pycoretest.py
@@ -5,8 +5,8 @@ import unittest
 from rope.base import exceptions, libutils
 from rope.base.builtins import File, BuiltinClass
 from rope.base.pycore import _TextChangeDetector
+from rope.base.pynamesdef import AssignedName
 from rope.base.pyobjects import get_base_type, AbstractFunction
-from rope.base.pynames import AssignedName
 from ropetest import testutils
 
 

--- a/ropetest/pycoretest.py
+++ b/ropetest/pycoretest.py
@@ -6,7 +6,8 @@ from rope.base import exceptions, libutils
 from rope.base.builtins import File, BuiltinClass
 from rope.base.pycore import _TextChangeDetector
 from rope.base.pyobjects import get_base_type, AbstractFunction
-from rope.base.pynamesdef import AssignedName
+# ### from rope.base.pynamesdef import AssignedName
+from rope.base.pynames import AssignedName  # ###
 from ropetest import testutils
 
 


### PR DESCRIPTION
The PR eliminates empty distinctions and makes the *crucial*, *real* distinctions explicit.

**Oh joy**: there is no need to merge any files! We need only:
- Remove name clashes.
- Simply imports.

**Newly explicit distinctions (disambiguated names)**

- `pynames.ParameterNameStub` vs. `pyobjectsdef.ParameterName`
- `pyobjects.AssignedNameStub` vs. `pyobjectsdef.AssignedName`
- `pyobjects.PyComprehensionBase` vs `pyobjectsdef.PyComprehension`
   (PyComprehensionBase is not just a Stub class--it has one method)
- `pyobjects.PyFunctionStub` vs. `pyobjectsdef.PyFunction`
- `pyobjects.PyModuleStub` vs. `pyobjectsdef.PyModule`
- `pyobjects.PyPackageStub` vs. `pyobjectsdef.PyPackage`

For consistency, maybe `ParameterNameStub` should move to `pyobjects`.

**Step 1: Merge pynamesdef and pynames**

1. cff's (global searches) revealed that *only* the `ParameterName` name clashed between `pynames` and `pynamesdef`.
  Therefore, I renamed (in pynames) `ParameterName` to `ParameterNameStub`.
  This is an essential distinction, revealed for the first time in this PR.
  Iirc, I also renamed `PyFunction` to `PyFunctionStub` early on.
2. I then ran unit tests until they passed(!).
  I fixed *one failure at a time*, ensuring that I never got carried away with changes.
  I have used this (unintuitive?) tactics many times before, both here and in Leo.

**Step 2: The Grand Compromise: undo the merge!**

Yes, it *is* possible to merge `pynames` and `pynamesdef`. But without odious imports there is no need to do so!

With the new disambiguated names it was straightforward to restore `pynamesdef`!

**Notes**:

- At no time did I ever encounter circular imports.
- Even with tiny changes, I could not have kept the required changes straight in my head without Leo.
  However, the notes above and the diffs should be clear enough.

**Summary**

This PR:
- Disambiguates *all* class names, using uniform qualifiers everywhere.
- Removes the odious `import *` from `pynamesdef`. All imports are now straightforward.

I am proud of this PR. It took *lots* of work to make the diffs as small as they are. The diffs clearly confirm the renaming listed above.

At long last Rope's qualifiers are simple, uniform, truthful, and informative.