### PR TITLE
Create one database connection per thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - #710, #561 Implement `except*` syntax (@lieryan)
 - #711 allow building documentation without having rope module installed (@kloczek)
+- #720 create one sqlite3.Connection per thread using a thread local (@tkrabel)
 
 # Release 1.10.0
 

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -68,7 +68,6 @@ def filter_packages(
 
 
 _deprecated_default: bool = object()  # type: ignore
-thread_local = local()
 
 
 class AutoImport:
@@ -127,6 +126,7 @@ class AutoImport:
                 "`AutoImport(memory=True)` explicitly.",
                 DeprecationWarning,
             )
+        self.thread_local = local()
         self.connection = self.create_database_connection(
             project=project,
             memory=memory,
@@ -169,16 +169,16 @@ class AutoImport:
 
         This makes sure AutoImport can be shared across threads.
         """
-        if not hasattr(thread_local, "connection"):
-            thread_local.connection = self.create_database_connection(
+        if not hasattr(self.thread_local, "connection"):
+            self.thread_local.connection = self.create_database_connection(
                 project=self.project,
                 memory=self.memory,
             )
-        return thread_local.connection
+        return self.thread_local.connection
 
     @connection.setter
     def connection(self, value: sqlite3.Connection):
-        thread_local.connection = value
+        self.thread_local.connection = value
 
     def _setup_db(self):
         models.Metadata.create_table(self.connection)

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -164,7 +164,8 @@ class AutoImport:
 
     @property
     def connection(self):
-        """Creates a new connection if called from a new thread.
+        """
+        Creates a new connection if called from a new thread.
 
         This makes sure AutoImport can be shared across threads.
         """

--- a/ropetest/conftest.py
+++ b/ropetest/conftest.py
@@ -18,6 +18,13 @@ def project_path(project):
     yield pathlib.Path(project.address)
 
 
+@pytest.fixture
+def project2():
+    project = testutils.sample_project("sample_project2")
+    yield project
+    testutils.remove_project(project)
+
+
 """
 Standard project structure for pytest fixtures
 /mod1.py            -- mod1

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -108,6 +108,15 @@ def test_multithreading(
     assert [("from pkg1 import foo", "foo")] == results
 
 
+def test_connection(project: Project, project2: Project):
+    ai1 = AutoImport(project)
+    ai2 = AutoImport(project)
+    ai3 = AutoImport(project2)
+
+    assert ai1.connection is not ai2.connection
+    assert ai1.connection is not ai3.connection
+
+
 @contextmanager
 def assert_database_is_reset(conn):
     conn.execute("ALTER TABLE names ADD COLUMN deprecated_column")


### PR DESCRIPTION
# Description

Addresses https://github.com/python-rope/rope/pull/714#issuecomment-1784018856, using a threadlocal to create data base connections.

Fixes #713 

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
- [x] I have made corresponding changes to user documentation for new features
- [x] I have made corresponding changes to library documentation for API changes
