### PR TITLE
Add a function to identify ast Constant nodes more granularly

### DIFF
--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -1,7 +1,23 @@
 import ast
+import sys
 from ast import *  # noqa: F401,F403
 
 from rope.base import fscommands
+
+try:
+    from ast import _const_node_type_names
+except ImportError:
+    # backported from stdlib `ast`
+    _const_node_type_names = {
+        bool: "NameConstant",  # should be before int
+        type(None): "NameConstant",
+        int: "Num",
+        float: "Num",
+        complex: "Num",
+        str: "Str",
+        bytes: "Bytes",
+        type(...): "Ellipsis",
+    }
 
 
 def parse(source, filename="<string>", *args, **kwargs):  # type: ignore
@@ -35,3 +51,20 @@ class RopeNodeVisitor(ast.NodeVisitor):
         method = "_" + node.__class__.__name__
         visitor = getattr(self, method, self.generic_visit)
         return visitor(node)
+
+
+def get_const_subtype_name(node):
+    """Get pre-3.8 ast node name"""
+    # fmt: off
+    assert sys.version_info >= (3, 8), "This should only be called in Python 3.8 and above"
+    # fmt: on
+    assert isinstance(node, ast.Constant)
+    return _const_node_type_names[type(node.value)]
+
+
+def get_node_type_name(node):
+    return (
+        get_const_subtype_name(node)
+        if isinstance(node, ast.Constant)
+        else node.__class__.__name__
+    )

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -839,28 +839,14 @@ class PatchedASTTest(unittest.TestCase):
         )
 
     def test_set_node(self):
-        # make sure we are in a python version with set literals
         source = "{1, 2}\n"
-
-        try:
-            eval(source)
-        except SyntaxError:
-            return
-
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_region("Set", 0, len(source) - 1)
         checker.check_children("Set", ["{", "", "Num", "", ",", " ", "Num", "", "}"])
 
     def test_set_comp_node(self):
-        # make sure we are in a python version with set comprehensions
         source = "{i for i in range(1) if True}\n"
-
-        try:
-            eval(source)
-        except SyntaxError:
-            return
-
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_region("SetComp", 0, len(source) - 1)
@@ -873,14 +859,7 @@ class PatchedASTTest(unittest.TestCase):
         )
 
     def test_dict_comp_node(self):
-        # make sure we are in a python version with dict comprehensions
         source = "{i:i for i in range(1) if True}\n"
-
-        try:
-            eval(source)
-        except SyntaxError:
-            return
-
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         checker.check_region("DictComp", 0, len(source) - 1)


### PR DESCRIPTION
# Description

This is useful for the tests, that benefits from the more granular identification, making the test cases a bit more readable than if everything is an `ast.Constant`.