### PR TITLE
Ensure autoimport requests uses indexes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - #733 skip directories with perm error when building autoimport index (@MrBago)
 - #722, #723 Remove site-packages from packages search tree (@tkrabel)
 - #738 Implement os.PathLike on Resource (@lieryan)
+- #739, #736 Ensure autoimport requests uses indexes (@lieryan)
 
 # Release 1.11.0
 

--- a/rope/contrib/autoimport/models.py
+++ b/rope/contrib/autoimport/models.py
@@ -100,9 +100,14 @@ class Name(Model):
     @classmethod
     def create_table(cls, connection):
         super().create_table(connection)
-        connection.execute("CREATE INDEX IF NOT EXISTS name ON names(name)")
-        connection.execute("CREATE INDEX IF NOT EXISTS module ON names(module)")
-        connection.execute("CREATE INDEX IF NOT EXISTS package ON names(package)")
+        # fmt: off
+        connection.execute("CREATE INDEX IF NOT EXISTS names_name ON names(name)")
+        connection.execute("CREATE INDEX IF NOT EXISTS names_module ON names(module)")
+        connection.execute("CREATE INDEX IF NOT EXISTS names_package ON names(package)")
+        connection.execute("CREATE INDEX IF NOT EXISTS names_name_nocase ON names(name COLLATE NOCASE)")
+        connection.execute("CREATE INDEX IF NOT EXISTS names_module_nocase ON names(module COLLATE NOCASE)")
+        connection.execute("CREATE INDEX IF NOT EXISTS names_package_nocase ON names(package COLLATE NOCASE)")
+        # fmt: on
 
     search_submodule_like = objects.where('module LIKE ("%." || ?)')
     search_module_like = objects.where("module LIKE (?)")

--- a/rope/contrib/autoimport/models.py
+++ b/rope/contrib/autoimport/models.py
@@ -9,6 +9,9 @@ class FinalQuery:
     def __repr__(self):
         return f'{self.__class__.__name__}("{self._query}")'
 
+    def explain(self):
+        return FinalQuery("EXPLAIN QUERY PLAN " + self._query)
+
 
 class Query:
     def __init__(self, query: str, columns: List[str]):

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -186,3 +186,33 @@ def test_setup_db_metadata_table_is_current(autoimport):
     with assert_database_is_preserved(conn), \
             patch("rope.base.versioning.calculate_version_hash", return_value="up-to-date-value"):
         autoimport._setup_db()
+
+
+class TestQueryUsesIndexes:
+    def test_search_by_name_uses_index(self, autoimport):
+        query = models.Name.search_by_name.select_star().explain()
+        assert (
+            list(autoimport._execute(query, ("abc",)))[0][-1]
+            == "SEARCH names USING INDEX names_name (name=?)"
+        )
+
+    def test_search_by_name_like_uses_index(self, autoimport):
+        query = models.Name.search_by_name_like.select_star().explain()
+        assert (
+            list(autoimport._execute(query, ("abc",)))[0][-1]
+            == "SEARCH names USING INDEX names_name_nocase (name>? AND name<?)"
+        )
+
+    def test_search_module_like_uses_index(self, autoimport):
+        query = models.Name.search_module_like.select_star().explain()
+        assert (
+            list(autoimport._execute(query, ("abc",)))[0][-1]
+            == "SEARCH names USING INDEX names_module_nocase (module>? AND module<?)"
+        )
+
+    def test_search_submodule_like_uses_index(self, autoimport):
+        query = models.Name.search_submodule_like.select_star().explain()
+        assert (
+            list(autoimport._execute(query, ("abc",)))[0][-1]
+            == "SCAN names" # FIXME: avoid full table scan
+        )

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -189,30 +189,36 @@ def test_setup_db_metadata_table_is_current(autoimport):
 
 
 class TestQueryUsesIndexes:
+    def explain(self, autoimport, query):
+        explanation = list(autoimport._execute(query.explain(), ("abc",)))[0][-1]
+        # the explanation text varies, on some sqlite version
+        explanation = explanation.replace("TABLE ", "")
+        return explanation
+
     def test_search_by_name_uses_index(self, autoimport):
-        query = models.Name.search_by_name.select_star().explain()
+        query = models.Name.search_by_name.select_star()
         assert (
-            list(autoimport._execute(query, ("abc",)))[0][-1]
+            self.explain(autoimport, query)
             == "SEARCH names USING INDEX names_name (name=?)"
         )
 
     def test_search_by_name_like_uses_index(self, autoimport):
-        query = models.Name.search_by_name_like.select_star().explain()
+        query = models.Name.search_by_name_like.select_star()
         assert (
-            list(autoimport._execute(query, ("abc",)))[0][-1]
+            self.explain(autoimport, query)
             == "SEARCH names USING INDEX names_name_nocase (name>? AND name<?)"
         )
 
     def test_search_module_like_uses_index(self, autoimport):
-        query = models.Name.search_module_like.select_star().explain()
+        query = models.Name.search_module_like.select_star()
         assert (
-            list(autoimport._execute(query, ("abc",)))[0][-1]
+            self.explain(autoimport, query)
             == "SEARCH names USING INDEX names_module_nocase (module>? AND module<?)"
         )
 
     def test_search_submodule_like_uses_index(self, autoimport):
-        query = models.Name.search_submodule_like.select_star().explain()
+        query = models.Name.search_submodule_like.select_star()
         assert (
-            list(autoimport._execute(query, ("abc",)))[0][-1]
+            self.explain(autoimport, query)
             == "SCAN names" # FIXME: avoid full table scan
         )


### PR DESCRIPTION
# Description

The regular indexes are needed for searching exact matches. This PR adds a nocase index to allow doing prefix search using the LIKE query.

Fixes #736 

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md