### PR TITLE
Add explicit sphinx.configuration key

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,6 @@ python:
       path: .
       extra_requirements:
         - doc
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
This is now required according to "Deprecation of projects using Sphinx or MkDocs without an explicit configuration file"

Ref: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
