### PR TITLE
fix: Fix import paths with `site-packages` as part of package name

### DIFF
--- a/rope/contrib/autoimport/parse.py
+++ b/rope/contrib/autoimport/parse.py
@@ -97,6 +97,8 @@ def get_type_object(imported_object) -> NameType:
 
 def get_names(module: ModuleInfo, package: Package) -> List[Name]:
     """Get all names from a module and package."""
+    if "site-packages" in module.modname:
+        return []
     if isinstance(module, ModuleCompiled):
         return list(
             get_names_from_compiled(package.name, package.source, module.underlined)

--- a/rope/contrib/autoimport/parse.py
+++ b/rope/contrib/autoimport/parse.py
@@ -97,8 +97,6 @@ def get_type_object(imported_object) -> NameType:
 
 def get_names(module: ModuleInfo, package: Package) -> List[Name]:
     """Get all names from a module and package."""
-    if "site-packages" in module.modname:
-        return []
     if isinstance(module, ModuleCompiled):
         return list(
             get_names_from_compiled(package.name, package.source, module.underlined)

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -369,7 +369,10 @@ class AutoImport:
         project are cached.
         """
         if resources is None:
-            resources = self.project.get_python_files()
+            resources = [
+                f for f in self.project.get_python_files()
+                if "site-packages" not in f.pathlib.parts
+            ]
         job_set = task_handle.create_jobset(
             "Generating autoimport cache", len(resources)
         )

--- a/rope/contrib/autoimport/utils.py
+++ b/rope/contrib/autoimport/utils.py
@@ -69,6 +69,13 @@ def get_modname_from_path(
     package_name: str = package_path.stem
     rel_path_parts = modpath.relative_to(package_path).parts
     modname = ""
+    try:
+        site_packages_index = rel_path_parts.index("site-packages")
+    except ValueError:
+        pass
+    else:
+        # If path includes "site-packages", we're interested in part after this.
+        rel_path_parts = rel_path_parts[site_packages_index + 1:]
     if len(rel_path_parts) > 0:
         for part in rel_path_parts[:-1]:
             modname += part

--- a/rope/contrib/autoimport/utils.py
+++ b/rope/contrib/autoimport/utils.py
@@ -71,6 +71,7 @@ def get_modname_from_path(
     modname = ""
     try:
         site_packages_index = rel_path_parts.index("site-packages")
+        raise RuntimeError("No site-packages allowed here.", modpath)
     except ValueError:
         pass
     else:

--- a/ropetest/contrib/autoimport/utilstest.py
+++ b/ropetest/contrib/autoimport/utilstest.py
@@ -34,6 +34,13 @@ def test_get_modname_single_file(typing_path):
     assert utils.get_modname_from_path(typing_path, typing_path) == "typing"
 
 
+def test_get_modname_external(example_external_package_path):
+    assert utils.get_modname_from_path(
+        example_external_package_path,
+        example_external_package_path,
+    ) == "external_fixturepkg"
+
+
 def test_get_modname_folder(
     example_external_package_path,
     example_external_package_module_path,


### PR DESCRIPTION
# Description

This is another fix, related to #722, i just started using `python-lsp-server` and `rope` for autoimports, and noticed it includes `.direnv.python-3.11.lib.python3.11` as part of module name when importing.

~~We need to cut part of the path to site-packages, to generate correct import name.~~

That was my first attempt to fix this, but turned that wasn't a problem. The problem was, in my case - that local venv `.venv` was included in project resources.

As far as i understand, we have two caches

- `generate_cache` creates project-specific cache
- `generate_module_cache` creates cache of system/venv modules.

And when .venv is in the same dir as a project, it was included in project files.

My current first attempt just filters out path if it has "site-packages" in it, but, maybe we need smarter solution, for example:

`get_python_files` should exclude any file from `get_python_path_folders` (except project root).

For this i need some guidance, @tkrabel @lieryan 

# Checklist (delete if not relevant):

- [ ] I have added tests that prove my fix is effective or that my feature works (not yet)
- [ ] I have updated CHANGELOG.md (not yet)
