### PR TITLE
Add Python 3.13 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Software Development',
 ]
 version = '1.14.0'


### PR DESCRIPTION
Closes #838.

This adds the Python 3.13 Trove classifier, matching the existing CI matrix and ensuring the built package advertises support for a version that is already tested.

This intentionally does not change `requires-python` or remove the Python 3.8 classifier: CI coverage alone does not establish the project's supported-minimum-version policy.

Validation:

- `python -m pytest -q --deselect=ropetest/contrib/autoimporttest.py::AutoImportTest::test_generate_full_cache --deselect=ropetest/contrib/autoimporttest.py::AutoImportTest::test_skipping_directories_not_accessible_because_of_permission_error` — 2089 passed, 8 skipped, 5 xfailed
- The two deselected autoimport tests fail unchanged on the Windows baseline because their fixtures print a non-GBK character and exercise directory permissions.
- `python -m build --wheel --no-isolation`
- verified `Classifier: Programming Language :: Python :: 3.13` in the built wheel metadata
- `python -m pre_commit run --files pyproject.toml`