### PR TITLE
fix for issue #815

### DIFF
--- a/ropetest/refactor/inlinetest.py
+++ b/ropetest/refactor/inlinetest.py
@@ -1521,3 +1521,19 @@ class InlineTest(unittest.TestCase):
         """)
         with self.assertRaises(rope.base.exceptions.RefactoringError):
             refactored = self._inline(code, code.index("a_func") + 1)
+
+    @testutils.only_for_versions_higher("3.12")
+    def test_inlining_with_fstring_nested_quotes(self):
+        code = dedent('''\
+            s = "hello"
+            print(f'Value: {s}')
+            another_var = s
+            f'{''}'
+        ''')
+        expected = dedent('''\
+            print(f'Value: {"hello"}')
+            another_var = "hello"
+            f'{''}'
+        ''')
+        refactored = self._inline(code, code.index("s") + 1)
+        self.assertEqual(expected, refactored)


### PR DESCRIPTION
# Description

added a fallback strategy to _search_in_f_string in occurences.py allowing for backwards compatibility as the initial parsing method will be the same, added unit test case for the bug provided

Fixes #(issue)

# Checklist (delete if not relevant):

- [Done] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated CHANGELOG.md
- [ ] I have made corresponding changes to user documentation for new features
- [ ] I have made corresponding changes to library documentation for API changes
