### PR TITLE
Fix patchedast aborting on ''' inside a double-quoted f-string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # **Upcoming release**
 
+- Fix `patchedast` aborting on a `'''` sequence inside a double-quoted
+  f-string (`end_quote_char` picked the longest quote in the body instead of
+  the matching delimiter), which raised `MismatchedTokenError` and broke
+  rename/inline for the whole module (@marlon-costa-dc)
 - ...
 
 # Release 1.14.0

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -383,14 +383,16 @@ class _PatchingASTWalker:
             return self.source[start : quote_pos + len(quote_char)]
 
         def end_quote_char():
-            possible_quotes = [
-                (self.source.source.rfind(q, start, end), q)
-                for q in reversed(QUOTE_CHARS)
-            ]
-            _, quote_pos, quote_char = max(
-                (len(q), pos, q) for pos, q in possible_quotes if pos != -1
-            )
-            return self.source[end - len(quote_char) : end]
+            # The closing delimiter is the quote char the f-string literally
+            # ends with -- NOT the longest quote char anywhere in the body.
+            # A ''' appearing inside a "..." f-string body must not be picked
+            # as the delimiter (issue: end_quote_char used max(len(q)) and
+            # mis-matched, producing a token that consume_joined_string could
+            # not locate).
+            for quote_char in QUOTE_CHARS:
+                if self.source.source[end - len(quote_char) : end] == quote_char:
+                    return self.source[end - len(quote_char) : end]
+            return self.source[end - 1 : end]
 
         QUOTE_CHARS = ['"""', "'''", '"', "'"]
         offset = self.source.offset

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -273,6 +273,19 @@ class PatchedASTTest(unittest.TestCase):
         checker.check_children("FormattedValue", ["{", "", "Name", "", "}"])
 
     @testutils.only_for_versions_higher("3.6")
+    def test_handling_format_strings_with_triple_quote_in_body(self):
+        # A double-quoted f-string whose body contains a ''' sequence must not
+        # confuse the end-quote detection (end_quote_char picked the longest
+        # quote in the body instead of the matching delimiter).
+        source = 'f"abc = \'\'\'{a}"\n'
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        checker.check_children(
+            "JoinedStr", ['f"', "abc = '''", "FormattedValue", "", '"']
+        )
+        checker.check_children("FormattedValue", ["{", "", "Name", "", "}"])
+
+    @testutils.only_for_versions_higher("3.6")
     def test_handling_format_strings_with_implicit_join(self):
         source = '''"1" + rf'abc{a}' f"""xxx{b} """\n'''
         ast_frag = patchedast.get_patched_ast(source, True)


### PR DESCRIPTION
## Description

`patchedast._JoinedStr.end_quote_char()` selects the closing delimiter by `max(len(quote))` over **every** quote character found anywhere in the f-string body. When a `'''` sequence appears inside a double-quoted f-string, e.g.:

```python
f"cfg = '''\n{value}"
```

the `'''` in the body is picked as the delimiter instead of the actual closing `"`. That produces a reconstructed token that `consume_joined_string()` cannot locate, raising:

```
ValueError: substring not found
```

which surfaces as `MismatchedTokenError` and **aborts rename / inline for the entire module** — a single such f-string anywhere in a project breaks refactoring of that file.

## Root cause

`end_quote_char()` chose the quote by length precedence rather than by which delimiter the f-string literally ends with. The opening quote (`start_quote_char`) was already correct; the closing detection was not symmetric.

## Fix

Pick the delimiter the f-string literally ends with. `QUOTE_CHARS` is ordered longest-first (`"""`, `'''`, `"`, `'`), so triple-quoted strings are still matched before single-character quotes, and the closing quote now always matches the opening one regardless of quote characters in the body.

## Reproducer (before the fix)

```python
import ast
from rope.refactor import patchedast
patchedast.patch_ast(ast.parse('f"a = \'\'\'{y}"\n'), 'f"a = \'\'\'{y}"\n')
# ValueError: substring not found
```

## Testing

- New regression test `test_handling_format_strings_with_triple_quote_in_body` in `ropetest/refactor/patchedasttest.py` (red before, green after).
- Full suites green: `ropetest/refactor/` = 944 passed, 7 skipped, 1 xfailed.
- `patchedasttest.py` = 141 passed, 6 skipped.

## Checklist

- [x] I have added tests that prove my fix is effective
- [x] I have updated CHANGELOG.md
- [ ] I have made corresponding changes to user documentation for new features (n/a — bug fix)
- [ ] I have made corresponding changes to library documentation for API changes (n/a — no API change)