### PR TITLE
Update readme to reflect 1.0 has been released.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Overview
 Most Python syntax up to Python 3.10 is supported. Please file bugs and contribute
 patches if you encounter gaps.
 
-Since version 1.0.0, rope does no longer support running on Python 2.
+Since version 1.0.0, rope no longer support running on Python 2.
 If you need Python 2 support, then check out the `python2` branch or the 0.x.x
 releases.
 

--- a/README.rst
+++ b/README.rst
@@ -32,10 +32,10 @@ Overview
 .. _`rope`: https://github.com/python-rope/rope
 
 
-Most Python syntax from Python 2.7 up to Python 3.10 is supported. Please file bugs and contribute
+Most Python syntax up to Python 3.10 is supported. Please file bugs and contribute
 patches if you encounter gaps.
 
-From version 1.0.0 onwards, rope will no longer support running on Python 2.
+Since version 1.0.0, rope does no longer support running on Python 2.
 If you need Python 2 support, then check out the `python2` branch or the 0.x.x
 releases.
 


### PR DESCRIPTION
# Description
Readme talked about dropping python 2 support in 1.0 in future tense, but 1.0 is actually out for a long time

