### PR TITLE
Treat packages in `ignored_resources` as non-project files for autoimport purposes

### DIFF
--- a/rope/contrib/autoimport/utils.py
+++ b/rope/contrib/autoimport/utils.py
@@ -49,7 +49,11 @@ def get_package_source(
     """Detect the source of a given package. Rudimentary implementation."""
     if name in sys.builtin_module_names:
         return Source.BUILTIN
-    if project is not None and project.address in str(package):
+    if (
+        project is not None
+        and project.address in str(package)
+        and not project.is_ignored(project.get_file(str(package)))
+    ):
         return Source.PROJECT
     if "site-packages" in package.parts:
         return Source.SITE_PACKAGE


### PR DESCRIPTION
# Description

This changes autoimport's logic for determining the "package type" (i.e. part of the project, part of site-packages, ...) so that it treats anything found in the project's `ignored_resources` folders (which includes folders like `.venv` by default) as _not_ belonging to the project.

Fixes #813 

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated CHANGELOG.md
- [ ] I have made corresponding changes to user documentation for new features
  - Not needed
- [ ] I have made corresponding changes to library documentation for API changes
  - Not needed