### PR TITLE
PR: remove unnecessary eval in generate.py

### DIFF
--- a/rope/contrib/generate.py
+++ b/rope/contrib/generate.py
@@ -18,7 +18,14 @@ def create_generate(kind, project, resource, offset, goal_resource=None):
     'package'.
 
     """
-    generate = eval("Generate" + kind.title())
+    d = {
+        'class': GenerateClass,
+        'function': GenerateFunction,
+        'module': GenerateModule,
+        'package': GeneratePackage,
+        'variable': GenerateVariable,
+    }
+    generate = d.get(kind)
     return generate(project, resource, offset, goal_resource=goal_resource)
 
 

--- a/rope/contrib/generate.py
+++ b/rope/contrib/generate.py
@@ -19,11 +19,11 @@ def create_generate(kind, project, resource, offset, goal_resource=None):
 
     """
     d = {
-        'class': GenerateClass,
-        'function': GenerateFunction,
-        'module': GenerateModule,
-        'package': GeneratePackage,
-        'variable': GenerateVariable,
+        "class": GenerateClass,
+        "function": GenerateFunction,
+        "module": GenerateModule,
+        "package": GeneratePackage,
+        "variable": GenerateVariable,
     }
     generate = d.get(kind)
     return generate(project, resource, offset, goal_resource=goal_resource)


### PR DESCRIPTION
A nit, discovered while investigating the unit test framework. The eval does not seem like a security problem :-)

The new code does, however, reinforce the docstring.

Hmm. `create_generate` does not appear anywhere in Rope except for the two unit tests that test it. Nor do the docs mention `create_generate`. What's going on?