### PR TITLE
allow build documenatation without have rope module installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # **Upcoming release**
 
-- #710, #561 Implement `except*` syntax
+- #710, #561 Implement `except*` syntax (@lieryan)
+- #711 allow building documentation without having rope module installed (@kloczek)
 
 # Release 1.10.0
 
-- #708, #709 Add support for Python 3.12
+- #708, #709 Add support for Python 3.12 (@lieryan)
 
 # Release 1.9.0
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
# Description

This patch allows build documentation without have `rope` module installed by execute `sphinx-build -n -T -b <output_format> docs`. This patch does exactly what is described in comment above.

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
