### PR TITLE
Fix autoimport not scanning packages recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - #650 Install pre-commit hooks on rope repository (@lieryan)
 - #655 Remove unused __init__() methods (@edreamleo, @lieryan)
 - #674 Fix/supress all mypy complaints
+- #687 Fix autoimport not scanning packages recursively (@lieryan)
 
 
 # Release 1.7.0

--- a/rope/contrib/autoimport/utils.py
+++ b/rope/contrib/autoimport/utils.py
@@ -118,7 +118,7 @@ def get_files(
         yield ModuleFile(package.path, package.path.stem, underlined, False)
     else:
         assert package.path
-        for file in package.path.glob("*.py"):
+        for file in package.path.glob("**/*.py"):
             if file.name == "__init__.py":
                 yield ModuleFile(
                     file,

--- a/ropetest/contrib/autoimport/utilstest.py
+++ b/ropetest/contrib/autoimport/utilstest.py
@@ -1,5 +1,7 @@
 """Tests for autoimport utility functions, written in pytest"""
 
+from pathlib import Path
+
 from rope.contrib.autoimport import utils
 from rope.contrib.autoimport.defs import Package, PackageType, Source
 
@@ -57,3 +59,13 @@ def test_get_package_tuple_compiled(compiled_lib):
     assert Package(
         lib_name, Source.STANDARD, lib_path, PackageType.COMPILED
     ) == utils.get_package_tuple(lib_path)
+
+
+def test_get_files(project, mod1, pkg1, mod2):
+    root: Package = utils.get_package_tuple(project.root.pathlib)
+    paths = [m.filepath.relative_to(project.root.pathlib) for m in utils.get_files(root)]
+    assert paths == [
+        Path("mod1.py"),
+        Path("pkg1/__init__.py"),
+        Path("pkg1/mod2.py"),
+    ]

--- a/ropetest/contrib/autoimport/utilstest.py
+++ b/ropetest/contrib/autoimport/utilstest.py
@@ -64,8 +64,8 @@ def test_get_package_tuple_compiled(compiled_lib):
 def test_get_files(project, mod1, pkg1, mod2):
     root: Package = utils.get_package_tuple(project.root.pathlib)
     paths = [m.filepath.relative_to(project.root.pathlib) for m in utils.get_files(root)]
-    assert paths == [
+    assert set(paths) == {
         Path("mod1.py"),
         Path("pkg1/__init__.py"),
         Path("pkg1/mod2.py"),
-    ]
+    }


### PR DESCRIPTION
# Description

Change glob pattern in get_files() to scan site-packages recursively.

Fixes #687 

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md