### PR TITLE
PR: Remove 'ast' qualification from refs to RopeNodeVisitor

### DIFF
--- a/rope/base/evaluate.py
+++ b/rope/base/evaluate.py
@@ -13,6 +13,7 @@ from rope.base import (
     pyobjectsdef,
     worder,
 )
+from rope.base.ast import RopeNodeVisitor
 
 BadIdentifierError = exceptions.BadIdentifierError
 
@@ -157,7 +158,7 @@ class ScopeNameFinder:
         )
 
 
-class StatementEvaluator(ast.RopeNodeVisitor):
+class StatementEvaluator(RopeNodeVisitor):
     def __init__(self, scope):
         self.scope = scope
         self.result = None

--- a/rope/base/nameanalyze.py
+++ b/rope/base/nameanalyze.py
@@ -1,4 +1,5 @@
 from rope.base import ast
+from rope.base.ast import RopeNodeVisitor
 
 
 def get_name_levels(node):
@@ -18,7 +19,7 @@ def get_name_levels(node):
     return visitor.names
 
 
-class _NodeNameCollector(ast.RopeNodeVisitor):
+class _NodeNameCollector(RopeNodeVisitor):
     def __init__(self, levels=None):
         self.names = []
         self.levels = levels

--- a/rope/base/pyobjectsdef.py
+++ b/rope/base/pyobjectsdef.py
@@ -14,6 +14,7 @@ from rope.base import (
     pyobjects,
     utils,
 )
+from rope.base.ast import RopeNodeVisitor
 
 
 class PyFunction(pyobjects.PyFunction):
@@ -291,7 +292,7 @@ class PyPackage(pyobjects.PyPackage):
         return rope.base.libutils.modname(self.resource) if self.resource else ""
 
 
-class _AnnAssignVisitor(ast.RopeNodeVisitor):
+class _AnnAssignVisitor(RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
         self.assigned_ast = None
@@ -333,7 +334,7 @@ class _AnnAssignVisitor(ast.RopeNodeVisitor):
         pass
 
 
-class _ExpressionVisitor(ast.RopeNodeVisitor):
+class _ExpressionVisitor(RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
 
@@ -360,7 +361,7 @@ class _ExpressionVisitor(ast.RopeNodeVisitor):
         self.visit(node.value)
 
 
-class _AssignVisitor(ast.RopeNodeVisitor):
+class _AssignVisitor(RopeNodeVisitor):
     def __init__(self, scope_visitor):
         self.scope_visitor = scope_visitor
         self.assigned_ast = None

--- a/rope/contrib/finderrors.py
+++ b/rope/contrib/finderrors.py
@@ -24,6 +24,7 @@ TODO:
 
 """
 from rope.base import ast, evaluate, pyobjects
+from rope.base.ast import RopeNodeVisitor
 
 
 def find_errors(project, resource):
@@ -37,7 +38,7 @@ def find_errors(project, resource):
     return finder.errors
 
 
-class _BadAccessFinder(ast.RopeNodeVisitor):
+class _BadAccessFinder(RopeNodeVisitor):
     def __init__(self, pymodule):
         self.pymodule = pymodule
         self.scope = pymodule.get_scope()

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from itertools import chain
 
 from rope.base import ast, codeanalyze
+from rope.base.ast import RopeNodeVisitor
 from rope.base.change import ChangeContents, ChangeSet
 from rope.base.exceptions import RefactoringError
 from rope.base.utils.datastructures import OrderedSet
@@ -514,7 +515,7 @@ class _ExceptionalConditionChecker:
         return next.isalnum() or next == "_"
 
 
-class _ExtractMethodParts(ast.RopeNodeVisitor):
+class _ExtractMethodParts(RopeNodeVisitor):
     def __init__(self, info):
         self.info = info
         self.info_collector = self._create_info_collector()
@@ -777,7 +778,7 @@ class _ExtractVariableParts:
         return {}
 
 
-class _FunctionInformationCollector(ast.RopeNodeVisitor):
+class _FunctionInformationCollector(RopeNodeVisitor):
     def __init__(self, start, end, is_global):
         self.start = start
         self.end = end
@@ -958,7 +959,7 @@ def _get_argnames(arguments):
     return result
 
 
-class _VariableReadsAndWritesFinder(ast.RopeNodeVisitor):
+class _VariableReadsAndWritesFinder(RopeNodeVisitor):
     def __init__(self):
         self.written = set()
         self.read = set()
@@ -998,7 +999,7 @@ class _VariableReadsAndWritesFinder(ast.RopeNodeVisitor):
         return visitor.read
 
 
-class _BaseErrorFinder(ast.RopeNodeVisitor):
+class _BaseErrorFinder(RopeNodeVisitor):
     @classmethod
     def has_errors(cls, code):
         if code.strip() == "":
@@ -1066,7 +1067,7 @@ class _AsyncStatementFinder(_BaseErrorFinder):
         pass
 
 
-class _GlobalFinder(ast.RopeNodeVisitor):
+class _GlobalFinder(RopeNodeVisitor):
     def __init__(self):
         self.globals_ = OrderedSet()
 

--- a/rope/refactor/importutils/module_imports.py
+++ b/rope/refactor/importutils/module_imports.py
@@ -1,6 +1,7 @@
 from typing import List, Union
 
 from rope.base import ast, exceptions, pynames, pynamesdef, utils
+from rope.base.ast import RopeNodeVisitor
 from rope.refactor.importutils import actions, importinfo
 
 
@@ -415,7 +416,7 @@ class _OneTimeSelector:
         return False
 
 
-class _UnboundNameFinder(ast.RopeNodeVisitor):
+class _UnboundNameFinder(RopeNodeVisitor):
     def __init__(self, pyobject):
         self.pyobject = pyobject
 

--- a/rope/refactor/suites.py
+++ b/rope/refactor/suites.py
@@ -1,6 +1,7 @@
 from itertools import chain
 
 from rope.base import ast
+from rope.base.ast import RopeNodeVisitor
 
 
 def find_visible(node, lines):
@@ -98,7 +99,7 @@ class Suite:
         return self.parent._get_level() + 1
 
 
-class _SuiteWalker(ast.RopeNodeVisitor):
+class _SuiteWalker(RopeNodeVisitor):
     def __init__(self, suite):
         self.suite = suite
         self.suites = []

--- a/rope/refactor/usefunction.py
+++ b/rope/refactor/usefunction.py
@@ -8,6 +8,7 @@ from rope.base import (
     pyobjects,
     taskhandle,
 )
+from rope.base.ast import RopeNodeVisitor
 from rope.refactor import restructure, similarfinder, sourceutils
 
 
@@ -181,7 +182,7 @@ def _named_expr_count(node):
     return visitor.named_expression
 
 
-class _ReturnOrYieldFinder(ast.RopeNodeVisitor):
+class _ReturnOrYieldFinder(RopeNodeVisitor):
     def __init__(self):
         self.returns = 0
         self.named_expression = 0


### PR DESCRIPTION
A helper PR for #632.

- [x] Remove `ast.` qualification from `RopeNodeVisitor`, adding
 `from rope.base.ast import RopeNodeVisitor` as needed.

**Pitch**

Because of the already-existing `Rope` prefix, there can be no confusion between `stdlib.ast.NodeVisitor` and `rope.base.ast.RopeNodeVisitor`.

This PR continues the convention (established by PR #635) that no qualification is need for members of `rope.base.ast` whose names start with `Rope` or `rope_`.

This PR should help clarify (and reduce diffs?) PR #632.