### PR TITLE
Fix #836: correct _const_node_type_names fallback for Python 3.14+

### DIFF
--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -8,18 +8,31 @@ try:
     # Suppress the mypy complaint: Module "ast" has no attribute "_const_node_type_names"
     from ast import _const_node_type_names  # type:ignore
 except ImportError:
-    # backported from stdlib `ast`
-    assert sys.version_info < (3, 8) or sys.version_info >= (3, 14)
-    _const_node_type_names = {
-        bool: "NameConstant",  # should be before int
-        type(None): "NameConstant",
-        int: "Num",
-        float: "Num",
-        complex: "Num",
-        str: "Str",
-        bytes: "Bytes",
-        type(...): "Ellipsis",
-    }
+    if sys.version_info >= (3, 8):
+        # Python 3.14+ removed _const_node_type_names; all constant literals
+        # are represented as ast.Constant nodes.
+        _const_node_type_names = {
+            bool: "Constant",  # should be before int
+            type(None): "Constant",
+            int: "Constant",
+            float: "Constant",
+            complex: "Constant",
+            str: "Constant",
+            bytes: "Constant",
+            type(...): "Constant",
+        }
+    else:
+        # Python < 3.8 used separate node types (Num, Str, Bytes, etc.)
+        _const_node_type_names = {
+            bool: "NameConstant",  # should be before int
+            type(None): "NameConstant",
+            int: "Num",
+            float: "Num",
+            complex: "Num",
+            str: "Str",
+            bytes: "Bytes",
+            type(...): "Ellipsis",
+        }
 
 
 def parse(source, filename="<string>", *args, **kwargs):  # type: ignore

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1511,6 +1511,28 @@ class PatchedASTTest(unittest.TestCase):
         ])
 
 
+class ConstNodeTypeNamesTest(unittest.TestCase):
+    def _name(self, value):
+        import ast as stdlib_ast
+        node = stdlib_ast.Constant(value=value)
+        return ast.get_const_subtype_name(node)
+
+    @unittest.skipIf(sys.version_info < (3, 8), "get_const_subtype_name requires 3.8+")
+    def test_int_name(self):
+        expected = "Constant" if sys.version_info >= (3, 14) else "Num"
+        self.assertEqual(self._name(1), expected)
+
+    @unittest.skipIf(sys.version_info < (3, 8), "get_const_subtype_name requires 3.8+")
+    def test_str_name(self):
+        expected = "Constant" if sys.version_info >= (3, 14) else "Str"
+        self.assertEqual(self._name("hello"), expected)
+
+    @unittest.skipIf(sys.version_info < (3, 8), "get_const_subtype_name requires 3.8+")
+    def test_none_name(self):
+        expected = "Constant" if sys.version_info >= (3, 14) else "NameConstant"
+        self.assertEqual(self._name(None), expected)
+
+
 class _ResultChecker:
     def __init__(self, test_case, ast):
         self.test_case = test_case


### PR DESCRIPTION
Fixes #836.

`ast._const_node_type_names` was removed in Python 3.14. The `except ImportError` fallback in `rope/base/ast.py` already handled this case at the assertion level, but the fallback dict still used the old pre-3.8 names (`"Num"`, `"Str"`, `"NameConstant"`, etc.). On Python 3.14 all constant literals are `ast.Constant` nodes, so the fallback dict should map every type to `"Constant"` instead.

Split the except block into two branches: `>= (3, 8)` (i.e. Python 3.14+ which removed the attribute) uses `"Constant"` for all types; `< (3, 8)` keeps the original mapping for the old node types. Also removed the bare `assert` since the if/else now makes the intent explicit.

Added `ConstNodeTypeNamesTest` to cover the expected return values of `get_const_subtype_name()` per Python version.
