### PR TITLE
PR: Annotate functions/methods related to inference

### DIFF
--- a/rope/base/builtins.py
+++ b/rope/base/builtins.py
@@ -1,9 +1,14 @@
 """This module tries to support builtin types and functions."""
+from __future__ import annotations
 import inspect
 import io
+import typing
 
 import rope.base.evaluate
 from rope.base import arguments, ast, pynames, pyobjects, utils
+
+if typing.TYPE_CHECKING:
+    from rope.base.pyobjects import PyObject
 
 
 class BuiltinModule(pyobjects.AbstractModule):
@@ -450,7 +455,7 @@ class Tuple(BuiltinClass):
         }
         super().__init__(tuple, attributes)
 
-    def get_holding_objects(self):
+    def get_holding_objects(self) -> typing.List[PyObject]:
         return self.objects
 
     def _new_tuple(self, args):

--- a/rope/base/pyobjects.py
+++ b/rope/base/pyobjects.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
 from typing import Optional
 
 from rope.base import ast, exceptions, utils
 
 
 class PyObject:
-    def __init__(self, type_):
+    def __init__(self, type_: PyObject):
         if type_ is None:
             type_ = self
         self.type = type_
@@ -22,7 +23,7 @@ class PyObject:
     def get_module(self):
         return None
 
-    def get_type(self):
+    def get_type(self) -> PyObject:
         return self.type
 
     def __getitem__(self, key):


### PR DESCRIPTION
This is the start of the my direct study of Rope's inference code.

Notes:

- Only `builtins.Tuple` defines `get_holding_objects`.
  Huh? The calls to this method look like calls to `PyObject.get_holding_objects`.
  It's a pretty strange situation.