### PR TITLE
movetest: add test_moving_modules_lazy_import

### DIFF
--- a/ropetest/refactor/movetest.py
+++ b/ropetest/refactor/movetest.py
@@ -598,6 +598,21 @@ class MoveRefactoringTest(unittest.TestCase):
             print(pkg2.pkg3.pkg4.mod4)""")
         self.assertEqual(expected, self.mod1.read())
 
+    def test_moving_modules_lazy_import(self):
+        pkg2 = testutils.create_package(self.project, "pkg2")
+        pkg3 = testutils.create_package(self.project, "pkg3", pkg2)
+        pkg4 = testutils.create_package(self.project, "pkg4", pkg3)
+        code = dedent("""\
+            def import_later():
+                import pkg.mod4""")
+        self.mod1.write(code)
+        self._move(self.mod4, None, pkg4)
+        self.assertTrue(self.project.find_module("pkg2.pkg3.pkg4.mod4") is not None)
+        expected = dedent("""\
+            def import_later():
+                import pkg2.pkg3.pkg4.mod4""")
+        self.assertEqual(expected, self.mod1.read())
+
     def test_moving_package_with_from_and_normal_imports(self):
         pkg2 = testutils.create_package(self.project, "pkg2")
         code = dedent("""\


### PR DESCRIPTION
Adds a failing test case for https://github.com/python-rope/rope/issues/731:

```console
>       self.assertEqual(expected, self.mod1.read())
E       AssertionError: 'def import_later():\n    import pkg2.pkg3.pkg4.mod4' != 'import pkg2.pkg3.pkg4.mod4\ndef import_la[34 chars]mod4'
E       + import pkg2.pkg3.pkg4.mod4
E         def import_later():
E             import pkg2.pkg3.pkg4.mod4

ropetest/refactor/movetest.py:614: AssertionError
================================================================================================= warnings summary =================================================================================================
ropetest/refactor/movetest.py: 75 warnings
  /home/ss/Sources/rope/rope/base/project.py:229: DeprecationWarning: Delete once deprecated functions are gone
    self._init_source_folders()
```


# Description

Please include a summary of the change and which issue is fixed.

Fixes https://github.com/python-rope/rope/issues/731 (doesn't yet)

# Checklist (delete if not relevant):

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated CHANGELOG.md
