### PR TITLE
Python3.13 compat

### DIFF
--- a/rope/base/oi/type_hinting/utils.py
+++ b/rope/base/oi/type_hinting/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from typing import TYPE_CHECKING, Optional, Union
 
 import rope.base.utils as base_utils
@@ -81,7 +82,10 @@ def resolve_type(
     """
     Find proper type object from its name.
     """
-    deprecated_aliases = {"collections": "collections.abc"}
+    if sys.version_info < (3, 13):
+        deprecated_aliases = {"collections": "collections.abc"}
+    else:
+        deprecated_aliases = {"collections": "_collections_abc"}
     ret_type = None
     logging.debug("Looking for %s", type_name)
     if "." not in type_name:

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -569,14 +569,17 @@ class AutoImport:
         return list(OrderedDict.fromkeys(folder_paths))
 
     def _safe_iterdir(self, folder: Path):
-        dirs = folder.iterdir()
-        while True:
-            try:
-                yield next(dirs)
-            except PermissionError:
-                pass
-            except StopIteration:
-                break
+        try:
+            dirs = folder.iterdir()
+            while True:
+                try:
+                    yield next(dirs)
+                except PermissionError:
+                    pass
+                except StopIteration:
+                    break
+        except PermissionError:
+            pass
 
     def _get_available_packages(self) -> List[Package]:
         packages: List[Package] = [


### PR DESCRIPTION
# Description

- python 3.13 removed `collections/abc.py`, update the `deprecated_aliases` variable for this case
- python 3.13 raises `PermissionError` earlier on initialization of the `iterdir()` instead of just on `next()`

Fixes #801 

