### PR TITLE
PR for #662: fix mypy complaint

### DIFF
--- a/rope/base/oi/type_hinting/utils.py
+++ b/rope/base/oi/type_hinting/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import logging
-from typing import Union, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 
 import rope.base.utils as base_utils
 from rope.base import evaluate
@@ -76,7 +76,7 @@ def get_mro(pyclass):
     return class_list
 
 
-def resolve_type(type_name: str, pyobject: PyObj):
+def resolve_type(type_name: str, pyobject: PyObj) -> Optional[PyObject]:
     """
     Find proper type object from its name.
     """

--- a/rope/base/oi/type_hinting/utils.py
+++ b/rope/base/oi/type_hinting/utils.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
 import logging
-from typing import Optional, Union
+from typing import Union, TYPE_CHECKING
 
 import rope.base.utils as base_utils
 from rope.base import evaluate
 from rope.base.exceptions import AttributeNotFoundError
 from rope.base.pyobjects import PyClass, PyDefinedObject, PyFunction, PyObject
+
+if TYPE_CHECKING:
+    PyObj = Union[PyDefinedObject, PyObject]
 
 
 def get_super_func(pyfunc):
@@ -72,8 +76,7 @@ def get_mro(pyclass):
     return class_list
 
 
-def resolve_type(type_name, pyobject):
-    # type: (str, Union[PyDefinedObject, PyObject]) -> Optional[PyDefinedObject, PyObject]
+def resolve_type(type_name: str, pyobject: PyObj):
     """
     Find proper type object from its name.
     """

--- a/rope/base/oi/type_hinting/utils.py
+++ b/rope/base/oi/type_hinting/utils.py
@@ -76,7 +76,7 @@ def get_mro(pyclass):
     return class_list
 
 
-def resolve_type(type_name: str, pyobject: PyObj) -> Optional[PyObject]:
+def resolve_type(type_name: str, pyobject: PyObj) -> Optional[PyObj]:
     """
     Find proper type object from its name.
     """

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -6,8 +6,6 @@ from rope.base import ast, exceptions, utils
 if TYPE_CHECKING:
     from rope.base.resources import Resource
 
-    PyObj = Any  # temp.
-
 
 class PyObject:
     def __init__(self, type_):
@@ -25,7 +23,7 @@ class PyObject:
             raise exceptions.AttributeNotFoundError("Attribute %s not found" % name)
         return self.get_attributes()[name]
 
-    def get_module(self) -> Any:
+    def get_module(self) -> Optional[Any]:
         return None
 
     def get_type(self):

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -5,6 +5,7 @@ from rope.base import ast, exceptions, utils
 
 if TYPE_CHECKING:
     from rope.base.resources import Resource
+    from rope.base.pyscopes import Scope
 
 
 class PyObject:
@@ -162,7 +163,7 @@ class AbstractModule(PyObject):
     def get_doc(self) -> Optional[str]:
         return None
 
-    def get_module(self) -> Any:
+    def get_module(self) -> Optional[Scope]:
         return None
 
     def get_name(self) -> Optional[str]:

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -1,6 +1,12 @@
-from typing import Optional
+from __future__ import annotations
+from typing import Any, Optional, TYPE_CHECKING
 
 from rope.base import ast, exceptions, utils
+
+if TYPE_CHECKING:
+    from rope.base.resources import Resource
+
+    PyObj = Any  # temp.
 
 
 class PyObject:
@@ -18,6 +24,9 @@ class PyObject:
         if name not in self.get_attributes():
             raise exceptions.AttributeNotFoundError("Attribute %s not found" % name)
         return self.get_attributes()[name]
+
+    def get_module(self) -> Any:
+        return None
 
     def get_type(self):
         return self.type
@@ -152,11 +161,17 @@ class AbstractModule(PyObject):
     def __init__(self, doc=None):
         super().__init__(get_base_type("Module"))
 
-    def get_doc(self):
-        pass
+    def get_doc(self) -> Optional[str]:
+        return None
 
-    def get_resource(self):
-        pass
+    def get_module(self) -> Any:
+        return None
+
+    def get_name(self) -> Optional[str]:
+        return None
+
+    def get_resource(self) -> Optional[Resource]:
+        return None
 
 
 class PyDefinedObject:
@@ -219,7 +234,7 @@ class PyDefinedObject:
             self.scope = self._create_scope()
         return self.scope
 
-    def get_module(self):
+    def get_module(self) -> Any:
         current_object = self
         while current_object.parent is not None:
             current_object = current_object.parent
@@ -300,7 +315,7 @@ class _PyModule(PyDefinedObject, AbstractModule):
         PyDefinedObject.__init__(self, pycore, ast_node, None)
 
     @property
-    def absolute_name(self) -> str:
+    def absolute_name(self) -> Optional[str]:
         return self.get_name()
 
     def _get_concluded_data(self):

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from rope.base import ast, exceptions, utils
 
 if TYPE_CHECKING:
     from rope.base.resources import Resource
-    from rope.base.pyscopes import Scope
 
 
 class PyObject:
@@ -24,7 +23,7 @@ class PyObject:
             raise exceptions.AttributeNotFoundError("Attribute %s not found" % name)
         return self.get_attributes()[name]
 
-    def get_module(self) -> Optional[Any]:
+    def get_module(self) -> Optional[PyObject]:
         return None
 
     def get_type(self):
@@ -163,7 +162,7 @@ class AbstractModule(PyObject):
     def get_doc(self) -> Optional[str]:
         return None
 
-    def get_module(self) -> Optional[Scope]:
+    def get_module(self) -> Optional[PyObject]:
         return None
 
     def get_name(self) -> Optional[str]:
@@ -233,7 +232,7 @@ class PyDefinedObject:
             self.scope = self._create_scope()
         return self.scope
 
-    def get_module(self) -> Any:
+    def get_module(self) -> Optional[PyObject]:
         current_object = self
         while current_object.parent is not None:
             current_object = current_object.parent


### PR DESCRIPTION
See #662.  This PR fixes *all* mypy complaints involving pyobjects.py:

- In `rope/base/oi/type_hinting/utils.py` replace type comment with annotations.
- Add `AbstractModule.get_name` and `AbstractModule.get_resource`.
- Fully annotate all methods in `class AbstractModule`.

**To do**

- [ ] Verify (@lieryan) that the annotations for `PyObject.get_module` and `AbstractModule.get_module` are correct.