### PR TITLE
PR: Rename rope.base.ast.parse to rope_parse

### DIFF
--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -4,7 +4,7 @@ from ast import *  # noqa: F401,F403
 from rope.base import fscommands
 
 
-def parse(source, filename="<string>", *args, **kwargs):  # type: ignore
+def rope_parse(source, filename="<string>", *args, **kwargs):  # type: ignore
     if isinstance(source, str):
         source = fscommands.unicode_to_file_data(source)
     if b"\r" in source:

--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -13,6 +13,7 @@ from rope.base import (
     pyobjectsdef,
     worder,
 )
+from rope.base.ast import rope_parse
 
 BadIdentifierError = exceptions.BadIdentifierError
 
@@ -49,7 +50,7 @@ def eval_str(holding_scope, name):
 def eval_str2(holding_scope, name):
     try:
         # parenthesizing for handling cases like 'a_var.\nattr'
-        node = ast.parse("(%s)" % name)
+        node = rope_parse("(%s)" % name)
     except SyntaxError:
         raise BadIdentifierError("Not a resolvable python identifier selected.")
     return eval_node2(holding_scope, node)

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -14,6 +14,7 @@ from rope.base import (
     pyobjects,
     utils,
 )
+from rope.base.ast import rope_parse
 
 
 class PyFunction(pyobjects.PyFunction):
@@ -177,7 +178,7 @@ class PyModule(pyobjects.PyModule):
                 raise
             else:
                 source = "\n"
-                node = ast.parse("\n")
+                node = rope_parse("\n")
         self.source_code = source
         self.star_imports = []
         self.visitor_class = _GlobalVisitor
@@ -197,7 +198,7 @@ class PyModule(pyobjects.PyModule):
                     source_bytes = fscommands.unicode_to_file_data(source_code)
                 else:
                     source_bytes = source_code
-            ast_node = ast.parse(source_bytes, filename=filename)
+            ast_node = rope_parse(source_bytes, filename=filename)
         except SyntaxError as e:
             raise exceptions.ModuleSyntaxError(filename, e.lineno, e.msg)
         except UnicodeDecodeError as e:
@@ -239,7 +240,7 @@ class PyPackage(pyobjects.PyPackage):
                 init_dot_py, force_errors=force_errors
             ).get_ast()
         else:
-            ast_node = ast.parse("\n")
+            ast_node = rope_parse("\n")
         super().__init__(pycore, ast_node, resource)
 
     def _create_structural_attributes(self):

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -1081,7 +1081,7 @@ def _get_function_kind(scope):
 def _parse_text(body):
     body = sourceutils.fix_indentation(body, 0)
     try:
-        node = ast.parse(body)
+        node = ast.parse(body)  # stdlib.ast.parse.
     except SyntaxError:
         # needed to parse expression containing := operator
         try:

--- a/rope/refactor/occurrences.py
+++ b/rope/refactor/occurrences.py
@@ -49,6 +49,7 @@ from rope.base import (
     utils,
     worder,
 )
+from rope.base.ast import rope_parse
 
 
 class Finder:
@@ -339,7 +340,7 @@ class _TextualFinder:
                     yield match.start("fstring") + occurrence_node.col_offset
 
     def _search_in_f_string(self, f_string):
-        tree = ast.parse(f_string)
+        tree = rope_parse(f_string)
         for node in ast.walk(tree):
             if isinstance(node, ast.Name) and node.id == self.name:
                 yield node

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -6,6 +6,9 @@ from itertools import chain
 
 from rope.base import ast, codeanalyze, exceptions
 
+# To do: PR #633: remove call_for_nodes.
+from rope.base.ast import call_for_nodes, rope_parse
+
 COMMA_IN_WITH_PATTERN = re.compile(r"\(.*?\)|(,)")
 
 
@@ -15,7 +18,7 @@ def get_patched_ast(source, sorted_children=False):
     Adds ``sorted_children`` field only if `sorted_children` is True.
 
     """
-    return patch_ast(ast.parse(source), source, sorted_children)
+    return patch_ast(rope_parse(source), source, sorted_children)
 
 
 def patch_ast(node, source, sorted_children=False):
@@ -34,7 +37,7 @@ def patch_ast(node, source, sorted_children=False):
     if hasattr(node, "region"):
         return node
     walker = _PatchingASTWalker(source, children=sorted_children)
-    ast.call_for_nodes(node, walker)
+    call_for_nodes(node, walker)
     return node
 
 
@@ -110,7 +113,7 @@ class _PatchingASTWalker:
                 continue
             offset = self.source.offset
             if isinstance(child, ast.AST):
-                ast.call_for_nodes(child, self)
+                call_for_nodes(child, self)
                 token_start = child.region[0]
             else:
                 if child is self.String:

--- a/rope/refactor/similarfinder.py
+++ b/rope/refactor/similarfinder.py
@@ -4,6 +4,7 @@ import re
 import rope.base.builtins  # Use full qualification for clarity.
 import rope.refactor.wildcards  # Use full qualification for clarity.
 from rope.base import ast, codeanalyze, exceptions, libutils
+from rope.base.ast import rope_parse
 from rope.refactor import patchedast
 from rope.refactor.patchedast import MismatchedTokenError
 
@@ -73,10 +74,10 @@ class RawSimilarFinder:
     def __init__(self, source, node=None, does_match=None):
         if node is None:
             try:
-                node = ast.parse(source)
+                node = rope_parse(source)
             except SyntaxError:
                 # needed to parse expression containing := operator
-                node = ast.parse("(" + source + ")")
+                node = rope_parse("(" + source + ")")
         if does_match is None:
             self.does_match = self._simple_does_match
         else:
@@ -120,7 +121,7 @@ class RawSimilarFinder:
 
     def _create_pattern(self, expression):
         expression = self._replace_wildcards(expression)
-        node = ast.parse(expression)
+        node = rope_parse(expression)
         # Getting Module.Stmt.nodes
         nodes = node.body
         if len(nodes) == 1 and isinstance(nodes[0], ast.Expr):

--- a/ropetest/refactor/suitestest.py
+++ b/ropetest/refactor/suitestest.py
@@ -1,7 +1,7 @@
 import unittest
 from textwrap import dedent
 
-from rope.base import ast
+from rope.base.ast import rope_parse
 from rope.refactor import suites
 from ropetest import testutils
 
@@ -217,4 +217,4 @@ class SuiteTest(unittest.TestCase):
 
 
 def source_suite_tree(source):
-    return suites.ast_suite_tree(ast.parse(source))
+    return suites.ast_suite_tree(rope_parse(source))


### PR DESCRIPTION
A PR designed to reduce diffs in PR #632.
- [x] Rename `rope.base.ast.parse` to `rope_parse`, adding `from rope.base.ast import rope_parse` as needed.
- [x] Add comment in `rope.refactor.extract._parse_text` that `ast.parse` refers to `stdlib.ast.parse`.
- [x] Add comment about `call_for_nodes` in `rope.refactor.patchedast`.
   If accepted, PR #633 will eliminate `call_for_nodes` entirely.

**Pitch**

- Removes any possibility of confusion between `stdlib.ast.parse` and `rope.base.ast.parse`.
- Removes unnecessary qualifications for `rope_parse`.
- Prepares for another PR that will remove unnecessary qualifications for `RopeNodeVisitor`.
- Will reduce diffs in PR #632.