### PR TITLE
Refactor Autoimport database and indexing

### DIFF
--- a/rope/contrib/autoimport/_database.py
+++ b/rope/contrib/autoimport/_database.py
@@ -1,0 +1,171 @@
+import json
+import secrets
+import sqlite3
+from datetime import datetime
+from hashlib import sha256
+from typing import Iterable, List, Optional, Tuple
+
+from threading import local
+from rope.base import versioning
+from rope.base.project import Project
+from rope.contrib.autoimport import models
+from rope.contrib.autoimport.defs import (
+    Name,
+    Package,
+)
+
+
+class Database:
+    project: Project
+    memory: bool
+
+    def __init__(self, project: Project, memory: bool = False):
+        self.thread_local = local()
+        self.connection = self.create_database_connection(
+            project=project,
+            memory=memory,
+        )
+        self.project = project
+        self.memory = memory
+        self._setup_db()
+
+    @classmethod
+    def create_database_connection(
+        cls,
+        *,
+        project: Optional[Project] = None,
+        memory: bool = False,
+    ) -> sqlite3.Connection:
+        """
+        Create an sqlite3 connection
+
+        project : rope.base.project.Project
+            the project to use for project imports
+        memory : bool
+            if true, don't persist to disk
+        """
+
+        def calculate_project_hash(data: str) -> str:
+            return sha256(data.encode()).hexdigest()
+
+        if not memory and project is None:
+            raise Exception("if memory=False, project must be provided")
+        if memory or project is None or project.ropefolder is None:
+            # Allows the in-memory db to be shared across threads
+            # See https://www.sqlite.org/inmemorydb.html
+            project_hash: str
+            if project is None:
+                project_hash = secrets.token_hex()
+            elif project.ropefolder is None:
+                project_hash = calculate_project_hash(project.address)
+            else:
+                project_hash = calculate_project_hash(project.ropefolder.real_path)
+            return sqlite3.connect(
+                f"file:rope-{project_hash}:?mode=memory&cache=shared", uri=True
+            )
+        else:
+            return sqlite3.connect(project.ropefolder.pathlib / "autoimport.db")
+
+    def _setup_db(self):
+        models.Metadata.create_table(self.connection)
+        version_hash = list(
+            self._execute(models.Metadata.objects.select("version_hash"))
+        )
+        current_version_hash = versioning.calculate_version_hash(self.project)
+        if not version_hash or version_hash[0][0] != current_version_hash:
+            self.clear_cache()
+
+    def clear_cache(self):
+        """Clear all entries in global-name cache.
+
+        It might be a good idea to use this function before
+        regenerating global names.
+
+        """
+        with self.connection:
+            self._execute(models.Name.objects.drop_table())
+            self._execute(models.Package.objects.drop_table())
+            self._execute(models.Metadata.objects.drop_table())
+            models.Name.create_table(self.connection)
+            models.Package.create_table(self.connection)
+            models.Metadata.create_table(self.connection)
+            data = (
+                versioning.calculate_version_hash(self.project),
+                json.dumps(versioning.get_version_hash_data(self.project)),
+                datetime.utcnow().isoformat(),
+            )
+            assert models.Metadata.columns == [
+                "version_hash",
+                "hash_data",
+                "created_at",
+            ]
+            self._execute(models.Metadata.objects.insert_into(), data)
+
+            self.connection.commit()
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        """
+        Creates a new connection if called from a new thread.
+
+        This makes sure AutoImport can be shared across threads.
+        """
+        if not hasattr(self.thread_local, "connection"):
+            self.thread_local.connection = self.create_database_connection(
+                project=self.project,
+                memory=self.memory,
+            )
+        return self.thread_local.connection
+
+    @connection.setter
+    def connection(self, value: sqlite3.Connection):
+        self.thread_local.connection = value
+
+    def close(self):
+        """Close the autoimport database."""
+        self.connection.commit()
+        self.connection.close()
+
+    def _execute(self, query: models.FinalQuery, *args, **kwargs):
+        assert isinstance(query, models.FinalQuery)
+        return self.connection.execute(query._query, *args, **kwargs)
+
+    def _executemany(self, query: models.FinalQuery, *args, **kwargs):
+        assert isinstance(query, models.FinalQuery)
+        return self.connection.executemany(query._query, *args, **kwargs)
+
+    @staticmethod
+    def _convert_name(name: Name) -> tuple:
+        return (
+            name.name,
+            name.modname,
+            name.package,
+            name.source.value,
+            name.name_type.value,
+        )
+
+    def _dump_all(self) -> Tuple[List[Name], List[Package]]:
+        """Dump the entire database."""
+        name_results = self._execute(models.Name.objects.select_star()).fetchall()
+        package_results = self._execute(models.Package.objects.select_star()).fetchall()
+        return name_results, package_results
+
+    def add_names(self, names: Iterable[Name]):
+        if names is not None:
+            self._executemany(
+                models.Name.objects.insert_into(),
+                [self._convert_name(name) for name in names],
+            )
+
+    def add_name(self, name: Name):
+        self._execute(models.Name.objects.insert_into(), self._convert_name(name))
+
+    def add_packages(self, packages: List[Package]):
+        data = [(p.name, str(p.path)) for p in packages]
+        self._executemany(models.Package.objects.insert_into(), data)
+
+    def delete_package(self, package_name: str):
+        self._execute(models.Package.delete_by_package_name, (package_name,))
+
+    def commit(self):
+        self.connection.commit()

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -1,8 +1,7 @@
-import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing, contextmanager
 from textwrap import dedent
-from unittest.mock import ANY, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -16,71 +15,6 @@ from rope.contrib.autoimport.sqlite import AutoImport
 def autoimport(project: Project):
     with closing(AutoImport(project)) as ai:
         yield ai
-
-
-def is_in_memory_database(connection):
-    db_list = database_list(connection)
-    assert db_list == [(0, "main", ANY)]
-    return db_list[0][2] == ""
-
-
-def database_list(connection):
-    return list(connection.execute("PRAGMA database_list"))
-
-
-def test_in_memory_database_share_cache(project, project2):
-    ai_1 = AutoImport(project, memory=True)
-    ai_2 = AutoImport(project, memory=True)
-
-    ai_3 = AutoImport(project2, memory=True)
-
-    with ai_1.connection:
-        ai_1.connection.execute("CREATE TABLE shared(data)")
-        ai_1.connection.execute("INSERT INTO shared VALUES(28)")
-    assert ai_2.connection.execute("SELECT data FROM shared").fetchone() == (28,)
-    with pytest.raises(sqlite3.OperationalError, match="no such table: shared"):
-        ai_3.connection.execute("SELECT data FROM shared").fetchone()
-
-
-def test_autoimport_connection_parameter_with_in_memory(
-    project: Project,
-    autoimport: AutoImport,
-):
-    connection = AutoImport.create_database_connection(memory=True)
-    assert is_in_memory_database(connection)
-
-
-def test_autoimport_connection_parameter_with_project(
-    project: Project,
-    autoimport: AutoImport,
-):
-    connection = AutoImport.create_database_connection(project=project)
-    assert not is_in_memory_database(connection)
-
-
-def test_autoimport_create_database_connection_conflicting_parameter(
-    project: Project,
-    autoimport: AutoImport,
-):
-    with pytest.raises(Exception, match="if memory=False, project must be provided"):
-        AutoImport.create_database_connection(memory=False)
-
-
-def test_autoimport_memory_parameter_is_true(
-    project: Project,
-    autoimport: AutoImport,
-):
-    ai = AutoImport(project, memory=True)
-    assert is_in_memory_database(ai.connection)
-
-
-def test_autoimport_memory_parameter_is_false(
-    project: Project,
-    autoimport: AutoImport,
-):
-    ai = AutoImport(project, memory=False)
-    assert not is_in_memory_database(ai.connection)
-
 
 def test_init_py(
     autoimport: AutoImport,
@@ -123,74 +57,14 @@ def test_multithreading(
     assert [("from pkg1 import foo", "foo")] == results
 
 
-def test_connection(project: Project, project2: Project):
-    ai1 = AutoImport(project)
-    ai2 = AutoImport(project)
-    ai3 = AutoImport(project2)
-
-    assert ai1.connection is not ai2.connection
-    assert ai1.connection is not ai3.connection
 
 
-@contextmanager
-def assert_database_is_reset(conn):
-    conn.execute("ALTER TABLE names ADD COLUMN deprecated_column")
-    names_ddl, = [ddl for ddl in conn.iterdump() if "CREATE TABLE names" in ddl]
-    assert "deprecated_column" in names_ddl
 
-    yield
-
-    names_ddl, = [ddl for ddl in conn.iterdump() if "CREATE TABLE names" in ddl]
-    assert "deprecated_column" not in names_ddl, "Database did not get reset"
-
-
-@contextmanager
-def assert_database_is_preserved(conn):
-    conn.execute("ALTER TABLE names ADD COLUMN deprecated_column")
-    names_ddl, = [ddl for ddl in conn.iterdump() if "CREATE TABLE names" in ddl]
-    assert "deprecated_column" in names_ddl
-
-    yield
-
-    names_ddl, = [ddl for ddl in conn.iterdump() if "CREATE TABLE names" in ddl]
-    assert "deprecated_column" in names_ddl, "Database was reset unexpectedly"
-
-
-def test_setup_db_metadata_table_is_missing(autoimport):
-    conn = autoimport.connection
-    conn.execute("DROP TABLE metadata")
-    with assert_database_is_reset(conn):
-        autoimport._setup_db()
-
-
-def test_setup_db_metadata_table_is_outdated(autoimport):
-    conn = autoimport.connection
-    data = ("outdated", "", "2020-01-01T00:00:00")  # (version_hash, hash_data, created_at)
-    autoimport._execute(models.Metadata.objects.insert_into(), data)
-
-    with assert_database_is_reset(conn), \
-            patch("rope.base.versioning.calculate_version_hash", return_value="up-to-date-value"):
-        autoimport._setup_db()
-
-    with assert_database_is_preserved(conn), \
-            patch("rope.base.versioning.calculate_version_hash", return_value="up-to-date-value"):
-        autoimport._setup_db()
-
-
-def test_setup_db_metadata_table_is_current(autoimport):
-    conn = autoimport.connection
-    data = ("up-to-date-value", "", "2020-01-01T00:00:00")  # (version_hash, hash_data, created_at)
-    autoimport._execute(models.Metadata.objects.delete_from())
-    autoimport._execute(models.Metadata.objects.insert_into(), data)
-
-    with assert_database_is_preserved(conn), \
-            patch("rope.base.versioning.calculate_version_hash", return_value="up-to-date-value"):
-        autoimport._setup_db()
 
 
 class TestQueryUsesIndexes:
     def explain(self, autoimport, query):
-        explanation = list(autoimport._execute(query.explain(), ("abc",)))[0][-1]
+        explanation = list(autoimport.database._execute(query.explain(), ("abc",)))[0][-1]
         # the explanation text varies, on some sqlite version
         explanation = explanation.replace("TABLE ", "")
         return explanation

--- a/ropetest/contrib/autoimport/databasetest.py
+++ b/ropetest/contrib/autoimport/databasetest.py
@@ -1,0 +1,145 @@
+import sqlite3
+from contextlib import closing, contextmanager
+from unittest.mock import ANY, patch
+
+import pytest
+
+from rope.base.project import Project
+from rope.contrib.autoimport import models
+from rope.contrib.autoimport._database import Database
+
+
+
+@pytest.fixture
+def database(project: Project):
+    with closing(Database(project, memory=True)) as ai:
+        yield ai
+
+def is_in_memory_database(connection):
+    db_list = database_list(connection)
+    assert db_list == [(0, "main", ANY)]
+    return db_list[0][2] == ""
+
+
+def database_list(connection):
+    return list(connection.execute("PRAGMA database_list"))
+
+
+def test_in_memory_database_share_cache(project, project2):
+    ai_1 = Database(project, memory=True)
+    ai_2 = Database(project, memory=True)
+    ai_3 = Database(project2, memory=True)
+
+    with ai_1.connection:
+        ai_1.connection.execute("CREATE TABLE shared(data)")
+        ai_1.connection.execute("INSERT INTO shared VALUES(28)")
+    assert ai_2.connection.execute("SELECT data FROM shared").fetchone() == (28,)
+    with pytest.raises(sqlite3.OperationalError, match="no such table: shared"):
+        ai_3.connection.execute("SELECT data FROM shared").fetchone()
+
+
+def test_autoimport_connection_parameter_with_in_memory(
+    project: Project,
+    database: Database,
+):
+    connection = Database.create_database_connection(memory=True)
+    assert is_in_memory_database(connection)
+
+
+def test_autoimport_connection_parameter_with_project(
+    project: Project,
+    database: Database,
+):
+    connection = Database.create_database_connection(project=project)
+    assert not is_in_memory_database(connection)
+
+
+def test_autoimport_create_database_connection_conflicting_parameter(
+    project: Project,
+    database: Database,
+):
+    with pytest.raises(Exception, match="if memory=False, project must be provided"):
+        Database.create_database_connection(memory=False)
+
+
+def test_autoimport_memory_parameter_is_true(
+    project: Project,
+    database: Database,
+):
+    ai = Database(project, memory=True)
+    assert is_in_memory_database(ai.connection)
+
+
+def test_autoimport_memory_parameter_is_false(
+    project: Project,
+    database: Database,
+):
+    ai = Database(project, memory=False)
+    assert not is_in_memory_database(ai.connection)
+
+
+
+
+def test_connection(project: Project, project2: Project):
+    ai1 = Database(project, memory=True)
+    ai2 = Database(project, memory=True)
+    ai3 = Database(project2, memory=True)
+
+    assert ai1.connection is not ai2.connection
+    assert ai1.connection is not ai3.connection
+
+
+@contextmanager
+def assert_database_is_reset(conn):
+    conn.execute("ALTER TABLE names ADD COLUMN deprecated_column")
+    names_ddl, = [ddl for ddl in conn.iterdump() if "CREATE TABLE names" in ddl]
+    assert "deprecated_column" in names_ddl
+
+    yield
+
+    names_ddl, = [ddl for ddl in conn.iterdump() if "CREATE TABLE names" in ddl]
+    assert "deprecated_column" not in names_ddl, "Database did not get reset"
+
+
+@contextmanager
+def assert_database_is_preserved(conn):
+    conn.execute("ALTER TABLE names ADD COLUMN deprecated_column")
+    names_ddl, = [ddl for ddl in conn.iterdump() if "CREATE TABLE names" in ddl]
+    assert "deprecated_column" in names_ddl
+
+    yield
+
+    names_ddl, = [ddl for ddl in conn.iterdump() if "CREATE TABLE names" in ddl]
+    assert "deprecated_column" in names_ddl, "Database was reset unexpectedly"
+
+
+def test_setup_db_metadata_table_is_missing(database):
+    conn = database.connection
+    conn.execute("DROP TABLE metadata")
+    with assert_database_is_reset(conn):
+        database._setup_db()
+
+
+def test_setup_db_metadata_table_is_outdated(database):
+    conn = database.connection
+    data = ("outdated", "", "2020-01-01T00:00:00")  # (version_hash, hash_data, created_at)
+    database._execute(models.Metadata.objects.insert_into(), data)
+
+    with assert_database_is_reset(conn), \
+            patch("rope.base.versioning.calculate_version_hash", return_value="up-to-date-value"):
+        database._setup_db()
+
+    with assert_database_is_preserved(conn), \
+            patch("rope.base.versioning.calculate_version_hash", return_value="up-to-date-value"):
+        database._setup_db()
+
+
+def test_setup_db_metadata_table_is_current(database):
+    conn = database.connection
+    data = ("up-to-date-value", "", "2020-01-01T00:00:00")  # (version_hash, hash_data, created_at)
+    database._execute(models.Metadata.objects.delete_from())
+    database._execute(models.Metadata.objects.insert_into(), data)
+
+    with assert_database_is_preserved(conn), \
+            patch("rope.base.versioning.calculate_version_hash", return_value="up-to-date-value"):
+        database._setup_db()


### PR DESCRIPTION
# Description
The main autoimport class has gotten quite large. This PR simplifies it by splitting out a Database object. It also adds an index function to unify indexing between the different methods (resource, gen_cache, modules_cache) 
## Future Proposals
This can be iterated on in future PRs
- Simplify the constructor in the Database class (Combine with create_connection/setup_db??)
- Split out the searching component somehow?
- Split the indexing component? (IE, a core indexer with the _index function, a package discovery mechanism, and the rope API)
# Checklist (delete if not relevant):

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated CHANGELOG.md
- [ ] I have made corresponding changes to user documentation for new features
- [ ] I have made corresponding changes to library documentation for API changes
