### PR TITLE
docs: resolve warnings

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,5 +6,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: psf/black@stable

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pytest --cov -v
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: python-rope/rope

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,9 +11,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,3 +66,6 @@ html_css_files = ["rope.css"]
 
 # Make sure the target is unique
 autosectionlabel_prefix_document = True
+
+# suppress third-party generated warnings
+suppress_warnings = ["docutils"]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -70,7 +70,7 @@ autoimport.* Options
 .. autopytoolconfigtable:: rope.base.prefs.AutoimportPrefs
 
 imports.* Options
-----------------
+-----------------
 
 .. autopytoolconfigtable:: rope.base.prefs.ImportPrefs
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -400,7 +400,7 @@ Extract Method
 In these examples ``${region_start}`` and ``${region_end}`` show the
 selected region for extraction:
 
-.. code-block:: python
+.. code-block:: none
 
   def a_func():
       a = 1
@@ -421,7 +421,7 @@ After performing extract method we'll have:
 
 For multi-line extractions if we have:
 
-.. code-block:: python
+.. code-block:: none
 
   def a_func():
       a = 1
@@ -1265,7 +1265,7 @@ After running ``mod1`` either SOA or DOA on this module you can test:
 
 ``mod2.py``:
 
-.. code-block:: python
+.. code-block:: none
 
   import mod1
 

--- a/rope/base/ast.py
+++ b/rope/base/ast.py
@@ -6,7 +6,7 @@ from rope.base import fscommands
 
 try:
     # Suppress the mypy complaint: Module "ast" has no attribute "_const_node_type_names"
-    from ast import _const_node_type_names  # type:ignore
+    from ast import _const_node_type_names  # type: ignore
 except ImportError:
     # backported from stdlib `ast`
     assert sys.version_info < (3, 8) or sys.version_info >= (3, 14)

--- a/rope/base/fscommands.py
+++ b/rope/base/fscommands.py
@@ -65,7 +65,7 @@ class FileSystemCommands:
 class SubversionCommands:
     def __init__(self, *args):
         self.normal_actions = FileSystemCommands()
-        import pysvn  # type:ignore
+        import pysvn  # type: ignore
 
         self.client = pysvn.Client()
 
@@ -115,9 +115,9 @@ class MercurialCommands:
         self.repo = self.hg.hg.repository(self.ui, root)
 
     def _import_mercurial(self):
-        import mercurial.commands  # type:ignore
-        import mercurial.hg  # type:ignore
-        import mercurial.ui  # type:ignore
+        import mercurial.commands  # type: ignore
+        import mercurial.hg  # type: ignore
+        import mercurial.ui  # type: ignore
 
         return mercurial
 

--- a/rope/base/oi/doa.py
+++ b/rope/base/oi/doa.py
@@ -4,9 +4,9 @@ import hashlib
 import hmac
 
 try:
-    import cPickle as pickle  # type:ignore
+    import cPickle as pickle  # type: ignore
 except ImportError:
-    import pickle  # type:ignore
+    import pickle  # type: ignore
 import marshal
 import os
 import socket

--- a/rope/base/oi/runmod.py
+++ b/rope/base/oi/runmod.py
@@ -4,7 +4,7 @@ def __rope_start_everything():
     import sys
 
     try:
-        import cPickle as pickle  # type:ignore
+        import cPickle as pickle  # type: ignore
     except ImportError:
         import pickle
     import base64

--- a/rope/base/oi/type_hinting/evaluate.py
+++ b/rope/base/oi/type_hinting/evaluate.py
@@ -69,7 +69,7 @@ class SymbolTable:
             s.lbp = max(bp, s.lbp)
         return s
 
-    @multi  # type:ignore
+    @multi  # type: ignore
     def infix(self, name, bp):
         symbol = self.symbol(name, bp)
 
@@ -79,7 +79,7 @@ class SymbolTable:
             self.second = parser.expression(bp)
             return self
 
-    @multi  # type:ignore
+    @multi  # type: ignore
     def infix_r(self, name, bp):
         symbol = self.symbol(name, bp)
 
@@ -101,8 +101,8 @@ class SymbolTable:
             self.third = parser.expression(symbol2.lbp + 0.1)
             return self
 
-    @multi  # type:ignore
-    def prefix(self, name, bp):  # type:ignore
+    @multi  # type: ignore
+    def prefix(self, name, bp):  # type: ignore
         symbol = self.symbol(name, bp)
 
         @method(symbol)
@@ -110,7 +110,7 @@ class SymbolTable:
             self.first = parser.expression(bp)
             return self
 
-    @multi  # type:ignore
+    @multi  # type: ignore
     def postfix(self, name, bp):
         symbol = self.symbol(name, bp)
 
@@ -237,18 +237,18 @@ symbol("(name)")
 symbol("(end)")
 
 
-@method(symbol("(name)"))  # type:ignore
+@method(symbol("(name)"))  # type: ignore
 def nud(self, parser):
     return self
 
 
-@method(symbol("(name)"))  # type:ignore
+@method(symbol("(name)"))  # type: ignore
 def evaluate(self, pyobject):
     return utils.resolve_type(self.value, pyobject)
 
 
 # Parametrized objects
-@method(symbol("["))  # type:ignore
+@method(symbol("["))  # type: ignore
 def led(self, left, parser):
     self.first = left
     self.second = []
@@ -264,7 +264,7 @@ def led(self, left, parser):
     return self
 
 
-@method(symbol("["))  # type:ignore
+@method(symbol("["))  # type: ignore
 def evaluate(self, pyobject):
     return utils.parametrize_type(
         self.first.evaluate(pyobject), *[i.evaluate(pyobject) for i in self.second]
@@ -272,7 +272,7 @@ def evaluate(self, pyobject):
 
 
 # Anonymous Function Calls
-@method(symbol("("))  # type:ignore
+@method(symbol("("))  # type: ignore
 def nud(self, parser):
     self.second = []
     if parser.token.name != ")":
@@ -288,7 +288,7 @@ def nud(self, parser):
 
 
 # Function Calls
-@method(symbol("("))  # type:ignore
+@method(symbol("("))  # type: ignore
 def led(self, left, parser):
     self.first = left
     self.second = []
@@ -304,13 +304,13 @@ def led(self, left, parser):
     return self
 
 
-@method(symbol("("))  # type:ignore
+@method(symbol("("))  # type: ignore
 def evaluate(self, pyobject):
     # TODO: Implement me
     raise NotImplementedError
 
 
-@method(symbol("or"))  # type:ignore
+@method(symbol("or"))  # type: ignore
 @method(symbol("|"))
 def evaluate(self, pyobject):
     # TODO: Implement me

--- a/rope/base/oi/type_hinting/providers/numpydocstrings.py
+++ b/rope/base/oi/type_hinting/providers/numpydocstrings.py
@@ -10,7 +10,7 @@ from rope.base.ast import literal_eval
 from rope.base.oi.type_hinting.providers import docstrings
 
 try:
-    from numpydoc.docscrape import NumpyDocString  # type:ignore
+    from numpydoc.docscrape import NumpyDocString  # type: ignore
 except ImportError:
     NumpyDocString = None
 
@@ -41,4 +41,4 @@ class _DummyParamParser(docstrings.IParamParser):
 
 
 if not NumpyDocString:
-    NumPyDocstringParamParser = _DummyParamParser  # type:ignore
+    NumPyDocstringParamParser = _DummyParamParser  # type: ignore

--- a/rope/base/project.py
+++ b/rope/base/project.py
@@ -15,13 +15,13 @@ from rope.base.exceptions import ModuleNotFoundError
 
 # At present rope.base.prefs starts with `# type:ignore`.
 # As a result, mypy knows nothing about Prefs and get_config.
-from rope.base.prefs import Prefs, get_config  # type:ignore
+from rope.base.prefs import Prefs, get_config  # type: ignore
 from rope.base.resources import File, Folder, _ResourceMatcher
 
 try:
-    import cPickle as pickle  # type:ignore
+    import cPickle as pickle  # type: ignore
 except ImportError:
-    import pickle  # type:ignore
+    import pickle  # type: ignore
 
 
 class _Project:

--- a/rope/contrib/autoimport/sqlite.py
+++ b/rope/contrib/autoimport/sqlite.py
@@ -51,7 +51,6 @@ from rope.contrib.autoimport.utils import (
 )
 from rope.refactor import importutils
 
-
 if TYPE_CHECKING:
     from collections.abc import Collection
 

--- a/rope/refactor/move.py
+++ b/rope/refactor/move.py
@@ -336,10 +336,10 @@ class MoveGlobal:
         if dest is None or not dest.exists():
             raise exceptions.RefactoringError("Move destination does not exist.")
         if dest.is_folder() and dest.has_child("__init__.py"):  # type: ignore[attr-defined]
-            dest = dest.get_child("__init__.py")  # type:ignore
+            dest = dest.get_child("__init__.py")  # type: ignore
         # The previous guards protect against this mypy complaint:
         # Item "None" of "Union[str, Resource, None]" has no attribute "is_folder"
-        if dest.is_folder():  # type:ignore
+        if dest.is_folder():  # type: ignore
             raise exceptions.RefactoringError(
                 "Move destination for non-modules should not be folders."
             )


### PR DESCRIPTION
Fixes these warnings:

```
> mitmanek~/r/r/docs (git: master)$ make html
Running Sphinx v8.2.3
loading translations [en]... done
[autosummary] generating autosummary for: configuration.rst, contributing.rst,
dev/issues.rst, index.rst, library.rst, overview.rst, release-process.rst, rope.rst
building [mo]: targets for 0 po files that are out of date
writing output...
building [html]: targets for 8 source files that are out of date
updating environment: [new config] 8 added, 0 changed, 0 removed
reading sources... [100%] rope
/home/matej/archiv/knihovna/repos/rope/rope/base/prefs.py:docstring of
rope.base.prefs.Prefs:1: WARNING: Inline emphasis start-string without end-string.
[docutils]
/home/matej/archiv/knihovna/repos/rope/rope/base/prefs.py:docstring of
rope.base.prefs.Prefs:1: WARNING: Inline emphasis start-string without end-string.
[docutils]
/home/matej/archiv/knihovna/repos/rope/rope/base/prefs.py:docstring of
rope.base.prefs.Prefs:1: WARNING: Inline emphasis start-string without end-string.
[docutils]
/home/matej/archiv/knihovna/repos/rope/docs/configuration.rst:73: WARNING: Title underline
too short.

imports.* Options
---------------- [docutils]
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets...
copying static files...
Writing evaluated template result to
/home/matej/archiv/knihovna/repos/rope/docs/_build/html/_static/basic.css
Writing evaluated template result to
/home/matej/archiv/knihovna/repos/rope/docs/_build/html/_static/documentation_options.js
Writing evaluated template result to
/home/matej/archiv/knihovna/repos/rope/docs/_build/html/_static/language_data.js
Writing evaluated template result to
/home/matej/archiv/knihovna/repos/rope/docs/_build/html/_static/js/versions.js
copying static files: done
copying extra files...
copying extra files: done
copying assets: done
writing output... [100%] rope
/home/matej/archiv/knihovna/repos/rope/docs/overview.rst:403: WARNING: Lexing literal_block
'def a_func():\n    a = 1\n    b = 2 * a\n    c = ${region_start}a * 2 + b *
3${region_end}' as "python" resulted in an error at token: '$'. Retrying in relaxed mode.
[misc.highlighting_failure]
/home/matej/archiv/knihovna/repos/rope/docs/overview.rst:424: WARNING: Lexing literal_block
'def a_func():\n    a = 1\n    ${region_start}b = 2 * a\n    c = a * 2 + b *
3${region_end}\n    print(b, c)' as "python" resulted in an error at token: '$'. Retrying
in relaxed mode. [misc.highlighting_failure]
/home/matej/archiv/knihovna/repos/rope/docs/overview.rst:1268: WARNING: Lexing
literal_block 'import mod1\n\narg = mod1.C1()\na_var =
mod1.func(arg)\na_var.${codeassist}\nmod1.func(mod1.C2()).${codeassist}' as "python"
resulted in an error at token: '$'. Retrying in relaxed mode. [misc.highlighting_failure]
generating indices... genindex done
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 7 warnings.

The HTML pages are in _build/html.
mitmanek~/r/r/docs (git: master)$
```
