### PR TITLE
Add ratcheting type completeness check to CI

### DIFF
--- a/.github/workflows/type-completeness.yml
+++ b/.github/workflows/type-completeness.yml
@@ -1,0 +1,14 @@
+name: Type completeness ratchet
+
+on: [pull_request]
+
+jobs:
+  completeness:
+    name: Type completeness ratchet
+    runs-on: ubuntu-latest
+    steps:
+    - id: completeness
+      uses: Bibo-Joshi/pyright-type-completeness@1.0.0
+      with:
+        package-name: rope
+        install-command: "touch rope/py.typed && pip install ."


### PR DESCRIPTION
# Description

To help make progress in adding type hints for Rope's public API (#798), it might make sense to have a "ratcheting" mechanism in CI that prevents merging PRs which make the typing situation worse (by adding more untyped public functionality) and might motivate people to actively improve it by adding more type hints (although unfortunately the completeness score isn't visible directly on the PR page, which would probably help facilitate that).

This PR adds such a mechanism using the [pyright-type-completeness](https://github.com/marketplace/actions/pyright-type-completeness) GitHub Action.