### PR TITLE
Add error handling for extract of incomplete block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - #719 Allows the in-memory db to be shared across threads (@tkrabel)
 - #720 create one sqlite3.Connection per thread using a thread local (@tkrabel)
 - #715 change AutoImport's `get_modules` to be case sensitive (@bagel897)
+- #734 raise exception when extracting the start of a block without the end
 
 # Release 1.10.0
 

--- a/rope/refactor/sourceutils.py
+++ b/rope/refactor/sourceutils.py
@@ -1,5 +1,4 @@
 from rope.base import codeanalyze
-from typing import Optional
 
 
 def get_indents(lines, lineno):
@@ -92,16 +91,3 @@ def get_body_region(defined):
 
 def get_indent(project):
     return project.prefs.get("indent_size", 4)
-
-
-def find_nonblank_line(
-    lines, start_line: int, skip_comments: bool = True
-) -> Optional[int]:
-    """Return index of first non-blank line starting with start_line, None if not found"""
-    next_line = start_line
-    while next_line < lines.length():
-        line_code = lines.get_line(next_line).strip()
-        if line_code and (not skip_comments or not line_code.startswith("#")):
-            return next_line
-        next_line = next_line + 1
-    return None

--- a/rope/refactor/sourceutils.py
+++ b/rope/refactor/sourceutils.py
@@ -1,4 +1,5 @@
 from rope.base import codeanalyze
+from typing import Optional
 
 
 def get_indents(lines, lineno):
@@ -91,3 +92,16 @@ def get_body_region(defined):
 
 def get_indent(project):
     return project.prefs.get("indent_size", 4)
+
+
+def find_nonblank_line(
+    lines, start_line: int, skip_comments: bool = True
+) -> Optional[int]:
+    """Return index of first non-blank line starting with start_line, None if not found"""
+    next_line = start_line
+    while next_line < lines.length():
+        line_code = lines.get_line(next_line).strip()
+        if line_code and (not skip_comments or not line_code.startswith("#")):
+            return next_line
+        next_line = next_line + 1
+    return None

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1208,6 +1208,39 @@ class ExtractMethodTest(unittest.TestCase):
         with self.assertRaises(rope.base.exceptions.RefactoringError):
             self.do_extract_method(code, start, end, "new_func")
 
+    def test_no_incomplete_error_for_weird_indentation(self):
+        code = dedent("""\
+            def foo():
+                if foo:
+                    s = \"""
+            blah blah
+            blah
+            \"""
+                    print(
+            a, b, c
+                    )
+        """)
+        start = code.index("s =") + 3
+        after_first_triple_quote = code.index('"""') + 3
+        end = code.index('"""', after_first_triple_quote) + 3
+        self.do_extract_method(code, start, end, "new_func")
+
+    def test_no_incomplete_error_for_weird_indentation2(self):
+        code = dedent("""\
+            def foo():
+                print(
+            a, [
+                    3,
+                    4
+                    ],
+                    c
+                    )
+        """)
+        start = code.index("[")
+        end = code.index(']') + 1
+        print(code[start:end])
+        self.do_extract_method(code, start, end, "new_func")
+
     def test_extract_method_and_extra_blank_lines(self):
         code = dedent("""\
 

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1149,6 +1149,64 @@ class ExtractMethodTest(unittest.TestCase):
         end = code.rindex(")") + 1
         with self.assertRaises(rope.base.exceptions.RefactoringError):
             self.do_extract_method(code, start, end, "new_func")
+    
+    def test_raising_exception_on_incomplete_block(self):
+        code = dedent("""\
+            if True:
+                a = 1
+                b = 2
+        """)
+        start = code.index("if")
+        end = code.index("1") + 1
+        with self.assertRaises(rope.base.exceptions.RefactoringError):
+            self.do_extract_method(code, start, end, "new_func")
+
+    def test_raising_exception_on_incomplete_block_2(self):
+        code = dedent("""\
+            if True:
+                a = 1
+            #
+                b = 2
+        """)
+        start = code.index("if")
+        end = code.index("1") + 1
+        with self.assertRaises(rope.base.exceptions.RefactoringError):
+            self.do_extract_method(code, start, end, "new_func")
+
+    def test_raising_exception_on_incomplete_block_3(self):
+        code = dedent("""\
+            if True:
+                a = 1
+            
+                b = 2
+        """)
+        start = code.index("if")
+        end = code.index("1") + 1
+        with self.assertRaises(rope.base.exceptions.RefactoringError):
+            self.do_extract_method(code, start, end, "new_func")
+
+    def test_raising_exception_on_incomplete_block_4(self):
+        code = dedent("""\
+                #
+            if True:
+                a = 1
+                b = 2
+        """)
+        start = code.index("#")
+        end = code.index("1") + 1
+        with self.assertRaises(rope.base.exceptions.RefactoringError):
+            self.do_extract_method(code, start, end, "new_func")
+
+    def test_raising_exception_on_incomplete_block_5(self):
+        code = dedent("""\
+            if True:
+                if 0:
+                    a = 1
+        """)
+        start = code.index("if")
+        end = code.index("0:") + 2
+        with self.assertRaises(rope.base.exceptions.RefactoringError):
+            self.do_extract_method(code, start, end, "new_func")
 
     def test_extract_method_and_extra_blank_lines(self):
         code = dedent("""\

--- a/ropetest/refactor/extracttest.py
+++ b/ropetest/refactor/extracttest.py
@@ -1208,39 +1208,6 @@ class ExtractMethodTest(unittest.TestCase):
         with self.assertRaises(rope.base.exceptions.RefactoringError):
             self.do_extract_method(code, start, end, "new_func")
 
-    def test_no_incomplete_error_for_weird_indentation(self):
-        code = dedent("""\
-            def foo():
-                if foo:
-                    s = \"""
-            blah blah
-            blah
-            \"""
-                    print(
-            a, b, c
-                    )
-        """)
-        start = code.index("s =") + 3
-        after_first_triple_quote = code.index('"""') + 3
-        end = code.index('"""', after_first_triple_quote) + 3
-        self.do_extract_method(code, start, end, "new_func")
-
-    def test_no_incomplete_error_for_weird_indentation2(self):
-        code = dedent("""\
-            def foo():
-                print(
-            a, [
-                    3,
-                    4
-                    ],
-                    c
-                    )
-        """)
-        start = code.index("[")
-        end = code.index(']') + 1
-        print(code[start:end])
-        self.do_extract_method(code, start, end, "new_func")
-
     def test_extract_method_and_extra_blank_lines(self):
         code = dedent("""\
 


### PR DESCRIPTION
# Description

Raise exception when extracting the start of a block without the end, examples in the issue and the included tests.

Fixes #734

The added logic is:
* Raise when:
  * region end is more indented than region start, AND
  * the next line after region end is indented as much as region end or more.
* When any of these (start, end, or next) are on a blank/comment line, consider the next "real" line instead.

This seems correct to me and passes existing tests, but it could use a look by someone familiar with this part of the code to make sure it makes sense and is following conventions.

# Checklist (delete if not relevant):

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated CHANGELOG.md
