### PR TITLE
Implement `except*` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # **Upcoming release**
 
+- #710, #561 Implement `except*` syntax
+
 # Release 1.10.0
 
 - #708, #709 Add support for Python 3.12

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -705,6 +705,9 @@ class _PatchingASTWalker:
         else:
             self._TryExcept(node)
 
+    def _TryStar(self, node):
+        self._Try(node)
+
     def _ExceptHandler(self, node):
         self._excepthandler(node)
 

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1809,6 +1809,7 @@ class ExtractMethodTest(unittest.TestCase):
         """)
         self.assertEqual(expected, refactored)
 
+    @testutils.only_for_versions_higher("3.11")
     def test_extract_method_and_try_except_star_block_1(self):
         code = dedent("""\
             def f():

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1809,6 +1809,28 @@ class ExtractMethodTest(unittest.TestCase):
         """)
         self.assertEqual(expected, refactored)
 
+    def test_extract_method_and_try_except_star_block_1(self):
+        code = dedent("""\
+            def f():
+                try:
+                    pass
+                except* Exception:
+                    pass
+        """)
+        start, end = self._convert_line_range_to_offset(code, 2, 5)
+        refactored = self.do_extract_method(code, start, end, "g")
+        expected = dedent("""\
+            def f():
+                g()
+
+            def g():
+                try:
+                    pass
+                except* Exception:
+                    pass
+        """)
+        self.assertEqual(expected, refactored)
+
     def test_extract_method_and_augmented_assignment_nested_1(self):
         code = dedent("""\
             def f():

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1154,6 +1154,7 @@ class PatchedASTTest(unittest.TestCase):
         expected_children = ["try", "", ":", "\n    ", "Pass", "\n", "ExceptHandler", "\n", "finally", "", ":", "\n    ", "Pass"]
         checker.check_children(node_to_test, expected_children)
 
+    @testutils.only_for_versions_higher("3.11")
     def test_try_except_group_node(self):
         source = dedent("""\
             try:

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1154,6 +1154,27 @@ class PatchedASTTest(unittest.TestCase):
         expected_children = ["try", "", ":", "\n    ", "Pass", "\n", "ExceptHandler", "\n", "finally", "", ":", "\n    ", "Pass"]
         checker.check_children(node_to_test, expected_children)
 
+    def test_try_except_group_node(self):
+        source = dedent("""\
+            try:
+                pass
+            except* (ValueError, IOError) as e:
+                pass
+            except* ZeroDivisionError as e:
+                pass
+        """)
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            "TryStar",
+            ["try", "", ":", "\n    ", "Pass", "\n", "ExceptHandler", "\n", "ExceptHandler"],
+        )
+        expected_child = "e"
+        checker.check_children(
+            "ExceptHandler",
+            ["except", "* ", "Name", " ", "as", " ", expected_child, "", ":", "\n    ", "Pass"],
+        )
+
     def test_ignoring_comments(self):
         source = "#1\n1\n"
         ast_frag = patchedast.get_patched_ast(source, True)


### PR DESCRIPTION
# Description

Python 3.11 added exception groups using the `except*` syntax. This PR adds the patchedast for handling this syntax.

Fixes #561

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
