### PR TITLE
Avoid printing autoimport syntax errors

### DIFF
--- a/rope/contrib/autoimport/parse.py
+++ b/rope/contrib/autoimport/parse.py
@@ -47,7 +47,7 @@ def get_names_from_file(
     try:
         root_node = ast.parse(module.read_bytes())
     except SyntaxError as error:
-        print(error)
+        logger.debug("Skipping invalid source file %s: %s", module, error)
         return
     for node in ast.iter_child_nodes(root_node):
         if isinstance(node, ast.Assign):

--- a/ropetest/contrib/autoimport/parsetest.py
+++ b/ropetest/contrib/autoimport/parsetest.py
@@ -1,3 +1,5 @@
+import logging
+
 from rope.contrib.autoimport import parse
 from rope.contrib.autoimport.defs import Name, NameType, PartialName, Source
 
@@ -5,6 +7,17 @@ from rope.contrib.autoimport.defs import Name, NameType, PartialName, Source
 def test_typing_names(typing_path):
     names = list(parse.get_names_from_file(typing_path))
     assert PartialName("Text", NameType.Variable) in names
+
+
+def test_invalid_source_file_is_skipped_without_writing_to_stdout(tmp_path, caplog, capsys):
+    source = tmp_path / "invalid.py"
+    source.write_text("€ = 2\n", encoding="utf-8")
+
+    with caplog.at_level(logging.DEBUG, logger=parse.__name__):
+        assert list(parse.get_names_from_file(source)) == []
+
+    assert capsys.readouterr().out == ""
+    assert f"Skipping invalid source file {source}" in caplog.text
 
 
 def test_find_sys():


### PR DESCRIPTION
## Summary

When autoimport scans an invalid source file, `get_names_from_file()` prints the `SyntaxError` to standard output. On Windows consoles using GBK, a syntax error containing an unencodable character can raise `UnicodeEncodeError` in the worker process and interrupt cache generation.

This switches the diagnostic to the existing module logger at debug level. Invalid files continue to be skipped, without writing to standard output.

## Validation

- Added a regression test for an invalid source file containing `€`; it verifies the file is skipped, the diagnostic is logged, and standard output stays empty.
- `python -m pytest -q ropetest/contrib/autoimport/parsetest.py` — 4 passed
- `python -m pytest -q --deselect=ropetest/contrib/autoimporttest.py::AutoImportTest::test_generate_full_cache --deselect=ropetest/contrib/autoimporttest.py::AutoImportTest::test_skipping_directories_not_accessible_because_of_permission_error` — 2090 passed, 8 skipped, 5 xfailed
- The two deselected autoimport tests fail unchanged on the Windows baseline because of console encoding and permission-fixture behavior.
- `python -m pre_commit run --files rope/contrib/autoimport/parse.py ropetest/contrib/autoimport/parsetest.py`