### PR TITLE
Remove call_for_nodes(recursive) argument 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - #611 Implement JSON DataFile serialization (@lieryan)
 - #630 SQLite models improvements (@lieryan)
 - #631 Implement version hash (@lieryan)
+- #634 Remove call_for_nodes(recursive) argument (@edreamleo)
 
 
 # Release 1.6.0

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -21,12 +21,12 @@ def parse(source, filename="<string>", *args, **kwargs):  # type: ignore
         raise error
 
 
-def call_for_nodes(node, callback, recursive=False):
+def call_for_nodes(node, callback):
     """If callback returns `True` the child nodes are skipped"""
     result = callback(node)
-    if recursive and not result:
+    if not result:
         for child in ast.iter_child_nodes(node):
-            call_for_nodes(child, callback, recursive)
+            call_for_nodes(child, callback)
 
 
 class RopeNodeVisitor(ast.NodeVisitor):

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -110,7 +110,7 @@ class _PatchingASTWalker:
                 continue
             offset = self.source.offset
             if isinstance(child, ast.AST):
-                self.__call__(child)
+                self(child)
                 token_start = child.region[0]
             else:
                 if child is self.String:

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -34,7 +34,7 @@ def patch_ast(node, source, sorted_children=False):
     if hasattr(node, "region"):
         return node
     walker = _PatchingASTWalker(source, children=sorted_children)
-    ast.call_for_nodes(node, walker)
+    walker(node)
     return node
 
 
@@ -110,7 +110,7 @@ class _PatchingASTWalker:
                 continue
             offset = self.source.offset
             if isinstance(child, ast.AST):
-                ast.call_for_nodes(child, self)
+                self.__call__(child)
                 token_start = child.region[0]
             else:
                 if child is self.String:

--- a/rope/refactor/similarfinder.py
+++ b/rope/refactor/similarfinder.py
@@ -153,7 +153,7 @@ class _ASTMatcher:
     def find_matches(self):
         if self.matches is None:
             self.matches = []
-            ast.call_for_nodes(self.body, self._check_node, recursive=True)
+            ast.call_for_nodes(self.body, self._check_node)
         return self.matches
 
     def _check_node(self, node):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1535,7 +1535,7 @@ class _ResultChecker:
                 return self.result is not None
 
         search = Search()
-        ast.call_for_nodes(self.ast, search, recursive=True)
+        ast.call_for_nodes(self.ast, search)
         return search.result
 
     def check_children(self, text, children):


### PR DESCRIPTION
# Description

This PR consists of only this commit from edreamleo:

- [Remove 'recursive' kwarg to call_for_nodes and simplify](https://github.com/python-rope/rope/pull/633/commits/bb5f312ba9e12b1cea82e926f6f3e60b819dbe59)
