### PR TITLE
PR: Fix/suppress all mypy complaints (based on master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - #650 Install pre-commit hooks on rope repository (@lieryan)
 - #655 Remove unused __init__() methods (@edreamleo, @lieryan)
+- #674 Fix/supress all mypy complaints
 
 
 # Release 1.7.0

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -5,6 +5,7 @@ from ast import *  # noqa: F401,F403
 from rope.base import fscommands
 
 try:
+    # mypy right complains: Module "ast" has no attribute "_const_node_type_names"
     from ast import _const_node_type_names  # type:ignore
 except ImportError:
     # backported from stdlib `ast`

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -5,7 +5,7 @@ from ast import *  # noqa: F401,F403
 from rope.base import fscommands
 
 try:
-    # mypy right complains: Module "ast" has no attribute "_const_node_type_names"
+    # Suppress the mypy complaint: Module "ast" has no attribute "_const_node_type_names"
     from ast import _const_node_type_names  # type:ignore
 except ImportError:
     # backported from stdlib `ast`

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -5,7 +5,7 @@ from ast import *  # noqa: F401,F403
 from rope.base import fscommands
 
 try:
-    from ast import _const_node_type_names
+    from ast import _const_node_type_names  # type:ignore
 except ImportError:
     # backported from stdlib `ast`
     assert sys.version_info < (3, 8)

--- a/rope/base/fscommands.py
+++ b/rope/base/fscommands.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import typing
+from typing import Any
 
 FileContent = typing.NewType("FileContent", bytes)
 
@@ -64,7 +65,7 @@ class FileSystemCommands:
 class SubversionCommands:
     def __init__(self, *args):
         self.normal_actions = FileSystemCommands()
-        import pysvn
+        import pysvn  # type:ignore
 
         self.client = pysvn.Client()
 
@@ -113,10 +114,10 @@ class MercurialCommands:
 
         self.repo = self.hg.hg.repository(self.ui, root)
 
-    def _import_mercurial(self):
-        import mercurial.commands
-        import mercurial.hg
-        import mercurial.ui
+    def _import_mercurial(self) -> Any:
+        import mercurial.commands  # type:ignore
+        import mercurial.hg  # type:ignore
+        import mercurial.ui  # type:ignore
 
         return mercurial
 

--- a/rope/base/fscommands.py
+++ b/rope/base/fscommands.py
@@ -11,7 +11,6 @@ import re
 import shutil
 import subprocess
 import typing
-from typing import Any
 
 FileContent = typing.NewType("FileContent", bytes)
 
@@ -114,7 +113,7 @@ class MercurialCommands:
 
         self.repo = self.hg.hg.repository(self.ui, root)
 
-    def _import_mercurial(self) -> Any:
+    def _import_mercurial(self):
         import mercurial.commands  # type:ignore
         import mercurial.hg  # type:ignore
         import mercurial.ui  # type:ignore

--- a/rope/base/oi/doa.py
+++ b/rope/base/oi/doa.py
@@ -4,9 +4,9 @@ import hashlib
 import hmac
 
 try:
-    import cPickle as pickle
+    import cPickle as pickle  # type:ignore
 except ImportError:
-    import pickle
+    import pickle  # type:ignore
 import marshal
 import os
 import socket

--- a/rope/base/oi/runmod.py
+++ b/rope/base/oi/runmod.py
@@ -4,7 +4,7 @@ def __rope_start_everything():
     import sys
 
     try:
-        import cPickle as pickle
+        import cPickle as pickle  # type:ignore
     except ImportError:
         import pickle
     import base64

--- a/rope/base/oi/type_hinting/evaluate.py
+++ b/rope/base/oi/type_hinting/evaluate.py
@@ -69,7 +69,7 @@ class SymbolTable:
             s.lbp = max(bp, s.lbp)
         return s
 
-    @multi
+    @multi  # type:ignore
     def infix(self, name, bp):
         symbol = self.symbol(name, bp)
 
@@ -79,7 +79,7 @@ class SymbolTable:
             self.second = parser.expression(bp)
             return self
 
-    @multi
+    @multi  # type:ignore
     def infix_r(self, name, bp):
         symbol = self.symbol(name, bp)
 
@@ -101,8 +101,8 @@ class SymbolTable:
             self.third = parser.expression(symbol2.lbp + 0.1)
             return self
 
-    @multi
-    def prefix(self, name, bp):
+    @multi  # type:ignore
+    def prefix(self, name, bp):  # type:ignore
         symbol = self.symbol(name, bp)
 
         @method(symbol)
@@ -110,7 +110,7 @@ class SymbolTable:
             self.first = parser.expression(bp)
             return self
 
-    @multi
+    @multi  # type:ignore
     def postfix(self, name, bp):
         symbol = self.symbol(name, bp)
 
@@ -237,18 +237,18 @@ symbol("(name)")
 symbol("(end)")
 
 
-@method(symbol("(name)"))
+@method(symbol("(name)"))  # type:ignore
 def nud(self, parser):
     return self
 
 
-@method(symbol("(name)"))
+@method(symbol("(name)"))  # type:ignore
 def evaluate(self, pyobject):
     return utils.resolve_type(self.value, pyobject)
 
 
 # Parametrized objects
-@method(symbol("["))
+@method(symbol("["))  # type:ignore
 def led(self, left, parser):
     self.first = left
     self.second = []
@@ -264,7 +264,7 @@ def led(self, left, parser):
     return self
 
 
-@method(symbol("["))
+@method(symbol("["))  # type:ignore
 def evaluate(self, pyobject):
     return utils.parametrize_type(
         self.first.evaluate(pyobject), *[i.evaluate(pyobject) for i in self.second]
@@ -272,7 +272,7 @@ def evaluate(self, pyobject):
 
 
 # Anonymous Function Calls
-@method(symbol("("))
+@method(symbol("("))  # type:ignore
 def nud(self, parser):
     self.second = []
     if parser.token.name != ")":
@@ -288,7 +288,7 @@ def nud(self, parser):
 
 
 # Function Calls
-@method(symbol("("))
+@method(symbol("("))  # type:ignore
 def led(self, left, parser):
     self.first = left
     self.second = []
@@ -304,13 +304,13 @@ def led(self, left, parser):
     return self
 
 
-@method(symbol("("))
+@method(symbol("("))  # type:ignore
 def evaluate(self, pyobject):
     # TODO: Implement me
     raise NotImplementedError
 
 
-@method(symbol("or"))
+@method(symbol("or"))  # type:ignore
 @method(symbol("|"))
 def evaluate(self, pyobject):
     # TODO: Implement me

--- a/rope/base/oi/type_hinting/providers/numpydocstrings.py
+++ b/rope/base/oi/type_hinting/providers/numpydocstrings.py
@@ -9,7 +9,7 @@ from rope.base.ast import literal_eval
 from rope.base.oi.type_hinting.providers import docstrings
 
 try:
-    from numpydoc.docscrape import NumpyDocString
+    from numpydoc.docscrape import NumpyDocString  # type:ignore
 except ImportError:
     NumpyDocString = None
 
@@ -40,4 +40,4 @@ class _DummyParamParser(docstrings.IParamParser):
 
 
 if not NumpyDocString:
-    NumPyDocstringParamParser = _DummyParamParser
+    NumPyDocstringParamParser = _DummyParamParser  # type:ignore

--- a/rope/base/oi/type_hinting/utils.py
+++ b/rope/base/oi/type_hinting/utils.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
 import logging
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 
 import rope.base.utils as base_utils
 from rope.base import evaluate
 from rope.base.exceptions import AttributeNotFoundError
 from rope.base.pyobjects import PyClass, PyDefinedObject, PyFunction, PyObject
+
+if TYPE_CHECKING:
+    PyObj = Union[PyDefinedObject, PyObject]
 
 
 def get_super_func(pyfunc):
@@ -72,8 +76,7 @@ def get_mro(pyclass):
     return class_list
 
 
-def resolve_type(type_name, pyobject):
-    # type: (str, Union[PyDefinedObject, PyObject]) -> Optional[PyDefinedObject, PyObject]
+def resolve_type(type_name: str, pyobject: PyObj) -> Optional[PyObj]:
     """
     Find proper type object from its name.
     """

--- a/rope/base/oi/type_hinting/utils.py
+++ b/rope/base/oi/type_hinting/utils.py
@@ -86,6 +86,9 @@ def resolve_type(
     logging.debug("Looking for %s", type_name)
     if "." not in type_name:
         try:
+            # XXX: this looks incorrect? It doesn't seem like it would work
+            # correctly if you have a type/class not defined in the
+            # module/global scope
             ret_type = (
                 pyobject.get_module().get_scope().get_name(type_name).get_object()
             )

--- a/rope/base/oi/type_hinting/utils.py
+++ b/rope/base/oi/type_hinting/utils.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
+
 import logging
-from typing import Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 import rope.base.utils as base_utils
 from rope.base import evaluate
 from rope.base.exceptions import AttributeNotFoundError
 from rope.base.pyobjects import PyClass, PyDefinedObject, PyFunction, PyObject
-
-if TYPE_CHECKING:
-    PyObj = Union[PyDefinedObject, PyObject]
 
 
 def get_super_func(pyfunc):
@@ -76,7 +74,10 @@ def get_mro(pyclass):
     return class_list
 
 
-def resolve_type(type_name: str, pyobject: PyObj) -> Optional[PyObj]:
+def resolve_type(
+    type_name: str,
+    pyobject: Union[PyDefinedObject, PyObject],
+) -> Optional[Union[PyDefinedObject, PyObject]]:
     """
     Find proper type object from its name.
     """

--- a/rope/base/prefs.py
+++ b/rope/base/prefs.py
@@ -1,3 +1,5 @@
+# mypy reports many problems.
+# type: ignore
 """Rope preferences."""
 from dataclasses import asdict, dataclass
 from textwrap import dedent

--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import contextlib
 import json
 import os
@@ -10,13 +11,16 @@ import rope.base.fscommands  # Use full qualification for clarity.
 import rope.base.resourceobserver as resourceobserver
 from rope.base import exceptions, history, pycore, taskhandle, utils
 from rope.base.exceptions import ModuleNotFoundError
-from rope.base.prefs import Prefs, get_config
+
+# At present rope.base.prefs starts with `# type:ignore`.
+# As a result, mypy knows nothing about Prefs and get_config.
+from rope.base.prefs import Prefs, get_config  # type:ignore
 from rope.base.resources import File, Folder, _ResourceMatcher
 
 try:
-    import cPickle as pickle
+    import cPickle as pickle  # type:ignore
 except ImportError:
-    import pickle
+    import pickle  # type:ignore
 
 
 class _Project:

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -19,6 +19,9 @@ class PyObject:
             raise exceptions.AttributeNotFoundError("Attribute %s not found" % name)
         return self.get_attributes()[name]
 
+    def get_module(self):
+        return None
+
     def get_type(self):
         return self.type
 
@@ -224,6 +227,9 @@ class PyDefinedObject:
         while current_object.parent is not None:
             current_object = current_object.parent
         return current_object
+
+    def get_name(self):
+        return None
 
     def get_doc(self) -> Optional[str]:
         if len(self.get_ast().body) > 0:

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -435,7 +435,7 @@ class AutoImport:
 
         folders = self.project.get_python_path_folders()
         folder_paths = map(lambda folder: Path(folder.real_path), folders)
-        folder_paths = filter(filter_folders, folder_paths)
+        folder_paths = filter(filter_folders, folder_paths)  # type:ignore
         return list(OrderedDict.fromkeys(folder_paths))
 
     def _get_available_packages(self) -> List[Package]:

--- a/rope/refactor/extract.py
+++ b/rope/refactor/extract.py
@@ -1,4 +1,5 @@
 import re
+from typing import Dict
 from contextlib import contextmanager
 from itertools import chain
 
@@ -34,7 +35,7 @@ from rope.refactor import patchedast, similarfinder, sourceutils, suites, usefun
 # There are a few more helper functions and classes used by above
 # classes.
 class _ExtractRefactoring:
-    kind_prefixes = {}
+    kind_prefixes: Dict[str, str] = {}
 
     def __init__(self, project, resource, start_offset, end_offset, variable=False):
         self.project = project

--- a/rope/refactor/importutils/importinfo.py
+++ b/rope/refactor/importutils/importinfo.py
@@ -1,3 +1,6 @@
+from typing import List, Tuple
+
+
 class ImportStatement:
     """Represent an import in a module
 
@@ -187,7 +190,7 @@ class FromImport(ImportInfo):
 
 
 class EmptyImport(ImportInfo):
-    names_and_aliases = []
+    names_and_aliases: List[Tuple[str, str]] = []
 
     def is_empty(self):
         return True

--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -7,7 +7,7 @@ based on inputs.
 from __future__ import annotations
 
 import typing
-from typing import Union
+from typing import Optional, List, Union
 
 from rope.base import (
     codeanalyze,
@@ -310,8 +310,8 @@ class MoveGlobal:
 
     def get_changes(
         self,
-        dest: Union[None, str, resources.Resource],
-        resources=None,
+        dest: Optional[Union[str, resources.Resource]],
+        resources: Optional[List[resources.File]] = None,
         task_handle=taskhandle.DEFAULT_TASK_HANDLE,
     ):
         """Return the changes needed for this refactoring
@@ -324,15 +324,21 @@ class MoveGlobal:
           will be applied to all python files.
 
         """
+        # To do (in another PR): Create a new var: dest_resource: resource.Reource
+        # Doing so should remove the type:ignore below.
         if isinstance(dest, str):
             dest = self.project.find_module(dest)
         if resources is None:
             resources = self.project.get_python_files()
+        # The previous guards protect against this mypy complaint:
+        # "Resource" has no attribute "has_child"
         if dest is None or not dest.exists():
             raise exceptions.RefactoringError("Move destination does not exist.")
-        if dest.is_folder() and dest.has_child("__init__.py"):
-            dest = dest.get_child("__init__.py")
-        if dest.is_folder():
+        if dest.is_folder() and dest.has_child("__init__.py"):  # type:ignore
+            dest = dest.get_child("__init__.py")  # type:ignore
+        # The previous guards protect against this mypy complaint:
+        # Item "None" of "Union[str, Resource, None]" has no attribute "is_folder"
+        if dest.is_folder():  # type:ignore
             raise exceptions.RefactoringError(
                 "Move destination for non-modules should not be folders."
             )


### PR DESCRIPTION
**Summary**

This PR contains the *minimum* changes (to the `master` branch) needed to fix and suppress all mypy complaints *without* removing the wildcard import in `rope.base.ast`.

This PR:
- Shows that mypy is not adversely affected by the wildcard import in `rope.base.ast`!!
- Suppresses all mypy complaints, mostly with `# type: ignore` comments.
  Comments describe all interesting/unusual suppressions.
- Adds two missing base-class methods whose absence rightly generated mypy errors.

**Details**

- Add `# type: ignore` as needed to suppress warnings about optional imports.
- **rope.base.ast**: mypy rightly complains about an import, but this import does not mypy significantly!
- **rope.base.oi.type_hinting.evaluate**: Suppress complaints about functions decorated with `@multi`.
- **rope.base.oi.type_hinting.utils**: Replace a type comment with a proper annotation.
  The new annotation uses a type alias, `PyObj`, showing that annotations need not be visually daunting.
- **rope.base.prefs**: Suppress all mypy errors by adding `# type: ignore` as the first line of the file.
- **rope.base.project**:  Add  `# type: ignore` to compensate for suppressing mypy in `rope.base.prefs`.
- **Add two missing methods**: `pyobjects.PyObject.get_module` and `pyobjects.PyDefinedObject.get_name`.
  Imo:
    - mypy rightly complained about these methods.
    - Adding these two missing method will help simplify the `Abstract` classes later on.
 - Add (straightforward) annotations of `List` and `Dict` types as needed.
 - **MoveGlobal.get_changes**: Revise existing annotations and suppress complaints.
   Comments suggest actual code revisions, but such changes should wait for a separate PR.