### PR TITLE
Use in-memory database with shared cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - #710, #561 Implement `except*` syntax (@lieryan)
 - #711 allow building documentation without having rope module installed (@kloczek)
-- #719 Allow in-memory databases being shared across threads (@tkrabel)
+- #719 Allows the in-memory db to be shared across threads (@tkrabel)
 
 # Release 1.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - #710, #561 Implement `except*` syntax (@lieryan)
 - #711 allow building documentation without having rope module installed (@kloczek)
-- #719 Create in-memory databases with shared cache per project to support a one-thread-one-autoimport model in multithreading environments (@tkrabel)
+- #719 Allow in-memory databases being shared across threads (@tkrabel)
 
 # Release 1.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - #710, #561 Implement `except*` syntax (@lieryan)
 - #711 allow building documentation without having rope module installed (@kloczek)
+- #719 Create in-memory databases with shared cache per project to support a one-thread-one-autoimport model in multithreading environments (@tkrabel)
 
 # Release 1.10.0
 

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -154,10 +154,16 @@ class AutoImport:
         if memory or project is None or project.ropefolder is None:
             # Allows the in-memory db to be shared across threads
             # See https://www.sqlite.org/inmemorydb.html
-            project_hash = hash(project and project.ropefolder and project.ropefolder.real_path)
-            return sqlite3.connect(f"file:memdb{project_hash}:?mode=memory&cache=shared", uri=True)
+            project_hash = hash(
+                project and project.ropefolder and project.ropefolder.real_path
+            )
+            return sqlite3.connect(
+                f"file:memdb{project_hash}:?mode=memory&cache=shared", uri=True
+            )
         else:
-            return sqlite3.connect(str(Path(project.ropefolder.real_path) / "autoimport.db"))
+            return sqlite3.connect(
+                str(Path(project.ropefolder.real_path) / "autoimport.db")
+            )
 
     def _setup_db(self):
         models.Metadata.create_table(self.connection)

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -151,15 +151,13 @@ class AutoImport:
         """
         if not memory and project is None:
             raise Exception("if memory=False, project must be provided")
-        db_path: str
         if memory or project is None or project.ropefolder is None:
             # Allows the in-memory db to be shared across threads
             # See https://www.sqlite.org/inmemorydb.html
             project_hash = hash(project and project.ropefolder and project.ropefolder.real_path)
-            db_path = f"file:memdb{project_hash}:?mode=memory&cache=shared"
+            return sqlite3.connect(f"file:memdb{project_hash}:?mode=memory&cache=shared", uri=True)
         else:
-            db_path = str(Path(project.ropefolder.real_path) / "autoimport.db")
-        return sqlite3.connect(db_path)
+            return sqlite3.connect(str(Path(project.ropefolder.real_path) / "autoimport.db"))
 
     def _setup_db(self):
         models.Metadata.create_table(self.connection)

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -153,7 +153,10 @@ class AutoImport:
             raise Exception("if memory=False, project must be provided")
         db_path: str
         if memory or project is None or project.ropefolder is None:
-            db_path = ":memory:"
+            # Allows the in-memory db to be shared across threads
+            # See https://www.sqlite.org/inmemorydb.html
+            project_hash = hash(project and project.ropefolder and project.ropefolder.real_path)
+            db_path = f"file:memdb{project_hash}:?mode=memory&cache=shared"
         else:
             db_path = str(Path(project.ropefolder.real_path) / "autoimport.db")
         return sqlite3.connect(db_path)

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import json
+import random
 import re
 import sqlite3
 import sys
@@ -154,9 +155,13 @@ class AutoImport:
         if memory or project is None or project.ropefolder is None:
             # Allows the in-memory db to be shared across threads
             # See https://www.sqlite.org/inmemorydb.html
-            project_hash = hash(
-                project and project.ropefolder and project.ropefolder.real_path
-            )
+            project_hash: int
+            if project is None:
+                project_hash = random.randint(100_000_000, 999_999_999)
+            elif project.ropefolder is None:
+                project_hash = hash(project.address)
+            else:
+                project_hash = hash(project.ropefolder.real_path)
             return sqlite3.connect(
                 f"file:memdb{project_hash}:?mode=memory&cache=shared", uri=True
             )

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -155,6 +155,7 @@ class AutoImport:
         memory : bool
             if true, don't persist to disk
         """
+
         def calculate_project_hash(data: str) -> str:
             return sha256(data.encode()).hexdigest()
 
@@ -171,7 +172,7 @@ class AutoImport:
             else:
                 project_hash = calculate_project_hash(project.ropefolder.real_path)
             return sqlite3.connect(
-                f"file:memdb{project_hash}:?mode=memory&cache=shared", uri=True
+                f"file:rope-{project_hash}:?mode=memory&cache=shared", uri=True
             )
         else:
             return sqlite3.connect(

--- a/ropetest/conftest.py
+++ b/ropetest/conftest.py
@@ -14,6 +14,13 @@ def project():
 
 
 @pytest.fixture
+def project2():
+    project = testutils.sample_project("another_project")
+    yield project
+    testutils.remove_project(project)
+
+
+@pytest.fixture
 def project_path(project):
     yield pathlib.Path(project.address)
 

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -29,17 +29,17 @@ def database_list(connection):
 
 
 def test_in_memory_database_share_cache(project, project2):
-    ai1 = AutoImport(project, memory=True)
-    ai2 = AutoImport(project, memory=True)
+    ai_1 = AutoImport(project, memory=True)
+    ai_2 = AutoImport(project, memory=True)
 
-    ai3 = AutoImport(project2, memory=True)
+    ai_3 = AutoImport(project2, memory=True)
 
-    with ai1.connection:
-        ai1.connection.execute("CREATE TABLE shared(data)")
-        ai1.connection.execute("INSERT INTO shared VALUES(28)")
-    assert ai2.connection.execute("SELECT data FROM shared").fetchone() == (28,)
+    with ai_1.connection:
+        ai_1.connection.execute("CREATE TABLE shared(data)")
+        ai_1.connection.execute("INSERT INTO shared VALUES(28)")
+    assert ai_2.connection.execute("SELECT data FROM shared").fetchone() == (28,)
     with pytest.raises(sqlite3.OperationalError, match="no such table: shared"):
-        ai3.connection.execute("SELECT data FROM shared").fetchone()
+        ai_3.connection.execute("SELECT data FROM shared").fetchone()
 
 
 def test_autoimport_connection_parameter_with_in_memory(

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 from contextlib import closing, contextmanager
 from textwrap import dedent
 from unittest.mock import ANY, patch
@@ -19,11 +21,31 @@ def autoimport(project: Project):
 def is_in_memory_database(connection):
     db_list = database_list(connection)
     assert db_list == [(0, "main", ANY)]
-    return db_list[0][2] == ""
+    return db_list[0][2].endswith("mode=memory&cache=shared")
 
 
 def database_list(connection):
     return list(connection.execute("PRAGMA database_list"))
+
+
+def get_database_name(connection: sqlite3.Connection):
+    return database_list(connection)[0][2]
+
+
+def test_autoimport_database_name(
+    project: Project,
+):
+    # project is None
+    connection1 = AutoImport.create_database_connection(memory=True, project=None)
+    connection2 = AutoImport.create_database_connection(memory=True, project=None)
+    assert get_database_name(connection1) == get_database_name(connection2)
+
+    # project is not None
+    connection3 = AutoImport.create_database_connection(memory=True, project=project)
+    connection4 = AutoImport.create_database_connection(memory=True, project=project)
+    assert get_database_name(connection3) == get_database_name(connection4)
+
+    assert get_database_name(connection1) != get_database_name(connection3)
 
 
 def test_autoimport_connection_parameter_with_in_memory(

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -1,5 +1,3 @@
-import sqlite3
-
 from contextlib import closing, contextmanager
 from textwrap import dedent
 from unittest.mock import ANY, patch
@@ -21,31 +19,11 @@ def autoimport(project: Project):
 def is_in_memory_database(connection):
     db_list = database_list(connection)
     assert db_list == [(0, "main", ANY)]
-    return db_list[0][2].endswith("mode=memory&cache=shared")
+    return db_list[0][2] == ""
 
 
 def database_list(connection):
     return list(connection.execute("PRAGMA database_list"))
-
-
-def get_database_name(connection: sqlite3.Connection):
-    return database_list(connection)[0][2]
-
-
-def test_autoimport_database_name(
-    project: Project,
-):
-    # project is None
-    connection1 = AutoImport.create_database_connection(memory=True, project=None)
-    connection2 = AutoImport.create_database_connection(memory=True, project=None)
-    assert get_database_name(connection1) == get_database_name(connection2)
-
-    # project is not None
-    connection3 = AutoImport.create_database_connection(memory=True, project=project)
-    connection4 = AutoImport.create_database_connection(memory=True, project=project)
-    assert get_database_name(connection3) == get_database_name(connection4)
-
-    assert get_database_name(connection1) != get_database_name(connection3)
 
 
 def test_autoimport_connection_parameter_with_in_memory(

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -26,6 +26,17 @@ def database_list(connection):
     return list(connection.execute("PRAGMA database_list"))
 
 
+def test_in_memory_database_share_cache(project):
+    ai1 = AutoImport(project, memory=True)
+    ai2 = AutoImport(project, memory=True)
+
+    with ai1.connection:
+        ai1.connection.execute("CREATE TABLE shared(data)")
+        ai1.connection.execute("INSERT INTO shared VALUES(28)")
+    res = ai2.connection.execute("SELECT data FROM shared")
+    assert res.fetchone() == (28,)
+
+
 def test_autoimport_connection_parameter_with_in_memory(
     project: Project,
     autoimport: AutoImport,


### PR DESCRIPTION
# Description

As discussed in https://github.com/python-rope/rope/pull/714#issuecomment-1783791890, this PR sets the foundation for using `AutoImport` in a multithreading environment by using an in-memory database with shared cache per `Project` if `memory=True`. On-disk databases are not affected.

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
- [x] I have made corresponding changes to user documentation for new features
- [x] I have made corresponding changes to library documentation for API changes
