### PR TITLE
Isolate tests that uses external_fixturepkg into a venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # **Upcoming release**
 
+- #781, #783 Isolate tests that uses external_fixturepkg into a venv
 - #751 Check for ast.Attributes when finding occurrences in fstrings (@sandratsy)
 - #777, #698 add validation to refuse Rename refactoring to a python keyword (@lieryan)
 - #730 Match on module aliases for autoimport suggestions (@MrBago)

--- a/ropetest/conftest.py
+++ b/ropetest/conftest.py
@@ -1,6 +1,8 @@
+import os
 import pathlib
 import sys
 from subprocess import check_call
+from venv import EnvBuilder
 
 import pytest
 
@@ -8,9 +10,46 @@ from rope.base import resources
 from ropetest import testutils
 
 
+@pytest.fixture(scope="session")
+def session_venv(tmpdir_factory):
+    path = tmpdir_factory.mktemp("venv")
+    venv_path = pathlib.Path(path)
+
+    builder = EnvBuilder(with_pip=True)
+    builder.create(venv_path)
+
+    yield venv_path
+
+
+@pytest.fixture(scope="session")
+def session_venv_pyvenv_cfg(session_venv):
+    cfg = session_venv / "pyvenv.cfg"
+    return dict(line.split(" = ") for line in cfg.read_text().splitlines())
+
+
+@pytest.fixture(scope="session")
+def session_venv_site_packages(session_venv, session_venv_pyvenv_cfg):
+    major, minor, patch = session_venv_pyvenv_cfg["version"].split(".")
+    return session_venv / f"lib/python{major}.{minor}/site-packages"
+
+
+@pytest.fixture(scope='session')
+def session_venv_python_executable(session_venv):
+    # Get the path to the Python executable inside the venv
+    if os.name == 'nt':
+        python_executable = session_venv / 'Scripts' / 'python.exe'
+    else:
+        python_executable = session_venv / 'bin' / 'python'
+
+    # Yield the Python executable path
+    yield python_executable
+
+
 @pytest.fixture
-def project():
-    project = testutils.sample_project()
+def project(session_venv, session_venv_site_packages):
+    project = testutils.sample_project(
+        python_path=[str(session_venv_site_packages)],
+    )
     yield project
     testutils.remove_project(project)
 
@@ -21,8 +60,11 @@ def project_path(project):
 
 
 @pytest.fixture
-def project2():
-    project = testutils.sample_project("sample_project2")
+def project2(session_venv):
+    project = testutils.sample_project(
+        "sample_project2",
+        python_path=[str(session_venv_site_packages)],
+    )
     yield project
     testutils.remove_project(project)
 
@@ -50,9 +92,9 @@ def mod2(project, pkg1) -> resources.Folder:
 
 
 @pytest.fixture(scope="session")
-def external_fixturepkg():
+def external_fixturepkg(session_venv, session_venv_python_executable):
     check_call([
-        sys.executable,
+        session_venv_python_executable,
         "-m",
         "pip",
         "install",

--- a/ropetest/conftest.py
+++ b/ropetest/conftest.py
@@ -29,8 +29,11 @@ def session_venv_pyvenv_cfg(session_venv):
 
 @pytest.fixture(scope="session")
 def session_venv_site_packages(session_venv, session_venv_pyvenv_cfg):
-    major, minor, patch = session_venv_pyvenv_cfg["version"].split(".")
-    return session_venv / f"lib/python{major}.{minor}/site-packages"
+    if os.name == 'nt':
+        return session_venv / f"Lib/site-packages"
+    else:
+        major, minor, patch = session_venv_pyvenv_cfg["version"].split(".")
+        return session_venv / f"lib/python{major}.{minor}/site-packages"
 
 
 @pytest.fixture(scope='session')

--- a/ropetest/contrib/autoimport/conftest.py
+++ b/ropetest/contrib/autoimport/conftest.py
@@ -24,18 +24,21 @@ def typing_path():
 
 
 @pytest.fixture
-def example_external_package_module_path(external_fixturepkg):
-    from external_fixturepkg import mod1
-    yield pathlib.Path(mod1.__file__)
+def example_external_package_module_path(
+    session_venv,
+    external_fixturepkg,
+    session_venv_site_packages,
+):
+    return session_venv_site_packages / "external_fixturepkg/mod1.py"
 
 
 @pytest.fixture
-def example_external_package_path(external_fixturepkg):
-    import external_fixturepkg
-
-    # Uses __init__.py so we need the parent
-
-    yield pathlib.Path(external_fixturepkg.__file__).parent
+def example_external_package_path(
+    session_venv,
+    external_fixturepkg,
+    session_venv_site_packages,
+):
+    return session_venv_site_packages / "external_fixturepkg"
 
 
 @pytest.fixture

--- a/ropetest/contrib/autoimport/conftest.py
+++ b/ropetest/contrib/autoimport/conftest.py
@@ -8,19 +8,19 @@ from ropetest import testutils
 @pytest.fixture
 def mod1(project):
     mod1 = testutils.create_module(project, "mod1")
-    yield mod1
+    return mod1
 
 
 @pytest.fixture
 def mod1_path(mod1):
-    yield pathlib.Path(mod1.real_path)
+    return pathlib.Path(mod1.real_path)
 
 
 @pytest.fixture
 def typing_path():
     import typing
 
-    yield pathlib.Path(typing.__file__)
+    return pathlib.Path(typing.__file__)
 
 
 @pytest.fixture
@@ -42,4 +42,4 @@ def example_external_package_path(external_fixturepkg):
 def compiled_lib():
     import _sqlite3
 
-    yield "_sqlite3", pathlib.Path(_sqlite3.__file__)
+    return "_sqlite3", pathlib.Path(_sqlite3.__file__)

--- a/ropetest/contrib/autoimporttest.py
+++ b/ropetest/contrib/autoimporttest.py
@@ -177,8 +177,7 @@ class AutoImportTest(unittest.TestCase):
         self.assertGreater(len(self.importer._dump_all()), 0)
 
 
-def test_search_submodule(external_fixturepkg):
-    project = testutils.sample_project(extension_modules=["sys"])
+def test_search_submodule(project, external_fixturepkg):
     importer = autoimport.AutoImport(project, observe=False)
     importer.update_module("external_fixturepkg")
     import_statement = ("from external_fixturepkg import mod1", "mod1")


### PR DESCRIPTION
# Description

Isolate tests that uses external_fixturepkg into a venv

This avoids modifying the test runtime environment itself.

Fixes #781

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
