### PR TITLE
Remove site-packages from packages search tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - #710, #561 Implement `except*` syntax (@lieryan)
 - #711 allow building documentation without having rope module installed (@kloczek)
+- #722 speed up module cache generation by factor of 2 (@tkrabel)
 
 # Release 1.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # **Upcoming release**
 
 - #710, #561 Implement `except*` syntax (@lieryan)
-- #711 allow building documentation without having rope module installed (@kloczek)
-- #722 speed up module cache generation by factor of 2 (@tkrabel)
+- #711 Allow building documentation without having rope module installed (@kloczek)
+- #722 Speed up module cache generation by factor of 2 (@tkrabel)
 
 # Release 1.10.0
 

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -529,6 +529,7 @@ class AutoImport:
             chain(*self._execute(models.Package.objects.select_star()).fetchall())
         )
         existing.append(self.project_package.name)
+        existing.append("site-packages")
         return existing
 
     def _removed(self, resource):

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -529,7 +529,6 @@ class AutoImport:
             chain(*self._execute(models.Package.objects.select_star()).fetchall())
         )
         existing.append(self.project_package.name)
-        existing.append("site-packages")
         return existing
 
     def _removed(self, resource):

--- a/rope/contrib/autoimport/utils.py
+++ b/rope/contrib/autoimport/utils.py
@@ -20,7 +20,7 @@ def get_package_tuple(
     """
     package_name = package_path.name
     package_type: PackageType
-    if package_name.startswith(".") or package_name == "__pycache__":
+    if package_name.startswith(".") or package_name in ["__pycache__", "site-packages"]:
         return None
     if package_name.endswith((".egg-info", ".dist-info")):
         return None


### PR DESCRIPTION
# Description

Remove `site-packages` from the python package search tree to avoid duplicate entries in the autoimport database. This also speeds up generating the modules cache by a factor of ~2.

Fixes #722 

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
- [x] I have made corresponding changes to user documentation for new features
- [x] I have made corresponding changes to library documentation for API changes
