### PR TITLE
Fix mention of Move -> create_move in docs

### DIFF
--- a/docs/library.rst
+++ b/docs/library.rst
@@ -523,12 +523,15 @@ Refactorings
 ============
 
 Have a look at ``rope.refactor`` package and its sub-modules.  For
-example for performing a move refactoring you can create a ``Move``
-object like this:
+example for performing a move refactoring you can create an object
+representing this operation (which will be an instance of e.g.
+`MoveMethod`, `MoveModule`, ...) like this:
 
 .. code-block:: python
 
-  mover = Move(project, resource, offset)
+  from rope.refactor.move import create_move
+
+  mover = create_move(project, resource, offset)
 
 Where ``resource`` and ``offset`` is the location to perform the
 refactoring.


### PR DESCRIPTION
# Description

The docs on refactoring mention a `Move` class that doesn't exist in the current codebase. This changes it to `create_move` which does exist and matches the signature of the supposed `Move` class.

Fixes #794 