### PR TITLE
Add metadata table to Autoimport database

### DIFF
--- a/docs/library.rst
+++ b/docs/library.rst
@@ -844,9 +844,11 @@ autoimport will be removed in the future.
 `rope.contrib.autoimport.sqlite`
 --------------------------------
 
-By default, the sqlite3-based only stores autoimport cache in an in-memory
+Currently, the sqlite3-based only stores autoimport cache in an in-memory
 sqlite3 database, you can make it write the import cache to persistent storage
-by passing memory=False to AutoImport constructor.
+by passing memory=False to AutoImport constructor. This default will change in
+the future, if you want to always store the autoimport cache in-memory, then
+you need to explicitly pass memory=True.
 
 It must be closed when done with the ``AutoImport.close()`` method.
 

--- a/rope/contrib/autoimport/models.py
+++ b/rope/contrib/autoimport/models.py
@@ -79,6 +79,7 @@ class Metadata(Model):
     schema = {
         "version_hash": "TEXT",
         "hash_data": "TEXT",
+        "created_at": "TEXT",
     }
     columns = list(schema.keys())
     objects = Query(table_name, columns)

--- a/rope/contrib/autoimport/models.py
+++ b/rope/contrib/autoimport/models.py
@@ -44,7 +44,7 @@ class Query:
         )
 
     def drop_table(self) -> FinalQuery:
-        return FinalQuery(f"DROP TABLE {self.query}")
+        return FinalQuery(f"DROP TABLE IF EXISTS {self.query}")
 
     def delete_from(self) -> FinalQuery:
         return FinalQuery(f"DELETE FROM {self.query}")
@@ -71,6 +71,17 @@ class Model(ABC):
         connection.execute(
             f"CREATE TABLE IF NOT EXISTS {cls.table_name}({metadata_table_definition})"
         )
+
+
+class Metadata(Model):
+    table_name = "metadata"
+
+    schema = {
+        "version_hash": "TEXT",
+        "hash_data": "TEXT",
+    }
+    columns = list(schema.keys())
+    objects = Query(table_name, columns)
 
 
 class Name(Model):

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -8,6 +8,7 @@ import sys
 import warnings
 from collections import OrderedDict
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
+from datetime import datetime
 from itertools import chain
 from pathlib import Path
 from typing import Generator, Iterable, Iterator, List, Optional, Set, Tuple
@@ -441,8 +442,13 @@ class AutoImport:
             data = (
                 versioning.calculate_version_hash(self.project),
                 json.dumps(versioning.get_version_hash_data(self.project)),
+                datetime.utcnow().isoformat(),
             )
-            assert models.Metadata.columns == ["version_hash", "hash_data"]
+            assert models.Metadata.columns == [
+                "version_hash",
+                "hash_data",
+                "created_at",
+            ]
             self._execute(models.Metadata.objects.insert_into(), data)
 
             self.connection.commit()

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -4,6 +4,7 @@ import contextlib
 import re
 import sqlite3
 import sys
+import warnings
 from collections import OrderedDict
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
 from itertools import chain
@@ -63,6 +64,9 @@ def filter_packages(
     return filter(filter_package, packages)
 
 
+_deprecated_default: bool = object()  # type: ignore
+
+
 class AutoImport:
     """A class for finding the module that provides a name.
 
@@ -76,7 +80,13 @@ class AutoImport:
     project: Project
     project_package: Package
 
-    def __init__(self, project: Project, observe=True, underlined=False, memory=True):
+    def __init__(
+        self,
+        project: Project,
+        observe: bool = True,
+        underlined: bool = False,
+        memory: bool = _deprecated_default,
+    ):
         """Construct an AutoImport object.
 
         Parameters
@@ -87,8 +97,14 @@ class AutoImport:
             if true, listen for project changes and update the cache.
         underlined : bool
             If `underlined` is `True`, underlined names are cached, too.
-        memory : bool
-            if true, don't persist to disk
+        memory:
+            If true, don't persist to disk
+
+            DEPRECATION NOTICE: The default value will change to use an on-disk
+            database by default in the future. If you want to use an in-memory
+            database, you need to pass `memory=True` explicitly:
+
+                autoimport = AutoImport(..., memory=True)
         """
         self.project = project
         project_package = get_package_tuple(Path(project.root.real_path), project)
@@ -96,18 +112,49 @@ class AutoImport:
         assert project_package.path is not None
         self.project_package = project_package
         self.underlined = underlined
-        db_path: str
-        if memory or project.ropefolder is None:
-            db_path = ":memory:"
-        else:
-            db_path = str(Path(project.ropefolder.real_path) / "autoimport.db")
-        self.connection = sqlite3.connect(db_path)
+        if memory is _deprecated_default:
+            memory = True
+            warnings.warn(
+                "The default value for `AutoImport(memory)` argument will "
+                "change to use an on-disk database by default in the future. "
+                "If you want to use an in-memory database, you need to pass "
+                "`AutoImport(memory=True)` explicitly.",
+                DeprecationWarning,
+            )
+        self.connection = self.create_database_connection(
+            project=project,
+            memory=memory,
+        )
         self._setup_db()
         if observe:
             observer = resourceobserver.ResourceObserver(
                 changed=self._changed, moved=self._moved, removed=self._removed
             )
             project.add_observer(observer)
+
+    @classmethod
+    def create_database_connection(
+        cls,
+        *,
+        project: Optional[Project] = None,
+        memory: bool = False,
+    ) -> sqlite3.Connection:
+        """
+        Create an sqlite3 connection
+
+        project : rope.base.project.Project
+            the project to use for project imports
+        memory : bool
+            if true, don't persist to disk
+        """
+        if not memory and project is None:
+            raise Exception("if memory=False, project must be provided")
+        db_path: str
+        if memory or project is None or project.ropefolder is None:
+            db_path = ":memory:"
+        else:
+            db_path = str(Path(project.ropefolder.real_path) / "autoimport.db")
+        return sqlite3.connect(db_path)
 
     def _setup_db(self):
         models.Name.create_table(self.connection)

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -118,7 +118,7 @@ def test_setup_db_metadata_table_is_missing(autoimport):
 
 def test_setup_db_metadata_table_is_outdated(autoimport):
     conn = autoimport.connection
-    data = ("outdated", "")  # (version_hash, hash_data)
+    data = ("outdated", "", "2020-01-01T00:00:00")  # (version_hash, hash_data, created_at)
     autoimport._execute(models.Metadata.objects.insert_into(), data)
 
     with assert_database_is_reset(conn), \
@@ -132,7 +132,7 @@ def test_setup_db_metadata_table_is_outdated(autoimport):
 
 def test_setup_db_metadata_table_is_current(autoimport):
     conn = autoimport.connection
-    data = ("up-to-date-value", "")  # (version_hash, hash_data)
+    data = ("up-to-date-value", "", "2020-01-01T00:00:00")  # (version_hash, hash_data, created_at)
     autoimport._execute(models.Metadata.objects.delete_from())
     autoimport._execute(models.Metadata.objects.insert_into(), data)
 

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -1,6 +1,6 @@
-# Special cases, easier to express in pytest
 from contextlib import closing
 from textwrap import dedent
+from unittest.mock import ANY
 
 import pytest
 
@@ -13,6 +13,56 @@ from rope.contrib.autoimport.sqlite import AutoImport
 def autoimport(project: Project):
     with closing(AutoImport(project)) as ai:
         yield ai
+
+
+def is_in_memory_database(connection):
+    db_list = database_list(connection)
+    assert db_list == [(0, "main", ANY)]
+    return db_list[0][2] == ""
+
+
+def database_list(connection):
+    return list(connection.execute("PRAGMA database_list"))
+
+
+def test_autoimport_connection_parameter_with_in_memory(
+    project: Project,
+    autoimport: AutoImport,
+):
+    connection = AutoImport.create_database_connection(memory=True)
+    assert is_in_memory_database(connection)
+
+
+def test_autoimport_connection_parameter_with_project(
+    project: Project,
+    autoimport: AutoImport,
+):
+    connection = AutoImport.create_database_connection(project=project)
+    assert not is_in_memory_database(connection)
+
+
+def test_autoimport_create_database_connection_conflicting_parameter(
+    project: Project,
+    autoimport: AutoImport,
+):
+    with pytest.raises(Exception, match="if memory=False, project must be provided"):
+        AutoImport.create_database_connection(memory=False)
+
+
+def test_autoimport_memory_parameter_is_true(
+    project: Project,
+    autoimport: AutoImport,
+):
+    ai = AutoImport(project, memory=True)
+    assert is_in_memory_database(ai.connection)
+
+
+def test_autoimport_memory_parameter_is_false(
+    project: Project,
+    autoimport: AutoImport,
+):
+    ai = AutoImport(project, memory=False)
+    assert not is_in_memory_database(ai.connection)
 
 
 def test_init_py(


### PR DESCRIPTION
# Description

Add metadata table to the autoimport database.

Also, this deprecates the default value for `AutoImport(memory)` parameter, as the default value is going to change in the future.

Fixes #565

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
- [x] I have made corresponding changes to library documentation for API changes
