### PR TITLE
PR: eliminate call_for_nodes

### DIFF
--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -1,5 +1,6 @@
 import ast
 from ast import *  # noqa: F401,F403
+from typing import Callable
 
 from rope.base import fscommands
 
@@ -21,10 +22,13 @@ def parse(source, filename="<string>", *args, **kwargs):  # type: ignore
         raise error
 
 
-def call_for_nodes(node, callback):
-    """If callback returns `True` the child nodes are skipped"""
-    result = callback(node)
-    if not result:
+def call_for_nodes(node, callback: Callable) -> None:
+    """
+    Apply the callback to node.
+    Return immediately if the callback returns a result.
+    Otherwise, recursively call *all* of node's direct children.
+    """
+    if not callback(node):
         for child in ast.iter_child_nodes(node):
             call_for_nodes(child, callback)
 

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -1,6 +1,5 @@
 import ast
 from ast import *  # noqa: F401,F403
-from typing import Callable
 
 from rope.base import fscommands
 
@@ -20,17 +19,6 @@ def parse(source, filename="<string>", *args, **kwargs):  # type: ignore
         error.filename = filename
         error.msg = str(e)
         raise error
-
-
-def call_for_nodes(node, callback: Callable) -> None:
-    """
-    Apply the callback to node.
-    Return immediately if the callback returns a result.
-    Otherwise, recursively call *all* of node's direct children.
-    """
-    if not callback(node):
-        for child in ast.iter_child_nodes(node):
-            call_for_nodes(child, callback)
 
 
 class RopeNodeVisitor(ast.NodeVisitor):

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -21,12 +21,12 @@ def parse(source, filename="<string>", *args, **kwargs):  # type: ignore
         raise error
 
 
-def call_for_nodes(node, callback, recursive=False):
+def call_for_nodes(node, callback):
     """If callback returns `True` the child nodes are skipped"""
     result = callback(node)
-    if recursive and not result:
+    if not result:
         for child in ast.iter_child_nodes(node):
-            call_for_nodes(child, callback, recursive)
+            call_for_nodes(child, callback)
 
 
 class RopeNodeVisitor(ast.NodeVisitor):

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -34,7 +34,7 @@ def patch_ast(node, source, sorted_children=False):
     if hasattr(node, "region"):
         return node
     walker = _PatchingASTWalker(source, children=sorted_children)
-    ast.call_for_nodes(node, walker)
+    walker(node)
     return node
 
 
@@ -110,7 +110,7 @@ class _PatchingASTWalker:
                 continue
             offset = self.source.offset
             if isinstance(child, ast.AST):
-                ast.call_for_nodes(child, self)
+                self.__call__(child)
                 token_start = child.region[0]
             else:
                 if child is self.String:

--- a/rope/refactor/similarfinder.py
+++ b/rope/refactor/similarfinder.py
@@ -151,9 +151,16 @@ class _ASTMatcher:
         self.matches_callback = does_match
 
     def find_matches(self):
+        """Find matches in self.body."""
         if self.matches is None:
             self.matches = []
-            ast.call_for_nodes(self.body, self._check_node)
+
+            def find(node):
+                if not self._check_node(node):
+                    for child in ast.iter_child_nodes(node):
+                        find(child)
+
+            find(self.body)
         return self.matches
 
     def _check_node(self, node):

--- a/rope/refactor/similarfinder.py
+++ b/rope/refactor/similarfinder.py
@@ -153,7 +153,7 @@ class _ASTMatcher:
     def find_matches(self):
         if self.matches is None:
             self.matches = []
-            ast.call_for_nodes(self.body, self._check_node, recursive=True)
+            ast.call_for_nodes(self.body, self._check_node)
         return self.matches
 
     def _check_node(self, node):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1535,7 +1535,6 @@ class _ResultChecker:
                         break
 
                 return self.result is not None
-                ### return bool(self.result)
         
         search = Search()
 

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1535,7 +1535,7 @@ class _ResultChecker:
                 return self.result is not None
 
         search = Search()
-        ast.call_for_nodes(self.ast, search, recursive=True)
+        ast.call_for_nodes(self.ast, search)
         return search.result
 
     def check_children(self, text, children):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1513,44 +1513,12 @@ class _ResultChecker:
         goal = text
         if not isinstance(text, (tuple, list)):
             goal = [text]
-            
-        ### from leo.core import leoGlobals as g  ###
-        
-        if 1:
-            class Search:
-                result = None
 
-                def __call__(self, node):
+        class Search:
+            result = None
 
-                    for text in goal:
-                        if sys.version_info >= (3, 8) and text in [
-                            "Num",
-                            "Str",
-                            "NameConstant",
-                            "Ellipsis",
-                        ]:
-                            text = "Constant"
-                        if str(node).startswith(text):
-                            self.result = node
-                            break
-                        if node.__class__.__name__.startswith(text):
-                            self.result = node
-                            break
+            def __call__(self, node):
 
-                    ### g.trace(node.__class__.__name__, repr(goal), self.result.__class__.__name__)  ###
-                    ### return self.result is not None
-                    return bool(self.result)
-            def _search_nodes(self, node, goal):
-                # Return the *last* result found.
-                result = self._search_node(node, goal)
-                if not result:
-                    for child in ast.iter_child_nodes(node):
-                        result = self._search_nodes(child, goal)
-                return result
-            def _search_node(self, node, goal):
-                result = None
-                ### from leo.core import leoGlobals as g  ###
-                ### g.trace(node.__class__.__name__, goal)
                 for text in goal:
                     if sys.version_info >= (3, 8) and text in [
                         "Num",
@@ -1560,24 +1528,24 @@ class _ResultChecker:
                     ]:
                         text = "Constant"
                     if str(node).startswith(text):
-                        ### self.result = node
-                        result = node
+                        self.result = node
                         break
                     if node.__class__.__name__.startswith(text):
-                        ### self.result = node
-                        result = node
+                        self.result = node
                         break
-                ### g.trace('DONE', node.__class__.__name__, repr(goal), result.__class__.__name__)  ###
-                return result
 
-            search = Search()
-            ast.call_for_nodes(self.ast, search)
-            ### g.trace('search.result', search.result.__class__.__name__)  ###
-            ### print('')  ###
-            return search.result
-        else:
-            return self._search_nodes(self.ast, goal)
+                return self.result is not None
+                ### return bool(self.result)
+        
+        search = Search()
 
+        def find(node):
+            if not search(node):
+                for child in ast.iter_child_nodes(node):
+                    find(child)
+
+        find(self.ast)
+        return search.result
     def check_children(self, text, children):
         node = self._find_node(text)
         if node is None:


### PR DESCRIPTION
A preliminary PR for PR #632.

**Background**

`rope.base.ast.call_for_nodes` looks fishy to me:

- It defines neither a depth first nor a breadth first traversal, but a strange partial mix.
  I know of no simple description of what it does.
- It is used in two search-related contexts, but in each case only a *single* node is returned.
- Almost any change to `call_for_nodes` causes multiple unit tests to fail.

@lieryan Is there a simple explanation for what `call_for_nodes` does?

**Summary of changes**

- [x] Replace calls to `call_for_nodes` where the `recursive` kwarg is (implicitly) false.
   See `patched_ast` and `_PatchingASTWalker._handle`.
- [x] Remove the `recursive` kwarg from `call_for_nodes`.
- [x] Remove the call to `call_for_nodes` in `_ASTMatcher.find_matches`.
- [x] Remove the call to `call_for_nodes` in `_ResultChecker._find_node`.
- [x] Remove `call_for_nodes` itself.

**Why call_for_nodes should not be a utility**

I understand neither what `_ASTMatcher.find_matches` and `_ResultChecker._find_node` are supposed to do nor how they do it. Imo, these strange traversals should be presented adjacent to the search code. Duplicating these traversals is better than creating a strange helper.