### PR TITLE
Implement version hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - #627 Fix parsing of octal literal (@lieryan)
 - #611 Implement JSON DataFile serialization (@lieryan)
 - #630 SQLite models improvements (@lieryan)
+- #631 Implement version hash (@lieryan)
 
 
 # Release 1.6.0

--- a/rope/base/versioning.py
+++ b/rope/base/versioning.py
@@ -33,7 +33,10 @@ def _get_prefs_data(project) -> str:
     return json.dumps(prefs_data, sort_keys=True, indent=2)
 
 
-def _get_file_content(module_name) -> str:
+def _get_file_content(module_name: str) -> str:
     models_module = importlib.util.find_spec(module_name)
+    assert models_module and models_module.loader
+    assert isinstance(models_module.loader, importlib.machinery.SourceFileLoader)
     src = models_module.loader.get_source(module_name)
+    assert src
     return src

--- a/rope/base/versioning.py
+++ b/rope/base/versioning.py
@@ -1,12 +1,12 @@
 import hashlib
+import importlib.util
 import json
 
-import rope
 import rope.base.project
 
 
 def calculate_version_hash(project: rope.base.project.Project) -> str:
-    hasher = hashlib.sha1()
+    hasher = hashlib.sha256()
 
     version_data = f"{rope.VERSION}"
     hasher.update(version_data.encode("ascii"))
@@ -14,6 +14,8 @@ def calculate_version_hash(project: rope.base.project.Project) -> str:
     serialized_prefs_data = _prefs_version_hash_data(project)
     hasher.update(serialized_prefs_data.encode("ascii"))
 
+    schema_file_hash = _schema_file_hash("rope.contrib.autoimport.models")
+    hasher.update(schema_file_hash.encode("ascii"))
     return hasher.hexdigest()
 
 
@@ -21,3 +23,9 @@ def _prefs_version_hash_data(project):
     prefs_data = dict(vars(project.prefs))
     del prefs_data["callbacks"]
     return json.dumps(prefs_data, sort_keys=True, indent=2)
+
+
+def _schema_file_hash(module_name):
+    models_module = importlib.util.find_spec(module_name)
+    src = models_module.loader.get_source(module_name)
+    return hashlib.sha256(src.encode("utf-8")).hexdigest()

--- a/rope/base/versioning.py
+++ b/rope/base/versioning.py
@@ -1,9 +1,23 @@
 import hashlib
+import json
 
 import rope
 import rope.base.project
 
 
 def calculate_version_hash(project: rope.base.project.Project) -> str:
-    hasher = hashlib.sha1(f"{rope.VERSION}".encode("ascii"))
+    hasher = hashlib.sha1()
+
+    version_data = f"{rope.VERSION}"
+    hasher.update(version_data.encode("ascii"))
+
+    serialized_prefs_data = _prefs_version_hash_data(project)
+    hasher.update(serialized_prefs_data.encode("ascii"))
+
     return hasher.hexdigest()
+
+
+def _prefs_version_hash_data(project):
+    prefs_data = dict(vars(project.prefs))
+    del prefs_data["callbacks"]
+    return json.dumps(prefs_data, sort_keys=True, indent=2)

--- a/rope/base/versioning.py
+++ b/rope/base/versioning.py
@@ -1,8 +1,9 @@
 import hashlib
 
 import rope
+import rope.base.project
 
 
-def calculate_version_hash():
+def calculate_version_hash(project: rope.base.project.Project) -> str:
     hasher = hashlib.sha1(f"{rope.VERSION}".encode("ascii"))
     return hasher.hexdigest()

--- a/rope/base/versioning.py
+++ b/rope/base/versioning.py
@@ -1,0 +1,8 @@
+import hashlib
+
+import rope
+
+
+def calculate_version_hash():
+    hasher = hashlib.sha1(f"{rope.VERSION}".encode("ascii"))
+    return hasher.hexdigest()

--- a/rope/base/versioning.py
+++ b/rope/base/versioning.py
@@ -11,8 +11,8 @@ def calculate_version_hash(project: rope.base.project.Project) -> str:
     version_data = f"{rope.VERSION}"
     hasher.update(version_data.encode("ascii"))
 
-    serialized_prefs_data = _prefs_version_hash_data(project)
-    hasher.update(serialized_prefs_data.encode("ascii"))
+    hashed_prefs_data = _prefs_version_hash_data(project)
+    hasher.update(hashed_prefs_data.encode("ascii"))
 
     schema_file_hash = _schema_file_hash("rope.contrib.autoimport.models")
     hasher.update(schema_file_hash.encode("ascii"))
@@ -24,7 +24,8 @@ def _prefs_version_hash_data(project):
     del prefs_data["project_opened"]
     del prefs_data["callbacks"]
     del prefs_data["dependencies"]
-    return json.dumps(prefs_data, sort_keys=True, indent=2)
+    serialized_prefs_data = json.dumps(prefs_data, sort_keys=True, indent=2)
+    return hashlib.sha256(serialized_prefs_data.encode("utf-8")).hexdigest()
 
 
 def _schema_file_hash(module_name):

--- a/rope/base/versioning.py
+++ b/rope/base/versioning.py
@@ -21,7 +21,9 @@ def calculate_version_hash(project: rope.base.project.Project) -> str:
 
 def _prefs_version_hash_data(project):
     prefs_data = dict(vars(project.prefs))
+    del prefs_data["project_opened"]
     del prefs_data["callbacks"]
+    del prefs_data["dependencies"]
     return json.dumps(prefs_data, sort_keys=True, indent=2)
 
 

--- a/rope/base/versioning.py
+++ b/rope/base/versioning.py
@@ -1,11 +1,12 @@
 import hashlib
 import importlib.util
 import json
+from typing import Dict
 
 import rope.base.project
 
 
-def get_version_hash_data(project: rope.base.project.Project) -> dict[str, str]:
+def get_version_hash_data(project: rope.base.project.Project) -> Dict[str, str]:
     version_hash_data = dict(
         version_data=f"{rope.VERSION}",
         prefs_data=_get_prefs_data(project),

--- a/ropetest/conftest.py
+++ b/ropetest/conftest.py
@@ -1,0 +1,40 @@
+import pathlib
+
+import pytest
+
+from rope.base import resources
+from ropetest import testutils
+
+
+@pytest.fixture
+def project():
+    project = testutils.sample_project()
+    yield project
+    testutils.remove_project(project)
+
+
+@pytest.fixture
+def project_path(project):
+    yield pathlib.Path(project.address)
+
+
+"""
+Standard project structure for pytest fixtures
+/mod1.py            -- mod1
+/pkg1/__init__.py   -- pkg1
+/pkg1/mod2.py       -- mod2
+"""
+
+@pytest.fixture
+def mod1(project) -> resources.File:
+    return testutils.create_module(project, "mod1")
+
+
+@pytest.fixture
+def pkg1(project) -> resources.Folder:
+    return testutils.create_package(project, "pkg1")
+
+
+@pytest.fixture
+def mod2(project, pkg1) -> resources.Folder:
+    return testutils.create_module(project, "mod2", pkg1)

--- a/ropetest/contrib/autoimport/conftest.py
+++ b/ropetest/contrib/autoimport/conftest.py
@@ -6,13 +6,6 @@ from ropetest import testutils
 
 
 @pytest.fixture
-def project():
-    project = testutils.sample_project()
-    yield project
-    testutils.remove_project(project)
-
-
-@pytest.fixture
 def mod1(project):
     mod1 = testutils.create_module(project, "mod1")
     yield mod1
@@ -21,11 +14,6 @@ def mod1(project):
 @pytest.fixture
 def mod1_path(mod1):
     yield pathlib.Path(mod1.real_path)
-
-
-@pytest.fixture
-def project_path(project):
-    yield pathlib.Path(project.address)
 
 
 @pytest.fixture

--- a/ropetest/versioningtest.py
+++ b/ropetest/versioningtest.py
@@ -1,3 +1,4 @@
+import secrets
 from unittest.mock import patch
 
 from rope.base import versioning
@@ -26,4 +27,11 @@ def test_version_hash_varies_on_user_preferences(project):
     assert project.prefs.get("automatic_soa") is False
     project.prefs.set("automatic_soa", True)
     patched_version_hash = versioning.calculate_version_hash(project)
+    assert actual_version_hash != patched_version_hash
+
+
+def test_version_hash_varies_on_schema_file_hash(project):
+    actual_version_hash = versioning.calculate_version_hash(project)
+    with patch("rope.base.versioning._schema_file_hash", return_value=secrets.token_hex()):
+        patched_version_hash = versioning.calculate_version_hash(project)
     assert actual_version_hash != patched_version_hash

--- a/ropetest/versioningtest.py
+++ b/ropetest/versioningtest.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+from rope.base import versioning
+
+
+def test_calculate_version_hash():
+    version_hash = versioning.calculate_version_hash()
+    assert isinstance(version_hash, str)
+
+def test_version_hash_is_constant():
+    version_hash_1 = versioning.calculate_version_hash()
+    version_hash_2 = versioning.calculate_version_hash()
+    assert version_hash_1 == version_hash_2
+
+def test_version_hash_varies_on_rope_version():
+    actual_version_hash = versioning.calculate_version_hash()
+    with patch("rope.VERSION", "1.0.0"):
+        patched_version_hash = versioning.calculate_version_hash()
+    assert actual_version_hash != patched_version_hash

--- a/ropetest/versioningtest.py
+++ b/ropetest/versioningtest.py
@@ -3,17 +3,19 @@ from unittest.mock import patch
 from rope.base import versioning
 
 
-def test_calculate_version_hash():
-    version_hash = versioning.calculate_version_hash()
+def test_calculate_version_hash(project):
+    version_hash = versioning.calculate_version_hash(project)
     assert isinstance(version_hash, str)
 
-def test_version_hash_is_constant():
-    version_hash_1 = versioning.calculate_version_hash()
-    version_hash_2 = versioning.calculate_version_hash()
+
+def test_version_hash_is_constant(project):
+    version_hash_1 = versioning.calculate_version_hash(project)
+    version_hash_2 = versioning.calculate_version_hash(project)
     assert version_hash_1 == version_hash_2
 
-def test_version_hash_varies_on_rope_version():
-    actual_version_hash = versioning.calculate_version_hash()
+
+def test_version_hash_varies_on_rope_version(project):
+    actual_version_hash = versioning.calculate_version_hash(project)
     with patch("rope.VERSION", "1.0.0"):
-        patched_version_hash = versioning.calculate_version_hash()
+        patched_version_hash = versioning.calculate_version_hash(project)
     assert actual_version_hash != patched_version_hash

--- a/ropetest/versioningtest.py
+++ b/ropetest/versioningtest.py
@@ -19,3 +19,11 @@ def test_version_hash_varies_on_rope_version(project):
     with patch("rope.VERSION", "1.0.0"):
         patched_version_hash = versioning.calculate_version_hash(project)
     assert actual_version_hash != patched_version_hash
+
+
+def test_version_hash_varies_on_user_preferences(project):
+    actual_version_hash = versioning.calculate_version_hash(project)
+    assert project.prefs.get("automatic_soa") is False
+    project.prefs.set("automatic_soa", True)
+    patched_version_hash = versioning.calculate_version_hash(project)
+    assert actual_version_hash != patched_version_hash

--- a/ropetest/versioningtest.py
+++ b/ropetest/versioningtest.py
@@ -30,8 +30,8 @@ def test_version_hash_varies_on_user_preferences(project):
     assert actual_version_hash != patched_version_hash
 
 
-def test_version_hash_varies_on_schema_file_hash(project):
+def test_version_hash_varies_on_get_file_content(project):
     actual_version_hash = versioning.calculate_version_hash(project)
-    with patch("rope.base.versioning._schema_file_hash", return_value=secrets.token_hex()):
+    with patch("rope.base.versioning._get_file_content", return_value=secrets.token_hex()):
         patched_version_hash = versioning.calculate_version_hash(project)
     assert actual_version_hash != patched_version_hash


### PR DESCRIPTION
# Description

Add a method to calculate version hash that will eventually be used to version autoimport.db for auto-detecting whether we need to refresh the cached data. 

Note that this PR hadn't implemented storing the version_hash into the metadata table in autoimport.db yet. 

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md

Part of patch series #565