### PR TITLE
Add prefer_global_from_import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # **Upcoming release**
 
 - #624 Implement `nonlocal` keyword (@lieryan)
+- #696 Introduce the `prefer_global_from_imports` configuration (@nicoolas25)
 
 # Release 1.8.0
 

--- a/docs/default_config.py
+++ b/docs/default_config.py
@@ -112,6 +112,12 @@ def set_prefs(prefs):
     #
     #     prefs["prefer_module_from_imports"] = False
 
+    # If `True`, rope will insert new name imports as
+    # `from <module> import <global>` by default.
+    #
+    #     prefs["prefer_global_from_imports"] = False
+
+
     # If `True`, rope will transform a comma list of imports into
     # multiple separate import statements when organizing
     # imports.

--- a/rope/base/prefs.py
+++ b/rope/base/prefs.py
@@ -143,7 +143,14 @@ Builtin and c-extension modules that are allowed to be imported and inspected by
     prefer_module_from_imports: bool = field(
         default=False,
         description=dedent("""
-            If `True`, rope will insert new module imports as `from <package> import <module>`by default.
+            If `True`, rope will insert new module imports as `from <package> import <module>` by default.
+        """),
+    )
+
+    prefer_global_from_imports: bool = field(
+        default=False,
+        description=dedent("""
+            If `True`, rope will insert new global imports as `from <module> import <global>` by default.
         """),
     )
 

--- a/rope/refactor/importutils/__init__.py
+++ b/rope/refactor/importutils/__init__.py
@@ -305,19 +305,23 @@ def add_import(project, pymodule, module_name, name=None):
     # from mod import name
     if name is not None:
         from_import = FromImport(module_name, 0, [(name, None)])
+        if project.prefs.get("prefer_global_from_imports"):
+            selected_import = from_import
         names.append(name)
         candidates.append(from_import)
+
     # from pkg import mod
     if "." in module_name:
         pkg, mod = module_name.rsplit(".", 1)
         from_import = FromImport(pkg, 0, [(mod, None)])
-        if project.prefs.get("prefer_module_from_imports"):
+        if project.prefs.get("prefer_module_from_imports") and not selected_import:
             selected_import = from_import
         candidates.append(from_import)
         if name:
             names.append(mod + "." + name)
         else:
             names.append(mod)
+
     # import mod
     normal_import = NormalImport([(module_name, None)])
     if name:


### PR DESCRIPTION
# Description

Adding a `prefer_global_from_import` configuration option for pick the "global" form of import over the module one.

```diff
- from pkg import mod1
- mod1.AClass()
+ from pkg.mod1 import AClass
+ AClass()
```

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
