### PR TITLE
Fix fstrings with mismatched parens

### DIFF
--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -130,7 +130,8 @@ class _PatchingASTWalker:
                 child = self.source[region[0] : region[1]]
                 token_start = region[0]
             if not first_token:
-                formats.append(self.source[offset:token_start])
+                if not isinstance(node, ast.JoinedStr):
+                    formats.append(self.source[offset:token_start])
                 if self.children:
                     children.append(self.source[offset:token_start])
             else:

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -220,6 +220,12 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         checker.check_children("BinOp", ["Num", " ", "+", " ", "Str"])
 
+    def test_handling_fstrings(self):
+        source = '1 + f"("\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children("BinOp", ["Num", " ", "+", " ", "JoinedStr"])
+
     def test_handling_implicit_string_concatenation(self):
         source = "a = '1''2'"
         ast_frag = patchedast.get_patched_ast(source, True)


### PR DESCRIPTION
Fixes #435

I am not sure if this is the "correct" thing to do here, but it fixes the test case and doesn't break any others.

When run against our internal python codebase (~3500 files) it produces no errors anymore.