### PR TITLE
Allow sqlite to be accessed from different thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - #710, #561 Implement `except*` syntax (@lieryan)
 - #711 allow building documentation without having rope module installed (@kloczek)
+- #714 allow autoimport db connection to be used by mutliple threads (@tkrabel)
 
 # Release 1.10.0
 

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -87,7 +87,7 @@ class AutoImport:
         project: Project,
         observe: bool = True,
         underlined: bool = False,
-        threadsafe: bool = True,
+        check_same_thread: bool = True,
         memory: bool = _deprecated_default,
     ):
         """Construct an AutoImport object.
@@ -100,7 +100,7 @@ class AutoImport:
             If true, listen for project changes and update the cache.
         underlined : bool
             If `underlined` is `True`, underlined names are cached, too.
-        threadsafe : bool
+        check_same_thread : bool
             If true, sqlite3 connection can only be used in the thread it was created in.
         memory:
             If true, don't persist to disk
@@ -129,7 +129,7 @@ class AutoImport:
         self.connection = self.create_database_connection(
             project=project,
             memory=memory,
-            threadsafe=threadsafe,
+            check_same_thread=check_same_thread,
         )
         self._setup_db()
         if observe:
@@ -144,7 +144,7 @@ class AutoImport:
         *,
         project: Optional[Project] = None,
         memory: bool = False,
-        threadsafe: bool = True,
+        check_same_thread: bool = True,
     ) -> sqlite3.Connection:
         """
         Create an sqlite3 connection.
@@ -153,7 +153,7 @@ class AutoImport:
             The project to use for project imports.
         memory : bool
             If true, don't persist to disk.
-        threadsafe : bool
+        check_same_thread : bool
             If true, sqlite3 connection can only be used in the thread it was created in.
         """
         if not memory and project is None:
@@ -163,7 +163,7 @@ class AutoImport:
             db_path = ":memory:"
         else:
             db_path = str(Path(project.ropefolder.real_path) / "autoimport.db")
-        return sqlite3.connect(db_path, check_same_thread=threadsafe)
+        return sqlite3.connect(db_path, check_same_thread=check_same_thread)
 
     def _setup_db(self):
         models.Metadata.create_table(self.connection)

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -156,7 +156,7 @@ class AutoImport:
             db_path = ":memory:"
         else:
             db_path = str(Path(project.ropefolder.real_path) / "autoimport.db")
-        return sqlite3.connect(db_path)
+        return sqlite3.connect(db_path, check_same_thread=False)
 
     def _setup_db(self):
         models.Metadata.create_table(self.connection)

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -42,6 +42,14 @@ def test_autoimport_connection_parameter_with_project(
     assert not is_in_memory_database(connection)
 
 
+def test_autoimport_connection_parameter_with_threadsafe(
+    project: Project,
+    autoimport: AutoImport,
+):
+    connection = AutoImport.create_database_connection(project=project, threadsafe=False)
+    assert not is_in_memory_database(connection)
+
+
 def test_autoimport_create_database_connection_conflicting_parameter(
     project: Project,
     autoimport: AutoImport,

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -42,11 +42,11 @@ def test_autoimport_connection_parameter_with_project(
     assert not is_in_memory_database(connection)
 
 
-def test_autoimport_connection_parameter_with_threadsafe(
+def test_autoimport_connection_parameter_with_check_same_thread(
     project: Project,
     autoimport: AutoImport,
 ):
-    connection = AutoImport.create_database_connection(project=project, threadsafe=False)
+    connection = AutoImport.create_database_connection(project=project, check_same_thread=False)
     assert not is_in_memory_database(connection)
 
 


### PR DESCRIPTION
# Description

Remove checking if sqlite db is accessed from a different thread.

Fixes #713 

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
- [x] I have made corresponding changes to user documentation for new features
- [x] I have made corresponding changes to library documentation for API changes
