### PR TITLE
supports MatchOr, MatchSequence, MatchStar, MatchSingleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - #852 Implement patchedast handlers for TypeAlias 
 - #853 Implement patchedast handlers TypeVar
 - #847 Avoid printing autoimport syntax errors (@yangfan-yf-yf)
+- #819 supports MatchOr, MatchSequence, MatchStar (@jheld)
 
 # Release 1.14.0
 

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -808,7 +808,7 @@ class _PatchingASTWalker:
         self._handle(node, children)
 
     def _MatchStar(self, node):
-        self._handle(node, ["*_"])
+        self._handle(node, ["*", node.name or "_"])
 
     def _MatchAs(self, node):
         if node.pattern:

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -788,6 +788,13 @@ class _PatchingASTWalker:
         children.extend(node.cases)
         self._handle(node, children)
 
+    def _MatchOr(self, node):
+        children = [*self._child_nodes(node.patterns, "|")]
+        self._handle(node, children)
+
+    def _MatchSingleton(self, node):
+        self._handle(node, [str(node.value)])
+
     def _match_case(self, node):
         children = ["case", node.pattern]
         if node.guard:
@@ -795,6 +802,13 @@ class _PatchingASTWalker:
         children.append(":")
         children.extend(node.body)
         self._handle(node, children)
+
+    def _MatchSequence(self, node):
+        children = ["[", *self._child_nodes(node.patterns, ","), "]"]
+        self._handle(node, children)
+
+    def _MatchStar(self, node):
+        self._handle(node, ["*_"])
 
     def _MatchAs(self, node):
         if node.pattern:

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1425,6 +1425,78 @@ class PatchedASTTest(unittest.TestCase):
         ])
 
     @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_or(self):
+        source = dedent(
+            """\
+            match x:
+                case 'v'|'z':
+                    print(x)
+        """
+        )
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchOr")
+        checker.check_children("MatchOr", ["MatchValue", "", "|", "", "MatchValue"])
+
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_singleton_true(self):
+        source = dedent(
+            """\
+            match x:
+                case True:
+                    print(x)
+        """
+        )
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSingleton")
+        checker.check_children("MatchSingleton", ["True"])
+
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_singleton_none(self):
+        source = dedent(
+            """\
+            match x:
+                case None:
+                    print(x)
+        """
+        )
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSingleton")
+        checker.check_children("MatchSingleton", ["None"])
+
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_sequence_with_star(self):
+        source = dedent(
+            """\
+            match x:
+                case [*_]:
+                    print(x)
+        """
+        )
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSequence")
+        checker.check_children("MatchSequence", ["[", "", "MatchStar", "", "]"])
+
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_sequence_with_star_and_value(self):
+        source = dedent(
+            """\
+            match x:
+                case [*_, "something"]:
+                    print(x)
+        """
+        )
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSequence")
+        checker.check_children(
+            "MatchSequence", ["[", "", "MatchStar", "", ",", " ", "MatchValue", "", "]"]
+        )
+
+    @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_as_capture_pattern(self):
         source = dedent("""\
             match x:

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1467,7 +1467,7 @@ class PatchedASTTest(unittest.TestCase):
         checker.check_children("MatchSingleton", ["None"])
 
     @testutils.only_for_versions_higher("3.10")
-    def test_match_node_with_match_sequence_with_star(self):
+    def test_match_node_with_match_sequence_with_star_wildcard(self):
         source = dedent(
             """\
             match x:
@@ -1479,6 +1479,22 @@ class PatchedASTTest(unittest.TestCase):
         checker = _ResultChecker(self, ast_frag)
         self.assert_single_case_match_block(checker, "MatchSequence")
         checker.check_children("MatchSequence", ["[", "", "MatchStar", "", "]"])
+
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_sequence_with_tail_capture(self):
+        source = dedent(
+            """\
+            match x:
+                case [1, 2, *rest]:
+                    print(rest)
+        """
+        )
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSequence")
+        checker.check_children("MatchSequence", [
+            "[", "", "MatchValue", "", ",", " ", "MatchValue", "", ",", " ", "MatchStar", "", "]",
+        ])
 
     @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_sequence_with_star_and_value(self):


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.

Fixes maybe all of #623 

I was initially encountering an issue when trying to implement support for `MatchSingleton`, but I realized that the singleton wasn't actually a `Name`/`NameConstant`, but rather the string representation, at least in the test, so that helped me push through to support it as well.

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
- [x] I have made corresponding changes to user documentation for new features

