### PR TITLE
Fix parsing of octal literal by patchedast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # **Upcoming release**
 
 - #604 Fix test that sometimes leaves files behind in the current working directory (@lieryan)
-- #606 Deprecate compress_objectdb and compress_history
-- #607 Remove importing from legacy files with `.pickle` suffix
-- #625 Remove support for deprecated ast nodes
-- #616, #621 Remove `file` builtins
-- #626 Install pre-commit hooks on rope repository
-- #548 Implement MoveGlobal using string as destination module names
+- #606 Deprecate compress_objectdb and compress_history (@lieryan)
+- #607 Remove importing from legacy files with `.pickle` suffix (@lieryan)
+- #625 Remove support for deprecated ast nodes (@lieryan)
+- #616, #621 Remove `file` builtins (@edreamleo)
+- #626 Install pre-commit hooks on rope repository (@lieryan)
+- #548 Implement MoveGlobal using string as destination module names (@lieryan)
+- #627 Fix parsing of octal literal (@lieryan)
 
 # Release 1.6.0
 

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -940,7 +940,7 @@ class _Source:
 
     def _get_number_pattern(self):
         # HACK: It is merely an approaximation and does the job
-        integer = r"\-?(0x[\da-fA-F]+|\d+)"
+        integer = r"\-?(0[xo][\da-fA-F]+|\d+)"
         return r"(%s(\.\d*)?|(\.\d+))([eE][-+]?\d+)?[jJ]?" % integer
 
     _string_pattern = None

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -94,13 +94,14 @@ class PatchedASTTest(unittest.TestCase):
         checker.check_region("Num", start, start + 3)
 
     def test_octal_integer_literals_and_region(self):
-        source = "a = -0125e1\n"
+        source = "a = -0o1251\n"
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
-        start = source.index("-0125e1") + 1
+        start = source.index("-0o1251") + 1
         end = start + 6
         # Python 3 parses as UnaryOp(op=USub(), operand=Num(n=10))
         checker.check_region("Num", start, end)
+        checker.check_children("Num", ["0o1251"])
 
     def test_integer_literals_and_sorted_children(self):
         source = "a = 10\n"


### PR DESCRIPTION
# Description

Python 3 no longer supports the `01234` syntax for specifying octal literals (it raises a syntax error), now you have to use `0o1234`.

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md