### PR TITLE
Fix autoimport.sqlite deriving module names from non-package folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # **Upcoming release**
 
+- #823 Fix autoimport.sqlite deriving module names from non-package folders (@deepakganesh78)
 - ...
 
 # Release 1.14.0

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -44,7 +44,6 @@ from rope.contrib.autoimport.defs import (
 from rope.contrib.autoimport.parse import get_names
 from rope.contrib.autoimport.utils import (
     get_files,
-    get_modname_from_path,
     get_package_tuple,
     sort_and_deduplicate,
     sort_and_deduplicate_tuple,
@@ -654,12 +653,13 @@ class AutoImport:
         assert self.project_package.path
         underlined = underlined if underlined else self.underlined
         resource_path: Path = resource.pathlib
-        # The project doesn't need its name added to the path,
-        # since the standard python file layout accounts for that
-        # so we set add_package_name to False
-        resource_modname: str = get_modname_from_path(
-            resource_path, self.project_package.path, add_package_name=False
-        )
+        # Resolve the module name by walking up the package hierarchy from the
+        # resource (stopping at the first directory without an ``__init__.py``),
+        # rather than deriving it from the resource's path relative to the
+        # project root. The latter incorrectly includes intermediate,
+        # non-package directories in the module name.
+        # See https://github.com/python-rope/rope/issues/823
+        resource_modname: str = libutils.modname(resource)
         return ModuleFile(
             resource_path,
             resource_modname,

--- a/ropetest/contrib/autoimport/autoimporttest.py
+++ b/ropetest/contrib/autoimport/autoimporttest.py
@@ -132,6 +132,23 @@ def test_connection(project: Project, project2: Project):
     assert ai1.connection is not ai3.connection
 
 
+def test_resource_to_module_skips_non_package_folders(
+    autoimport: AutoImport,
+    project: Project,
+):
+    # Intermediate folders that are not packages (no ``__init__.py``) must not
+    # be included in the derived module name.
+    # Regression test for https://github.com/python-rope/rope/issues/823
+    src = project.root.create_folder("src")
+    pkg = src.create_folder("mypkg")
+    pkg.create_file("__init__.py")
+    documents = pkg.create_file("documents.py")
+
+    module = autoimport._resource_to_module(documents)
+
+    assert module.modname == "mypkg.documents"
+
+
 @contextmanager
 def assert_database_is_reset(conn):
     conn.execute("ALTER TABLE names ADD COLUMN deprecated_column")


### PR DESCRIPTION
Fixes #823

## Root cause

`AutoImport._resource_to_module` in `rope/contrib/autoimport/sqlite.py` derived a module's name from its path *relative to the project root*:

```python
resource_modname = get_modname_from_path(
    resource_path, self.project_package.path, add_package_name=False
)
```

`get_modname_from_path` simply joins every intermediate directory name, so it includes folders that are **not** Python packages. For a layout like

```
<root>/shared/src/shared/__init__.py
<root>/shared/src/shared/documents.py
```

where `shared/` (top) and `src/` are not packages, the sqlite backend reported the module as `shared.src.shared.documents` instead of the correct `shared.documents`.

The pickle backend does not have this bug because it uses `libutils.modname`, which walks *up* the package hierarchy from the resource and stops at the first directory without an `__init__.py`.

## Fix

Use `libutils.modname(resource)` in the sqlite backend's `_resource_to_module`, matching the pickle backend so both agree and intermediate non-package folders are excluded. The now-unused `get_modname_from_path` import is removed.

## Tests

Added `test_resource_to_module_skips_non_package_folders` which builds a `src/mypkg/documents.py` structure (where `src/` is not a package) and asserts the derived modname is `mypkg.documents`. It fails on `master` (`src.mypkg.documents`) and passes with this change.

Full suite: **2092 passed, 8 skipped, 5 xfailed** in a per-repo venv.
