### PR TITLE
PR: Remove po._get_base_type. Simplify get_base_type & get_unknown

### DIFF
--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -5,9 +5,7 @@ from rope.base import ast, exceptions, utils
 
 class PyObject:
     def __init__(self, type_):
-        if type_ is None:
-            type_ = self
-        self.type = type_
+        self.type = self if type_ is None else type_
 
     def get_attributes(self):
         if self.type is self:
@@ -63,22 +61,13 @@ class PyObject:
         """The same as ``iter(self.get_attributes())``"""
         return iter(self.get_attributes())
 
-    _types = None
     _unknown = None
 
-    @staticmethod
-    def _get_base_type(name):
-        if PyObject._types is None:
-            PyObject._types = {}
-            base_type = PyObject(None)
-            PyObject._types["Type"] = base_type
-            PyObject._types["Module"] = PyObject(base_type)
-            PyObject._types["Function"] = PyObject(base_type)
-            PyObject._types["Unknown"] = PyObject(base_type)
-        return PyObject._types[name]
+
+_anchor_types = None
 
 
-def get_base_type(name):
+def get_base_type(name: str) -> PyObject:
     """Return the base type with name `name`.
 
     The base types are 'Type', 'Function', 'Module' and 'Unknown'.  It
@@ -86,35 +75,38 @@ def get_base_type(name):
     is discouraged.  Use classes defined in this module instead.
     For example instead of
     ``pyobject.get_type() == get_base_type('Function')`` use
-    ``isinstance(pyobject, AbstractFunction)``.
+    ``is_abstract_function(pyobject)``.
 
-    You can use `AbstractClass` for classes, `AbstractFunction` for
-    functions, and `AbstractModule` for modules.  You can also use
-    `PyFunction` and `PyClass` for testing if an object is
-    defined somewhere and rope can access its source.  These classes
-    provide more methods.
+    You can use `is_abstract_class` for classes, `is_abstract_functions` for
+    functions, and `is_abstract_module` for modules.
 
     """
-    return PyObject._get_base_type(name)
+    global _anchor_types
+    if _anchor_types is None:
+        base_type = PyObject(None)
+        _anchor_types = {
+            "Function": PyObject(base_type),
+            "Module": PyObject(base_type),
+            "Type": base_type,  # a Class.
+            "Unknown": PyObject(base_type),
+        }
+    return _anchor_types[name]
 
 
-def get_unknown():
-    """Return a pyobject whose type is unknown
+def get_unknown() -> PyObject:
+    """Return a pyobject whose type is unknown.
 
-    Note that two unknown objects are equal.  So for example you can
-    write::
+    Note that two unknown objects are equal.
+
+    For example you can write::
 
       if pyname.get_object() == get_unknown():
           print('cannot determine what this pyname holds')
 
     Rope could have used `None` for indicating unknown objects but
-    we had to check that in many places.  So actually this method
-    returns a null object.
-
+    we had to check that in many places.
     """
-    if PyObject._unknown is None:
-        PyObject._unknown = PyObject(get_base_type("Unknown"))
-    return PyObject._unknown
+    return get_base_type("Unknown")
 
 
 class AbstractClass(PyObject):

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -62,30 +62,26 @@ class PyObject:
         return iter(self.get_attributes())
 
 
-_anchor_types = None
+_base_types = None
 
 
 def get_base_type(name: str) -> PyObject:
     """Return the base type with name `name`.
 
-    The base types are 'Type', 'Function', 'Module' and 'Unknown'.  It
-    was used to check the type of a `PyObject` but currently its use
-    is discouraged.  Use classes defined in this module instead.
-    For example instead of
-    ``pyobject.get_type() == get_base_type('Function')`` use
-    ``isinstance(pyobject, AbstractFunction)``.
+    Use:        ``isinstance(pyobject, AbstractFunction)``
+    instead of: ``pyobject.get_type() == get_base_type('Function')``.
 
     """
-    global _anchor_types
-    if _anchor_types is None:
+    global _base_types
+    if _base_types is None:
         base_type = PyObject(None)
-        _anchor_types = {
+        _base_types = {
             "Function": PyObject(base_type),
             "Module": PyObject(base_type),
             "Type": base_type,  # a Class.
             "Unknown": PyObject(base_type),
         }
-    return _anchor_types[name]
+    return _base_types[name]
 
 
 def get_unknown() -> PyObject:

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -73,7 +73,7 @@ def get_base_type(name: str) -> PyObject:
     is discouraged.  Use classes defined in this module instead.
     For example instead of
     ``pyobject.get_type() == get_base_type('Function')`` use
-    ``is_abstract_function(pyobject)``.
+    ``isinstance(pyobject, AbstractFunction)``.
 
     You can use `is_abstract_class` for classes, `is_abstract_functions` for
     functions, and `is_abstract_module` for modules.

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -61,8 +61,6 @@ class PyObject:
         """The same as ``iter(self.get_attributes())``"""
         return iter(self.get_attributes())
 
-    _unknown = None
-
 
 _anchor_types = None
 

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -75,9 +75,6 @@ def get_base_type(name: str) -> PyObject:
     ``pyobject.get_type() == get_base_type('Function')`` use
     ``isinstance(pyobject, AbstractFunction)``.
 
-    You can use `is_abstract_class` for classes, `is_abstract_functions` for
-    functions, and `is_abstract_module` for modules.
-
     """
     global _anchor_types
     if _anchor_types is None:


### PR DESCRIPTION
- [x] Simplify and annotate the `get_base_type` and `get_unknown` functions in `pyobjects.py`.
- [x] Slightly simplify the docstrings. (See below)
- [x] Remove `PyObject._get_base_type`, a static method. It was a faux helper.
- [x] Use a ternary operator to simplify `PyObject.__init__`.
- [x] Remove the unused `_types` and `_unknown` module-level symbols.

**Discussion**

The `get_base_type` function is an important component of type inference. It deserves to be simplified. The Theory of Operation should discuss the role of the base types.

I don't recall how `get_base_type` came into my view. Maybe I was looking at the functions in `soi.py`. Or maybe I was studying the three `Abstract` classes.