### PR TITLE
PR: Remove `from ast import *` from rope.base.ast

### DIFF
--- a/rope/base/arguments.py
+++ b/rope/base/arguments.py
@@ -3,7 +3,6 @@ import ast
 import rope.base.evaluate
 
 
-
 class Arguments:
     """A class for evaluating parameters passed to a function
 

--- a/rope/base/arguments.py
+++ b/rope/base/arguments.py
@@ -1,5 +1,7 @@
+import ast
+
 import rope.base.evaluate
-from rope.base import ast
+
 
 
 class Arguments:

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -1,5 +1,4 @@
 import ast
-from ast import *  # noqa: F401,F403
 
 from rope.base import fscommands
 

--- a/rope/base/builtins.py
+++ b/rope/base/builtins.py
@@ -1,9 +1,10 @@
 """This module tries to support builtin types and functions."""
+import ast
 import inspect
 import io
 
 import rope.base.evaluate
-from rope.base import arguments, ast, pynames, pyobjects, utils
+from rope.base import arguments, pynames, pyobjects, utils
 
 
 class BuiltinModule(pyobjects.AbstractModule):

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -1,18 +1,20 @@
+import ast
 from operator import itemgetter
 from typing import Optional, Tuple
 
+import rope.base
 import rope.base.builtins
 import rope.base.pynames
 import rope.base.pyobjects
 from rope.base import (
     arguments,
-    ast,
     exceptions,
     nameanalyze,
     pyobjects,
     pyobjectsdef,
     worder,
 )
+from rope.base.ast import RopeNodeVisitor
 
 BadIdentifierError = exceptions.BadIdentifierError
 
@@ -49,7 +51,7 @@ def eval_str(holding_scope, name):
 def eval_str2(holding_scope, name):
     try:
         # parenthesizing for handling cases like 'a_var.\nattr'
-        node = ast.parse("(%s)" % name)
+        node = rope.base.ast.parse("(%s)" % name)
     except SyntaxError:
         raise BadIdentifierError("Not a resolvable python identifier selected.")
     return eval_node2(holding_scope, node)
@@ -157,7 +159,7 @@ class ScopeNameFinder:
         )
 
 
-class StatementEvaluator(ast.RopeNodeVisitor):
+class StatementEvaluator(RopeNodeVisitor):
     def __init__(self, scope):
         self.scope = scope
         self.result = None

--- a/rope/base/nameanalyze.py
+++ b/rope/base/nameanalyze.py
@@ -1,4 +1,6 @@
-from rope.base import ast
+import ast
+
+from rope.base.ast import RopeNodeVisitor
 
 
 def get_name_levels(node):
@@ -18,7 +20,7 @@ def get_name_levels(node):
     return visitor.names
 
 
-class _NodeNameCollector(ast.RopeNodeVisitor):
+class _NodeNameCollector(RopeNodeVisitor):
     def __init__(self, levels=None):
         self.names = []
         self.levels = levels

--- a/rope/base/oi/soa.py
+++ b/rope/base/oi/soa.py
@@ -1,7 +1,9 @@
-import rope.base.ast
+import ast
+
 import rope.base.oi.soi
 import rope.base.pynames
 from rope.base import arguments, evaluate, nameanalyze, pyobjects
+from rope.base.ast import RopeNodeVisitor
 
 
 def analyze_module(pycore, pymodule, should_analyze, search_subscopes, followed_calls):
@@ -31,11 +33,11 @@ def _analyze_node(pycore, pydefined, should_analyze, search_subscopes, followed_
             )
 
         visitor = SOAVisitor(pycore, pydefined, _follow if followed_calls else None)
-        for child in rope.base.ast.iter_child_nodes(pydefined.get_ast()):
+        for child in ast.iter_child_nodes(pydefined.get_ast()):
             visitor.visit(child)
 
 
-class SOAVisitor(rope.base.ast.RopeNodeVisitor):
+class SOAVisitor(RopeNodeVisitor):
     def __init__(self, pycore, pydefined, follow_callback=None):
         self.pycore = pycore
         self.pymodule = pydefined.get_module()
@@ -49,7 +51,7 @@ class SOAVisitor(rope.base.ast.RopeNodeVisitor):
         pass
 
     def _Call(self, node):
-        for child in rope.base.ast.iter_child_nodes(node):
+        for child in ast.iter_child_nodes(node):
             self.visit(child)
         primary, pyname = evaluate.eval_node2(self.scope, node.func)
         if pyname is None:
@@ -97,7 +99,7 @@ class SOAVisitor(rope.base.ast.RopeNodeVisitor):
         ]
 
     def _AnnAssign(self, node):
-        for child in rope.base.ast.iter_child_nodes(node):
+        for child in ast.iter_child_nodes(node):
             self.visit(child)
         visitor = _SOAAssignVisitor()
         nodes = []
@@ -108,7 +110,7 @@ class SOAVisitor(rope.base.ast.RopeNodeVisitor):
         self._evaluate_assign_value(node, nodes, type_hint=node.annotation)
 
     def _Assign(self, node):
-        for child in rope.base.ast.iter_child_nodes(node):
+        for child in ast.iter_child_nodes(node):
             self.visit(child)
         visitor = _SOAAssignVisitor()
         nodes = []
@@ -143,7 +145,7 @@ class _SOAAssignVisitor(nameanalyze._NodeNameCollector):
         self.nodes = []
 
     def _added(self, node, levels):
-        if isinstance(node, rope.base.ast.Subscript) and isinstance(
-            node.slice, (rope.base.ast.Index, rope.base.ast.expr)
+        if isinstance(node, ast.Subscript) and isinstance(
+            node.slice, (ast.Index, ast.expr)
         ):
             self.nodes.append((node, levels))

--- a/rope/base/oi/type_hinting/providers/numpydocstrings.py
+++ b/rope/base/oi/type_hinting/providers/numpydocstrings.py
@@ -27,7 +27,7 @@ class NumPyDocstringParamParser(docstrings.IParamParser):
                     p_type = m.group(1)
 
                 if p_type.startswith("{"):
-                    types = {type(x).__name__ for x in literal_eval(p_type)}
+                    types = {type(x).__name__ for x in ast.literal_eval(p_type)}
                     return list(types)
                 else:
                     return [p_type]

--- a/rope/base/oi/type_hinting/providers/numpydocstrings.py
+++ b/rope/base/oi/type_hinting/providers/numpydocstrings.py
@@ -3,9 +3,9 @@ Some code extracted (or based on code) from:
 https://github.com/davidhalter/jedi/blob/b489019f5bd5750051122b94cc767df47751ecb7/jedi/evaluate/docstrings.py
 Thanks to @davidhalter for this utils under MIT License.
 """
+import ast
 import re
 
-from rope.base.ast import literal_eval
 from rope.base.oi.type_hinting.providers import docstrings
 
 try:

--- a/rope/base/oi/type_hinting/providers/pep0484_type_comments.py
+++ b/rope/base/oi/type_hinting/providers/pep0484_type_comments.py
@@ -1,6 +1,5 @@
 import re
 
-from rope.base.oi.type_hinting import utils
 from rope.base.oi.type_hinting.providers import interfaces
 
 

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -1,6 +1,7 @@
+import ast
 from typing import Optional
 
-from rope.base import ast, exceptions, utils
+from rope.base import exceptions, utils
 
 
 class PyObject:

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -1,3 +1,5 @@
+import ast
+
 import rope.base.builtins
 import rope.base.codeanalyze
 import rope.base.evaluate
@@ -6,7 +8,6 @@ import rope.base.oi.soi
 import rope.base.pyscopes
 from rope.base import (
     arguments,
-    ast,
     exceptions,
     fscommands,
     nameanalyze,
@@ -14,6 +15,7 @@ from rope.base import (
     pyobjects,
     utils,
 )
+from rope.base.ast import RopeNodeVisitor
 
 
 class PyFunction(pyobjects.PyFunction):
@@ -177,7 +179,7 @@ class PyModule(pyobjects.PyModule):
                 raise
             else:
                 source = "\n"
-                node = ast.parse("\n")
+                node = rope.base.ast.parse("\n")
         self.source_code = source
         self.star_imports = []
         self.visitor_class = _GlobalVisitor
@@ -197,7 +199,7 @@ class PyModule(pyobjects.PyModule):
                     source_bytes = fscommands.unicode_to_file_data(source_code)
                 else:
                     source_bytes = source_code
-            ast_node = ast.parse(source_bytes, filename=filename)
+            ast_node = rope.base.ast.parse(source_bytes, filename=filename)
         except SyntaxError as e:
             raise exceptions.ModuleSyntaxError(filename, e.lineno, e.msg)
         except UnicodeDecodeError as e:
@@ -239,7 +241,7 @@ class PyPackage(pyobjects.PyPackage):
                 init_dot_py, force_errors=force_errors
             ).get_ast()
         else:
-            ast_node = ast.parse("\n")
+            ast_node = rope.base.ast.parse("\n")
         super().__init__(pycore, ast_node, resource)
 
     def _create_structural_attributes(self):
@@ -291,7 +293,7 @@ class PyPackage(pyobjects.PyPackage):
         return rope.base.libutils.modname(self.resource) if self.resource else ""
 
 
-class _AnnAssignVisitor(ast.RopeNodeVisitor):
+class _AnnAssignVisitor(RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
         self.assigned_ast = None
@@ -333,7 +335,7 @@ class _AnnAssignVisitor(ast.RopeNodeVisitor):
         pass
 
 
-class _ExpressionVisitor(ast.RopeNodeVisitor):
+class _ExpressionVisitor(RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
 
@@ -360,7 +362,7 @@ class _ExpressionVisitor(ast.RopeNodeVisitor):
         self.visit(node.value)
 
 
-class _AssignVisitor(ast.RopeNodeVisitor):
+class _AssignVisitor(RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
         self.assigned_ast = None

--- a/rope/base/pyscopes.py
+++ b/rope/base/pyscopes.py
@@ -1,5 +1,6 @@
+import ast
 import rope.base.builtins  # Use full qualification for clarity.
-from rope.base import ast, codeanalyze, exceptions, pynames, utils
+from rope.base import codeanalyze, exceptions, pynames, utils
 from rope.refactor import patchedast
 
 

--- a/rope/contrib/autoimport/__init__.py
+++ b/rope/contrib/autoimport/__init__.py
@@ -1,6 +1,5 @@
 """AutoImport module for rope."""
 from .pickle import AutoImport as _PickleAutoImport
-from .sqlite import AutoImport as _SqliteAutoImport
 
 AutoImport = _PickleAutoImport
 

--- a/rope/contrib/autoimport/parse.py
+++ b/rope/contrib/autoimport/parse.py
@@ -4,13 +4,14 @@ Functions to find importable names.
 Can extract names from source code of a python file, .so object, or builtin module.
 """
 
+import ast
 import inspect
 import logging
 import pathlib
 from importlib import import_module
 from typing import Generator, List
 
-from rope.base import ast
+import rope.base
 
 from .defs import (
     ModuleCompiled,
@@ -45,7 +46,7 @@ def get_names_from_file(
 ) -> Generator[PartialName, None, None]:
     """Get all the names from a given file using ast."""
     try:
-        root_node = ast.parse(module.read_bytes())
+        root_node = rope.base.ast.parse(module.read_bytes())
     except SyntaxError as error:
         print(error)
         return

--- a/rope/contrib/finderrors.py
+++ b/rope/contrib/finderrors.py
@@ -25,8 +25,8 @@ TODO:
 """
 import ast
 
-from rope.base.ast import RopeNodeVisitor
 from rope.base import evaluate, pyobjects
+from rope.base.ast import RopeNodeVisitor
 
 
 def find_errors(project, resource):

--- a/rope/contrib/finderrors.py
+++ b/rope/contrib/finderrors.py
@@ -23,7 +23,10 @@ TODO:
 * ... ;-)
 
 """
-from rope.base import ast, evaluate, pyobjects
+import ast
+
+from rope.base.ast import RopeNodeVisitor
+from rope.base import evaluate, pyobjects
 
 
 def find_errors(project, resource):
@@ -37,7 +40,7 @@ def find_errors(project, resource):
     return finder.errors
 
 
-class _BadAccessFinder(ast.RopeNodeVisitor):
+class _BadAccessFinder(RopeNodeVisitor):
     def __init__(self, pymodule):
         self.pymodule = pymodule
         self.scope = pymodule.get_scope()

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -1082,16 +1082,15 @@ def _get_function_kind(scope):
 
 
 def _parse_text(body):
-    parse = rope.base.ast.parse
     body = sourceutils.fix_indentation(body, 0)
     try:
-        node = parse(body)
+        node = rope.base.ast.parse(body)
     except SyntaxError:
         # needed to parse expression containing := operator
         try:
-            node = parse("(" + body + ")")
+            node = rope.base.ast.parse("(" + body + ")")
         except SyntaxError:
-            node = parse(
+            node = rope.base.ast.parse(
                 "async def __rope_placeholder__():\n"
                 + sourceutils.fix_indentation(body, 4)
             )

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -1,6 +1,8 @@
+import ast
 from typing import List, Union
 
-from rope.base import ast, exceptions, pynames, pynamesdef, utils
+from rope.base import exceptions, pynames, pynamesdef, utils
+from rope.base.ast import RopeNodeVisitor
 from rope.refactor.importutils import actions, importinfo
 
 
@@ -415,7 +417,7 @@ class _OneTimeSelector:
         return False
 
 
-class _UnboundNameFinder(ast.RopeNodeVisitor):
+class _UnboundNameFinder(RopeNodeVisitor):
     def __init__(self, pyobject):
         self.pyobject = pyobject
 

--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -26,7 +26,7 @@ from rope.refactor.importutils.module_imports import (
 )
 
 if typing.TYPE_CHECKING:
-    from rope.base import project, resources
+    from rope.base import resources
 
 
 def create_move(project, resource, offset=None):

--- a/rope/refactor/occurrences.py
+++ b/rope/refactor/occurrences.py
@@ -35,12 +35,12 @@ calling the `create_finder()` function.
     arguments
 """
 
-
+import ast
 import contextlib
 import re
 
+import rope.base
 from rope.base import (
-    ast,
     codeanalyze,
     evaluate,
     exceptions,
@@ -339,7 +339,7 @@ class _TextualFinder:
                     yield match.start("fstring") + occurrence_node.col_offset
 
     def _search_in_f_string(self, f_string):
-        tree = ast.parse(f_string)
+        tree = rope.base.ast.parse(f_string)
         for node in ast.walk(tree):
             if isinstance(node, ast.Name) and node.id == self.name:
                 yield node

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -1,10 +1,12 @@
+import ast
 import collections
 import numbers
 import re
 import warnings
 from itertools import chain
 
-from rope.base import ast, codeanalyze, exceptions
+import rope.base
+from rope.base import codeanalyze, exceptions
 
 COMMA_IN_WITH_PATTERN = re.compile(r"\(.*?\)|(,)")
 
@@ -15,7 +17,7 @@ def get_patched_ast(source, sorted_children=False):
     Adds ``sorted_children`` field only if `sorted_children` is True.
 
     """
-    return patch_ast(ast.parse(source), source, sorted_children)
+    return patch_ast(rope.base.ast.parse(source), source, sorted_children)
 
 
 def patch_ast(node, source, sorted_children=False):
@@ -34,7 +36,7 @@ def patch_ast(node, source, sorted_children=False):
     if hasattr(node, "region"):
         return node
     walker = _PatchingASTWalker(source, children=sorted_children)
-    ast.call_for_nodes(node, walker)
+    rope.base.ast.call_for_nodes(node, walker)
     return node
 
 
@@ -110,7 +112,7 @@ class _PatchingASTWalker:
                 continue
             offset = self.source.offset
             if isinstance(child, ast.AST):
-                ast.call_for_nodes(child, self)
+                rope.base.ast.call_for_nodes(child, self)
                 token_start = child.region[0]
             else:
                 if child is self.String:

--- a/rope/refactor/restructure.py
+++ b/rope/refactor/restructure.py
@@ -1,6 +1,7 @@
+import ast
 import warnings
 
-from rope.base import ast, builtins, change, codeanalyze, libutils, taskhandle
+from rope.base import builtins, change, codeanalyze, libutils, taskhandle
 from rope.refactor import patchedast, similarfinder, sourceutils
 from rope.refactor.importutils import module_imports
 

--- a/rope/refactor/similarfinder.py
+++ b/rope/refactor/similarfinder.py
@@ -1,9 +1,11 @@
 """This module can be used for finding similar code"""
+import ast
 import re
 
+import rope.base
 import rope.base.builtins  # Use full qualification for clarity.
 import rope.refactor.wildcards  # Use full qualification for clarity.
-from rope.base import ast, codeanalyze, exceptions, libutils
+from rope.base import codeanalyze, exceptions, libutils
 from rope.refactor import patchedast
 from rope.refactor.patchedast import MismatchedTokenError
 
@@ -73,10 +75,10 @@ class RawSimilarFinder:
     def __init__(self, source, node=None, does_match=None):
         if node is None:
             try:
-                node = ast.parse(source)
+                node = rope.base.ast.parse(source)
             except SyntaxError:
                 # needed to parse expression containing := operator
-                node = ast.parse("(" + source + ")")
+                node = rope.base.ast.parse("(" + source + ")")
         if does_match is None:
             self.does_match = self._simple_does_match
         else:
@@ -120,7 +122,7 @@ class RawSimilarFinder:
 
     def _create_pattern(self, expression):
         expression = self._replace_wildcards(expression)
-        node = ast.parse(expression)
+        node = rope.base.ast.parse(expression)
         # Getting Module.Stmt.nodes
         nodes = node.body
         if len(nodes) == 1 and isinstance(nodes[0], ast.Expr):
@@ -153,7 +155,7 @@ class _ASTMatcher:
     def find_matches(self):
         if self.matches is None:
             self.matches = []
-            ast.call_for_nodes(self.body, self._check_node, recursive=True)
+            rope.base.ast.call_for_nodes(self.body, self._check_node, recursive=True)
         return self.matches
 
     def _check_node(self, node):

--- a/rope/refactor/suites.py
+++ b/rope/refactor/suites.py
@@ -1,6 +1,7 @@
+import ast
 from itertools import chain
 
-from rope.base import ast
+from rope.base.ast import RopeNodeVisitor
 
 
 def find_visible(node, lines):
@@ -98,7 +99,7 @@ class Suite:
         return self.parent._get_level() + 1
 
 
-class _SuiteWalker(ast.RopeNodeVisitor):
+class _SuiteWalker(RopeNodeVisitor):
     def __init__(self, suite):
         self.suite = suite
         self.suites = []

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -1,5 +1,6 @@
+import ast
+
 from rope.base import (
-    ast,
     change,
     evaluate,
     exceptions,
@@ -8,6 +9,7 @@ from rope.base import (
     pyobjects,
     taskhandle,
 )
+from rope.base.ast import RopeNodeVisitor
 from rope.refactor import restructure, similarfinder, sourceutils
 
 
@@ -181,7 +183,7 @@ def _named_expr_count(node):
     return visitor.named_expression
 
 
-class _ReturnOrYieldFinder(ast.RopeNodeVisitor):
+class _ReturnOrYieldFinder(RopeNodeVisitor):
     def __init__(self):
         self.returns = 0
         self.named_expression = 0

--- a/rope/refactor/wildcards.py
+++ b/rope/refactor/wildcards.py
@@ -1,4 +1,5 @@
-from rope.base import ast, builtins, evaluate, pyobjects
+import ast
+from rope.base import builtins, evaluate, pyobjects
 from rope.refactor import occurrences, patchedast
 
 

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1,9 +1,10 @@
+import ast
 import itertools
 import sys
 import unittest
 from textwrap import dedent
 
-from rope.base import ast
+import rope.base
 from rope.refactor import patchedast
 from ropetest import testutils
 
@@ -1535,7 +1536,7 @@ class _ResultChecker:
                 return self.result is not None
 
         search = Search()
-        ast.call_for_nodes(self.ast, search, recursive=True)
+        rope.base.ast.call_for_nodes(self.ast, search, recursive=True)
         return search.result
 
     def check_children(self, text, children):

--- a/ropetest/refactor/suitestest.py
+++ b/ropetest/refactor/suitestest.py
@@ -1,7 +1,7 @@
 import unittest
 from textwrap import dedent
 
-from rope.base import ast
+import rope.base
 from rope.refactor import suites
 from ropetest import testutils
 
@@ -217,4 +217,4 @@ class SuiteTest(unittest.TestCase):
 
 
 def source_suite_tree(source):
-    return suites.ast_suite_tree(ast.parse(source))
+    return suites.ast_suite_tree(rope.base.ast.parse(source))


### PR DESCRIPTION
Another attempt at removing `from ast import *` from `rope.base.ast`.

- [x] Add `import ast` whenever a module uses `stdlib.ast`.
- [x] Remove all `from rope.base import ast` statements.
- [x] Add `from rope.base.ast import RopeNodeVisitor` as needed,
  removing several different qualifiers from references to `RopeNodeVisitor`.
- [x] Replace `ast.parse` with `rope.base.ast.parse`.
- [x] Replace `rope.base.ast.iter_child_nodes` with `ast.iter_child_nodes`.
- [x] Replace `ast.call_for_nodes` with `rope.base.ast.call_for_nodes`.
- [x] Replace `rope.base.ast` qualifiers by `ast` when referring to `stdlib.ast` nodes.
- [x] In numpydocstrings.py, remove `from rope.base.ast import literal_eval`,
   and qualify `literal_eval` with `ast`.
- [x] Remove several unnecessary imports.

**Summary of changes**

- `ast` always means `stdlib.ast`.
- Use full `rope.base.ast` qualifications for the `parse` and `call_for_nodes` functions.
  Alternatively, we could rename `ast.py` to `rast.py` and use the `rast` qualifier.
- Use no qualification for `RopeNodeVisitor`.

In short, all references to `stdlib.ast` and `rope.base.ast` are uniform and explicit.

**Update**

As noted below, three helper PR's will make most of the changes mentioned above.