### PR TITLE
PR for #616: failing unit test after removing 'file' from rope.base.builtins

### DIFF
--- a/rope/base/builtins.py
+++ b/rope/base/builtins.py
@@ -841,7 +841,6 @@ _initial_builtins = {
     "tuple": BuiltinName(get_tuple_type()),
     "set": BuiltinName(get_set_type()),
     "str": BuiltinName(get_str_type()),
-    "file": BuiltinName(get_file_type()),
     "open": BuiltinName(BuiltinFunction(function=_open_function, builtin=open)),
     "range": BuiltinName(BuiltinFunction(function=_range_function, builtin=range)),
     "reversed": BuiltinName(

--- a/ropetest/contrib/codeassisttest.py
+++ b/ropetest/contrib/codeassisttest.py
@@ -1154,7 +1154,7 @@ class CodeAssistTest(unittest.TestCase):
         self.assert_completion_in_result("GlobalClass", "global", result, type="class")
 
     def test_builtin_class_completion_proposal(self):
-        for varname in ("object", "dict", "file"):
+        for varname in ("object", "dict"):
             result = self._assist(varname[0])
             self.assert_completion_in_result(varname, "builtin", result, type="class")
 
@@ -1188,6 +1188,11 @@ class CodeAssistTest(unittest.TestCase):
             self.assert_completion_in_result(
                 expected, "builtin", result, type="function"
             )
+        code2 = "o"
+        result = self._assist(code2)
+        for expected in ("open",):
+            self.assert_completion_in_result(
+                expected, "builtin", result, type="function")
 
     def test_attribute_function_completion_proposal(self):
         code = dedent("""\

--- a/ropetest/contrib/codeassisttest.py
+++ b/ropetest/contrib/codeassisttest.py
@@ -1192,7 +1192,8 @@ class CodeAssistTest(unittest.TestCase):
         result = self._assist(code2)
         for expected in ("open",):
             self.assert_completion_in_result(
-                expected, "builtin", result, type="function")
+                expected, "builtin", result, type="function"
+            )
 
     def test_attribute_function_completion_proposal(self):
         code = dedent("""\


### PR DESCRIPTION
See #616.

[x] - Remove 'file' from builtins.
[x] - Remove completions test for 'file'.
[x] - Add completions test for 'open'