### PR TITLE
Implement preferred_import_style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - #787 Add type hints to importinfo.py and add repr to ImportInfo (@lieryan)
 - #786 Upgrade Actions used in Github Workflows (@lieryan)
 - #785 Refactoring movetest.py (@lieryan)
+- #788 Introduce the `preferred_import_style` configuration (@nicoolas25, @lieryan)
 
 # Release 1.13.0
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,7 +69,7 @@ autoimport.* Options
 
 .. autopytoolconfigtable:: rope.base.prefs.AutoimportPrefs
 
-import.* Options
+imports.* Options
 ----------------
 
 .. autopytoolconfigtable:: rope.base.prefs.ImportPrefs

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,6 +69,10 @@ autoimport.* Options
 
 .. autopytoolconfigtable:: rope.base.prefs.AutoimportPrefs
 
+import.* Options
+----------------
+
+.. autopytoolconfigtable:: rope.base.prefs.ImportPrefs
 
 Old Configuration File
 ----------------------

--- a/docs/default_config.py
+++ b/docs/default_config.py
@@ -107,10 +107,13 @@ def set_prefs(prefs):
     #
     #     prefs["ignore_bad_imports"] = False
 
-    # If `True`, rope will insert new module imports as
-    # `from <package> import <module>` by default.
+    # Controls how rope inserts new import statements. Must be one of:
+    # 
+    # - "normal-import" will insert `import <package>`
+    # - "from-module" will insert `from <package> import <module>`
+    # - "from-global" insert insert `from <package>.<module> import <object>`
     #
-    #     prefs["prefer_module_from_imports"] = False
+    #     prefs.imports.preferred_import_style = "normal-import"
 
     # If `True`, rope will transform a comma list of imports into
     # multiple separate import statements when organizing

--- a/rope/base/prefs.py
+++ b/rope/base/prefs.py
@@ -1,5 +1,3 @@
-# mypy reports many problems.
-# type: ignore
 """Rope preferences."""
 from dataclasses import asdict, dataclass
 from textwrap import dedent

--- a/rope/refactor/importutils/__init__.py
+++ b/rope/refactor/importutils/__init__.py
@@ -8,6 +8,8 @@ refactorings or as a separate task.
 import rope.base.codeanalyze
 import rope.base.evaluate
 from rope.base import libutils
+from rope.base.prefs import get_preferred_import_style
+from rope.base.prefs import ImportStyle
 from rope.base.change import ChangeContents, ChangeSet
 from rope.refactor import occurrences, rename
 from rope.refactor.importutils import actions, module_imports
@@ -299,6 +301,7 @@ def get_module_imports(project, pymodule):
 
 
 def add_import(project, pymodule, module_name, name=None):
+    preferred_import_style = get_preferred_import_style(project.prefs)
     imports = get_module_imports(project, pymodule)
     candidates = []
     names = []
@@ -306,13 +309,15 @@ def add_import(project, pymodule, module_name, name=None):
     # from mod import name
     if name is not None:
         from_import = FromImport(module_name, 0, [(name, None)])
+        if preferred_import_style == ImportStyle.from_global:
+            selected_import = from_import
         names.append(name)
         candidates.append(from_import)
     # from pkg import mod
     if "." in module_name:
         pkg, mod = module_name.rsplit(".", 1)
         from_import = FromImport(pkg, 0, [(mod, None)])
-        if project.prefs.get("prefer_module_from_imports"):
+        if preferred_import_style == ImportStyle.from_module:
             selected_import = from_import
         candidates.append(from_import)
         if name:

--- a/ropetest/refactor/importutilstest.py
+++ b/ropetest/refactor/importutilstest.py
@@ -1,8 +1,66 @@
 import unittest
 from textwrap import dedent
 
+from rope.base.prefs import get_preferred_import_style, ImportStyle, Prefs, ImportPrefs
+from rope.base.prefs import DEFAULT_IMPORT_STYLE
 from rope.refactor.importutils import ImportTools, add_import, importinfo
 from ropetest import testutils
+
+
+class TestImportPrefs:
+    def test_preferred_import_style_is_normal_import(self, project):
+        pref = Prefs(imports=ImportPrefs(preferred_import_style="normal-import"))
+        assert pref.imports.preferred_import_style == "normal-import"
+        assert get_preferred_import_style(pref) == ImportStyle.normal_import
+
+    def test_preferred_import_style_is_from_module(self, project):
+        pref = Prefs(imports=ImportPrefs(preferred_import_style="from-module"))
+        assert pref.imports.preferred_import_style == "from-module"
+        assert get_preferred_import_style(pref) == ImportStyle.from_module
+
+    def test_preferred_import_style_is_from_global(self, project):
+        pref = Prefs(imports=ImportPrefs(preferred_import_style="from-global"))
+        assert pref.imports.preferred_import_style == "from-global"
+        assert get_preferred_import_style(pref) == ImportStyle.from_global
+
+    def test_invalid_preferred_import_style_is_default(self, project):
+        pref = Prefs(imports=ImportPrefs(preferred_import_style="invalid-value"))
+        assert pref.imports.preferred_import_style == "invalid-value"
+        assert get_preferred_import_style(pref) == DEFAULT_IMPORT_STYLE
+        assert get_preferred_import_style(pref) == ImportStyle.normal_import
+
+    def test_default_preferred_import_style_default_is_normal_imports(self, project):
+        pref = Prefs()
+        assert pref.imports.preferred_import_style == "default"
+        assert get_preferred_import_style(pref) == ImportStyle.normal_import
+
+    def test_default_preferred_import_style_default_and_prefer_module_from_imports(self, project):
+        pref = Prefs(
+            prefer_module_from_imports=True,
+            imports=ImportPrefs(preferred_import_style="default"),
+        )
+        assert get_preferred_import_style(pref) == ImportStyle.from_module
+
+    def test_preferred_import_style_is_normal_import_takes_precedence_over_prefer_module_from_imports(self, project):
+        pref = Prefs(
+            prefer_module_from_imports=True,
+            imports=ImportPrefs(preferred_import_style="normal_import"),
+        )
+        assert get_preferred_import_style(pref) == ImportStyle.normal_import
+
+    def test_preferred_import_style_is_from_module_takes_precedence_over_prefer_module_from_imports(self, project):
+        pref = Prefs(
+            prefer_module_from_imports=True,
+            imports=ImportPrefs(preferred_import_style="from-module"),
+        )
+        assert get_preferred_import_style(pref) == ImportStyle.from_module
+
+    def test_preferred_import_style_is_from_global_takes_precedence_over_prefer_module_from_imports(self, project):
+        pref = Prefs(
+            prefer_module_from_imports=True,
+            imports=ImportPrefs(preferred_import_style="from-global"),
+        )
+        assert get_preferred_import_style(pref) == ImportStyle.from_global
 
 
 class ImportUtilsTest(unittest.TestCase):

--- a/ropetest/refactor/movetest.py
+++ b/ropetest/refactor/movetest.py
@@ -254,6 +254,75 @@ class MoveRefactoringTest(unittest.TestCase):
             self.mod3.read(),
         )
 
+    def test_adding_imports_preferred_import_style_is_normal_import(self) -> None:
+        self.project.prefs.imports.preferred_import_style = "normal-import"
+        self.origin_module.write(dedent("""\
+            class AClass(object):
+                pass
+            def a_function():
+                pass
+        """))
+        self.mod3.write(dedent("""\
+            import origin_module
+            a_var = origin_module.AClass()
+            origin_module.a_function()"""))
+        # Move to destination_module_in_pkg which is in a different package
+        self._move(self.origin_module, self.origin_module.read().index("AClass") + 1, self.destination_module_in_pkg)
+        self.assertEqual(
+            dedent("""\
+                import origin_module
+                import pkg.destination_module_in_pkg
+                a_var = pkg.destination_module_in_pkg.AClass()
+                origin_module.a_function()"""),
+            self.mod3.read(),
+        )
+
+    def test_adding_imports_preferred_import_style_is_from_module(self) -> None:
+        self.project.prefs.imports.preferred_import_style = "from-module"
+        self.origin_module.write(dedent("""\
+            class AClass(object):
+                pass
+            def a_function():
+                pass
+        """))
+        self.mod3.write(dedent("""\
+            import origin_module
+            a_var = origin_module.AClass()
+            origin_module.a_function()"""))
+        # Move to destination_module_in_pkg which is in a different package
+        self._move(self.origin_module, self.origin_module.read().index("AClass") + 1, self.destination_module_in_pkg)
+        self.assertEqual(
+            dedent("""\
+                import origin_module
+                from pkg import destination_module_in_pkg
+                a_var = destination_module_in_pkg.AClass()
+                origin_module.a_function()"""),
+            self.mod3.read(),
+        )
+
+    def test_adding_imports_preferred_import_style_is_from_global(self) -> None:
+        self.project.prefs.imports.preferred_import_style = "from-global"
+        self.origin_module.write(dedent("""\
+            class AClass(object):
+                pass
+            def a_function():
+                pass
+        """))
+        self.mod3.write(dedent("""\
+            import origin_module
+            a_var = origin_module.AClass()
+            origin_module.a_function()"""))
+        # Move to destination_module_in_pkg which is in a different package
+        self._move(self.origin_module, self.origin_module.read().index("AClass") + 1, self.destination_module_in_pkg)
+        self.assertEqual(
+            dedent("""\
+                import origin_module
+                from pkg.destination_module_in_pkg import AClass
+                a_var = AClass()
+                origin_module.a_function()"""),
+            self.mod3.read(),
+        )
+
     def test_adding_imports_noprefer_from_module(self) -> None:
         self.project.prefs["prefer_module_from_imports"] = False
         self.origin_module.write(dedent("""\


### PR DESCRIPTION
# Description

Added a new setting (`imports.preferred_import_style`) that controls how rope inserts new import statements.

It can be set to:

- `normal-import` (default) which will insert imports as `import <package>`
- `from-module` which will insert imports as `from <package> import <module>`
- `from-global` which will insert imports as `from <package>.<module> import <object>`

Credit: the solution here is based on [nicoolas25](https://github.com/nicoolas25)'s work on #696, but implements the config settings in a slightly different way.

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
- [x] I have made corresponding changes to user documentation for new features
