### PR TITLE
Remove support for deprecated ast nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - #604 Fix test that sometimes leaves files behind in the current working directory (@lieryan)
 - #606 Deprecate compress_objectdb and compress_history
 - #607 Remove importing from legacy files with `.pickle` suffix
+- #625 Remove support for deprecated ast nodes
 
 # Release 1.6.0
 

--- a/docs/library.rst
+++ b/docs/library.rst
@@ -501,7 +501,7 @@ might want to do something like:
           percent = jobset.get_percent_done()
           if percent is not None:
               text += ' ... %s percent done' % percent
-          print text
+          print(text)
 
   handle.add_observer(update_progress)
 
@@ -631,7 +631,7 @@ Using rename refactoring:
   >>> from rope.contrib import generate
   >>> pkg = generate.create_package(project, 'pkg')
   >>> mod2 = generate.create_module(project, 'mod2', pkg)
-  >>> mod2.write('import mod1\nprint mod1.a_var\n')
+  >>> mod2.write('import mod1\nprint(mod1.a_var)\n')
 
   # We can use `Project.find_module` for finding modules, too
   >>> assert mod2 == project.find_module('pkg.mod2')
@@ -643,7 +643,7 @@ Using rename refactoring:
   >>> mod1.read()
   u'new_var = 10\n'
   >>> mod2.read()
-  u'import mod1\nprint mod1.new_var\n'
+  u'import mod1\nprint(mod1.new_var)\n'
 
   # Undoing rename refactoring
   >>> project.history.undo()
@@ -651,7 +651,7 @@ Using rename refactoring:
   >>> mod1.read()
   u'a_var = 10\n'
   >>> mod2.read()
-  u'import mod1\nprint mod1.a_var\n'
+  u'import mod1\nprint(mod1.a_var)\n'
 
   # Cleaning up
   >>> pkg.remove()

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -126,9 +126,6 @@ class _PatchingASTWalker:
                     region = self.source.consume_number()
                 elif child == self.empty_tuple:
                     region = self.source.consume_empty_tuple()
-                elif child == "!=":
-                    # INFO: This has been added to handle deprecated ``<>``
-                    region = self.source.consume_not_equal()
                 elif child == self.semicolon_or_as_in_except:
                     # INFO: This has been added to handle deprecated
                     # semicolon in except
@@ -925,12 +922,6 @@ class _Source:
     def consume_empty_tuple(self):
         return self._consume_pattern(re.compile(r"\(\s*\)"))
 
-    def consume_not_equal(self):
-        if _Source._not_equals_pattern is None:
-            _Source._not_equals_pattern = re.compile(r"<>|!=")
-        repattern = _Source._not_equals_pattern
-        return self._consume_pattern(repattern)
-
     def consume_except_as_or_semicolon(self):
         repattern = re.compile(r"as|,")
         return self._consume_pattern(repattern)
@@ -1019,4 +1010,3 @@ class _Source:
 
     _string_pattern = None
     _number_pattern = None
-    _not_equals_pattern = None

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -298,9 +298,6 @@ class _PatchingASTWalker:
             children.append(node.value)
         self._handle(node, children)
 
-    def _Repr(self, node):
-        self._handle(node, ["`", node.value, "`"])
-
     def _BinOp(self, node):
         children = [node.left] + self._get_op(node.op) + [node.right]
         self._handle(node, children)

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -641,6 +641,7 @@ class _PatchingASTWalker:
         if node.exc:
             children.append(node.exc)
         if node.cause:
+            children.append("from")
             children.append(node.cause)
         self._handle(node, children)
 

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -72,9 +72,6 @@ class _PatchingASTWalker:
 
     Number = object()
     String = object()
-    exec_open_paren_or_space = object()
-    exec_close_paren_or_space = object()
-    exec_in_or_comma = object()
     with_or_comma_context_manager = object()
     empty_tuple = object()
 
@@ -125,15 +122,6 @@ class _PatchingASTWalker:
                     region = self.source.consume_number()
                 elif child == self.empty_tuple:
                     region = self.source.consume_empty_tuple()
-                elif child == self.exec_open_paren_or_space:
-                    # These three cases handle the differences between
-                    # the deprecated exec statement and the exec
-                    # function.
-                    region = self.source.consume_exec_open_paren_or_space()
-                elif child == self.exec_in_or_comma:
-                    region = self.source.consume_exec_in_or_comma()
-                elif child == self.exec_close_paren_or_space:
-                    region = self.source.consume_exec_close_paren_or_space()
                 elif child == self.with_or_comma_context_manager:
                     region = self.source.consume_with_or_comma_context_manager()
                 elif isinstance(node, (ast.JoinedStr, ast.FormattedValue)):
@@ -463,15 +451,6 @@ class _PatchingASTWalker:
 
     def _NamedExpr(self, node):
         children = [node.target, ":=", node.value]
-        self._handle(node, children)
-
-    def _Exec(self, node):
-        children = ["exec", self.exec_open_paren_or_space, node.body]
-        if node.globals:
-            children.extend([self.exec_in_or_comma, node.globals])
-        if node.locals:
-            children.extend([",", node.locals])
-        children.append(self.exec_close_paren_or_space)
         self._handle(node, children)
 
     def _ExtSlice(self, node):
@@ -915,18 +894,6 @@ class _Source:
 
     def consume_empty_tuple(self):
         return self._consume_pattern(re.compile(r"\(\s*\)"))
-
-    def consume_exec_open_paren_or_space(self):
-        repattern = re.compile(r"\(|")
-        return self._consume_pattern(repattern)
-
-    def consume_exec_in_or_comma(self):
-        repattern = re.compile(r"in|,")
-        return self._consume_pattern(repattern)
-
-    def consume_exec_close_paren_or_space(self):
-        repattern = re.compile(r"\)|")
-        return self._consume_pattern(repattern)
 
     def consume_with_or_comma_context_manager(self):
         repattern = re.compile(r"with|,")

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -940,7 +940,7 @@ class _Source:
 
     def _get_number_pattern(self):
         # HACK: It is merely an approaximation and does the job
-        integer = r"\-?(0x[\da-fA-F]+|\d+)[lL]?"
+        integer = r"\-?(0x[\da-fA-F]+|\d+)"
         return r"(%s(\.\d*)?|(\.\d+))([eE][-+]?\d+)?[jJ]?" % integer
 
     _string_pattern = None

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -639,17 +639,6 @@ class _PatchingASTWalker:
     def _Pass(self, node):
         self._handle(node, ["pass"])
 
-    def _Print(self, node):
-        children = ["print"]
-        if node.dest:
-            children.extend([">>", node.dest])
-            if node.values:
-                children.append(",")
-        children.extend(self._child_nodes(node.values, ","))
-        if not node.nl:
-            children.append(",")
-        self._handle(node, children)
-
     def _Raise(self, node):
         children = ["raise"]
         if node.exc:

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -72,7 +72,6 @@ class _PatchingASTWalker:
 
     Number = object()
     String = object()
-    semicolon_or_as_in_except = object()
     exec_open_paren_or_space = object()
     exec_close_paren_or_space = object()
     exec_in_or_comma = object()
@@ -126,10 +125,6 @@ class _PatchingASTWalker:
                     region = self.source.consume_number()
                 elif child == self.empty_tuple:
                     region = self.source.consume_empty_tuple()
-                elif child == self.semicolon_or_as_in_except:
-                    # INFO: This has been added to handle deprecated
-                    # semicolon in except
-                    region = self.source.consume_except_as_or_semicolon()
                 elif child == self.exec_open_paren_or_space:
                     # These three cases handle the differences between
                     # the deprecated exec statement and the exec
@@ -757,12 +752,11 @@ class _PatchingASTWalker:
         self._excepthandler(node)
 
     def _excepthandler(self, node):
-        # self._handle(node, [self.semicolon_or_as_in_except])
         children = ["except"]
         if node.type:
             children.append(node.type)
         if node.name:
-            children.append(self.semicolon_or_as_in_except)
+            children.append("as")
             children.append(node.name)
         children.append(":")
         children.extend(node.body)
@@ -921,10 +915,6 @@ class _Source:
 
     def consume_empty_tuple(self):
         return self._consume_pattern(re.compile(r"\(\s*\)"))
-
-    def consume_except_as_or_semicolon(self):
-        repattern = re.compile(r"as|,")
-        return self._consume_pattern(repattern)
 
     def consume_exec_open_paren_or_space(self):
         repattern = re.compile(r"\(|")

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -651,15 +651,6 @@ class _PatchingASTWalker:
             children.append(node.value)
         self._handle(node, children)
 
-    def _Sliceobj(self, node):
-        children = []
-        for index, slice in enumerate(node.nodes):
-            if index > 0:
-                children.append(":")
-            if slice:
-                children.append(slice)
-        self._handle(node, children)
-
     def _Index(self, node):
         self._handle(node, [node.value])
 

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -2342,22 +2342,6 @@ class ExtractMethodTest(unittest.TestCase):
         """)
         self.assertEqual(expected, refactored)
 
-    @testutils.only_for_versions_lower("3")
-    def test_extract_exec_statement(self):
-        code = dedent("""\
-            exec "def f(): pass" in {}
-        """)
-        start, end = self._convert_line_range_to_offset(code, 1, 1)
-        refactored = self.do_extract_method(code, start, end, "new_func")
-        expected = dedent("""\
-
-            def new_func():
-                exec "def f(): pass" in {}
-
-            new_func()
-        """)
-        self.assertEqual(expected, refactored)
-
     @testutils.only_for_versions_higher("3.5")
     def test_extract_async_function(self):
         code = dedent("""\

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -79,14 +79,6 @@ class PatchedASTTest(unittest.TestCase):
         start = source.index("0x1")
         checker.check_region("Num", start, start + 3)
 
-    @testutils.only_for_versions_lower("3")
-    def test_long_literals_and_region(self):
-        source = "a = 0x1L\n"
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        start = source.index("0x1L")
-        checker.check_region("Num", start, start + 4)
-
     def test_octal_integer_literals_and_region(self):
         source = "a = -0125e1\n"
         ast_frag = patchedast.get_patched_ast(source, True)
@@ -300,14 +292,6 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_children("JoinedStr", ['f"', "abc", "FormattedValue", "", '"'])
         checker.check_children("FormattedValue", ["{", "", "BinOp", "", "}"])
-
-    @testutils.only_for_versions_lower("3")
-    def test_long_integer_literals(self):
-        source = "0x1L + a"
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        checker.check_children("BinOp", ["Num", " ", "+", " ", "Name"])
-        checker.check_children("Num", ["0x1L"])
 
     def test_complex_number_literals(self):
         source = "1.0e2j + a"

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -556,21 +556,6 @@ class PatchedASTTest(unittest.TestCase):
             "arguments", [expected_child, "", ",", " ", "**", "", "p2"]
         )
 
-    @testutils.only_for_versions_lower("3")
-    def test_function_node_and_tuple_parameters(self):
-        source = dedent("""\
-            def f(a, (b, c)):
-                pass
-        """)
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        checker.check_region("Function", 0, len(source) - 1)
-        checker.check_children(
-            "Function",
-            ["def", " ", "f", "", "(", "", "arguments", "", ")", "", ":", "\n    ", "Pass"],
-        )
-        checker.check_children("arguments", ["Name", "", ",", " ", "Tuple"])
-
     def test_dict_node(self):
         source = "{1: 2, 3: 4}\n"
         ast_frag = patchedast.get_patched_ast(source, True)

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -369,14 +369,6 @@ class PatchedASTTest(unittest.TestCase):
         checker.check_region("AugAssign", 0, len(source) - 1)
         checker.check_children("AugAssign", ["Name", " ", "+", "", "=", " ", "Num"])
 
-    @testutils.only_for_versions_lower("3")
-    def test_back_quotenode(self):
-        source = "`1`\n"
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        checker.check_region("Repr", 0, len(source) - 1)
-        checker.check_children("Repr", ["`", "", "Num", "", "`"])
-
     def test_bitand(self):
         source = "1 & 2\n"
         ast_frag = patchedast.get_patched_ast(source, True)

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1,5 +1,6 @@
-import unittest
+import itertools
 import sys
+import unittest
 from textwrap import dedent
 
 from rope.base import ast
@@ -37,6 +38,19 @@ class PatchedASTTest(unittest.TestCase):
             "\n        ",
             "Expr",
         ])
+
+    def test_operator_support_completeness(self):
+        ast_ops = {
+            n.__name__
+            for n in itertools.chain(
+                ast.boolop.__subclasses__(),
+                ast.cmpop.__subclasses__(),
+                ast.operator.__subclasses__(),
+                ast.unaryop.__subclasses__(),
+            )
+        }
+        supported_ops = set(patchedast._PatchingASTWalker._operators)
+        assert ast_ops == supported_ops
 
     def test_bytes_string(self):
         source = '1 + b"("\n'

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -946,24 +946,26 @@ class PatchedASTTest(unittest.TestCase):
         checker.check_children("Expr", ["BoolOp"])
         checker.check_children("BoolOp", ["UnaryOp", " ", "or", " ", NameConstant])
 
-    @testutils.only_for_versions_lower("3")
-    def test_raise_node_for_python2(self):
-        source = "raise x, y, z\n"
+    def test_raise_node_bare(self):
+        source = "raise\n"
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_region("Raise", 0, len(source) - 1)
-        checker.check_children(
-            "Raise", ["raise", " ", "Name", "", ",", " ", "Name", "", ",", " ", "Name"]
-        )
+        checker.check_children("Raise", ["raise"])
 
-    # @#testutils.only_for('3')
-    @unittest.skipIf(sys.version < "3", "This is wrong")
     def test_raise_node_for_python3(self):
         source = "raise x(y)\n"
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_region("Raise", 0, len(source) - 1)
         checker.check_children("Raise", ["raise", " ", "Call"])
+
+    def test_raise_node_for_python3_with_cause(self):
+        source = "raise x(y) from e\n"
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_region("Raise", 0, len(source) - 1)
+        checker.check_children("Raise", ["raise", " ", "Call", " ", "from", " ", "Name"])
 
     def test_return_node(self):
         source = dedent("""\

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -621,36 +621,6 @@ class PatchedASTTest(unittest.TestCase):
         checker.check_region("BinOp", 0, len(source) - 1)
         checker.check_children("BinOp", ["Num", " ", "/", " ", "Num"])
 
-    @testutils.only_for_versions_lower("3")
-    def test_simple_exec_node(self):
-        source = 'exec ""\n'
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        checker.check_region("Exec", 0, len(source) - 1)
-        checker.check_children("Exec", ["exec", "", "", " ", "Str", "", ""])
-
-    @testutils.only_for_versions_lower("3")
-    def test_exec_node(self):
-        source = 'exec "" in locals(), globals()\n'
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        checker.check_region("Exec", 0, len(source) - 1)
-        checker.check_children(
-            "Exec",
-            ["exec", "", "", " ", "Str", " ", "in", " ", "Call", "", ",", " ", "Call", "", ""],
-        )
-
-    @testutils.only_for_versions_lower("3")
-    def test_exec_node_with_parens(self):
-        source = 'exec("", locals(), globals())\n'
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        checker.check_region("Exec", 0, len(source) - 1)
-        checker.check_children(
-            "Exec",
-            ["exec", "", "(", "", "Str", "", ",", " ", "Call", "", ",", " ", "Call", "", ")"],
-        )
-
     def test_for_node(self):
         source = dedent("""\
             for i in range(1):
@@ -1199,7 +1169,7 @@ class PatchedASTTest(unittest.TestCase):
         expected_children = ["try", "", ":", "\n    ", "Pass", "\n", "finally", "", ":", "\n    ", "Pass"]
         checker.check_children(node_to_test, expected_children)
 
-    def test_try_except_node__with_as_syntax(self):
+    def test_try_except_node(self):
         source = dedent("""\
             try:
                 pass

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1199,25 +1199,6 @@ class PatchedASTTest(unittest.TestCase):
         expected_children = ["try", "", ":", "\n    ", "Pass", "\n", "finally", "", ":", "\n    ", "Pass"]
         checker.check_children(node_to_test, expected_children)
 
-    @testutils.only_for_versions_lower("3")
-    def test_try_except_node(self):
-        source = dedent("""\
-            try:
-                pass
-            except Exception, e:
-                pass
-        """)
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        checker.check_children(
-            "TryExcept",
-            ["try", "", ":", "\n    ", "Pass", "\n", ("excepthandler", "ExceptHandler")],
-        )
-        checker.check_children(
-            ("excepthandler", "ExceptHandler"),
-            ["except", " ", "Name", "", ",", " ", "Name", "", ":", "\n    ", "Pass"],
-        )
-
     def test_try_except_node__with_as_syntax(self):
         source = dedent("""\
             try:

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1272,13 +1272,6 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_children("Module", ["", "Expr", "\n", "Expr", "\n"])
 
-    @testutils.only_for_versions_lower("3")
-    def test_how_to_handle_old_not_equals(self):
-        source = "1 <> 2\n"
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        checker.check_children("Compare", ["Num", " ", "<>", " ", "Num"])
-
     def test_semicolon(self):
         source = "1;\n"
         patchedast.get_patched_ast(source, True)

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -955,24 +955,6 @@ class PatchedASTTest(unittest.TestCase):
         checker.check_children("BoolOp", ["UnaryOp", " ", "or", " ", NameConstant])
 
     @testutils.only_for_versions_lower("3")
-    def test_print_node(self):
-        source = "print >>out, 1,\n"
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        checker.check_region("Print", 0, len(source) - 1)
-        checker.check_children(
-            "Print", ["print", " ", ">>", "", "Name", "", ",", " ", "Num", "", ","]
-        )
-
-    @testutils.only_for_versions_lower("3")
-    def test_printnl_node(self):
-        source = "print 1\n"
-        ast_frag = patchedast.get_patched_ast(source, True)
-        checker = _ResultChecker(self, ast_frag)
-        checker.check_region("Print", 0, len(source) - 1)
-        checker.check_children("Print", ["print", " ", "Num"])
-
-    @testutils.only_for_versions_lower("3")
     def test_raise_node_for_python2(self):
         source = "raise x, y, z\n"
         ast_frag = patchedast.get_patched_ast(source, True)


### PR DESCRIPTION
# Description

Remove code for old ast nodes for syntaxes that are no longer supported by Python 3.7 and upwards.

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
