### PR TITLE
Do not use sys.executable for pip uninstall

### DIFF
--- a/ropetest/conftest.py
+++ b/ropetest/conftest.py
@@ -105,4 +105,11 @@ def external_fixturepkg(session_venv, session_venv_python_executable):
         "ropetest-package-fixtures/external_fixturepkg/dist/external_fixturepkg-1.0.0-py3-none-any.whl",
     ])
     yield
-    check_call([sys.executable, "-m", "pip", "uninstall", "--yes", "external-fixturepkg"])
+    check_call([
+        session_venv_python_executable,
+        "-m",
+        "pip",
+        "uninstall",
+        "--yes",
+        "external-fixturepkg"
+    ])


### PR DESCRIPTION
# Description

The system executable might be an externally managed environment[1], which means pip then refuses to uninstall the installed package, and it bubbles up as a teardown error. Use the venv to avoid that.

1: https://packaging.python.org/en/latest/specifications/externally-managed-environments/