### PR TITLE
Adapt conditional for Python 3.14

### DIFF
--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -9,7 +9,7 @@ try:
     from ast import _const_node_type_names  # type:ignore
 except ImportError:
     # backported from stdlib `ast`
-    assert sys.version_info < (3, 8)
+    assert sys.version_info < (3, 8) or sys.version_info >= (3, 14)
     _const_node_type_names = {
         bool: "NameConstant",  # should be before int
         type(None): "NameConstant",


### PR DESCRIPTION
As of Python 3.14 `ast` will lack `_const_node_type_names`.

Close #810
