### PR TITLE
Recognise async def method headers in worder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # **Upcoming release**
 
+- #859 Fix `find_definition`/Rename not resolving `async def` methods called via `self` (@gadievron)
 - #850 Update and pin black version in pre-commit and Github Actions
 - #851 Bump supported python version to up to Python 3.14
 - #852 Implement patchedast handlers for TypeAlias 

--- a/rope/base/worder.py
+++ b/rope/base/worder.py
@@ -310,7 +310,8 @@ class _RealFinder:
         word_start = self._find_word_start(offset - 1)
         line_start = self._get_line_start(word_start)
         prev_word = self.code[line_start:word_start].strip()
-        return prev_word in ["def", "class"]
+        # normalize whitespace so `async  def` / `async\tdef` (valid Python) match too
+        return " ".join(prev_word.split()) in ["def", "class", "async def"]
 
     def _find_first_non_space_char(self, offset):
         if offset >= len(self.code):

--- a/ropetest/contrib/findittest.py
+++ b/ropetest/contrib/findittest.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 from rope.base import exceptions
 from rope.contrib.findit import find_definition, find_implementations, find_occurrences
+from rope.refactor.rename import Rename
 from ropetest import testutils
 
 
@@ -145,3 +146,109 @@ class FindItTest(unittest.TestCase):
         result = find_definition(self.project, code, code.index("var"))
         self.assertEqual(mod1, result.resource)
         self.assertEqual(0, result.offset)
+
+    # worder's is_a_class_or_function_name_in_header only recognised the
+    # canonical `def`/`class` prefixes, so an `async def` method header was
+    # not treated as a definition and find_definition resolved a call via
+    # self to the call site itself (never the def).
+
+    def test_find_definition_of_async_method(self):
+        code = dedent("""\
+            class C(object):
+                async def target(self):
+                    pass
+
+                async def run(self):
+                    await self.target()
+        """)
+        call_offset = code.rindex("target")
+        result = find_definition(self.project, code, call_offset)
+        def_offset = code.index("target")
+        self.assertIsNotNone(result)
+        self.assertEqual(def_offset, result.offset)
+
+    def test_find_definition_of_async_method_extra_whitespace(self):
+        # `async  def` (two spaces) / `async\tdef` are valid Python and must
+        # be recognised too, not just canonical single-space `async def`.
+        code = dedent("""\
+            class C(object):
+                async  def target(self):
+                    pass
+
+                async  def run(self):
+                    await self.target()
+        """)
+        call_offset = code.rindex("target")
+        result = find_definition(self.project, code, call_offset)
+        def_offset = code.index("target")
+        self.assertIsNotNone(result)
+        self.assertEqual(def_offset, result.offset)
+
+    def test_find_definition_of_async_method_tab_separated(self):
+        # `async\tdef` (tab-separated) is valid Python; the normalised
+        # predicate must recognise it too.
+        code = dedent("""\
+            class C(object):
+                async def target(self):
+                    pass
+
+                async def run(self):
+                    await self.target()
+        """).replace("async def", "async\tdef")
+        call_offset = code.rindex("target")
+        result = find_definition(self.project, code, call_offset)
+        def_offset = code.index("target")
+        self.assertIsNotNone(result)
+        self.assertEqual(def_offset, result.offset)
+
+    def test_rename_heals_async_method(self):
+        # Rename from the call must reach the async def, not orphan it --
+        # the damaging end-to-end symptom of the unrecognised header.
+        mod = testutils.create_module(self.project, "mod")
+        code = dedent("""\
+            class C(object):
+                async def target(self):
+                    pass
+
+                async def run(self):
+                    await self.target()
+        """)
+        mod.write(code)
+        call_offset = code.rindex("target")
+        changes = Rename(self.project, mod, call_offset).get_changes("renamed")
+        self.project.do(changes)
+        result = mod.read()
+        # both the call and the def must be renamed -- not silently orphaned
+        self.assertEqual(0, result.count("target"))
+        self.assertEqual(2, result.count("renamed"))
+
+    def test_find_definition_of_sync_method_still_resolves(self):
+        # regression control: sync methods must keep resolving
+        code = dedent("""\
+            class C(object):
+                def target(self):
+                    pass
+
+                def run(self):
+                    self.target()
+        """)
+        call_offset = code.rindex("target")
+        result = find_definition(self.project, code, call_offset)
+        def_offset = code.index("target")
+        self.assertIsNotNone(result)
+        self.assertEqual(def_offset, result.offset)
+
+    def test_find_definition_of_module_level_async_function(self):
+        # control: module-level async defs already resolve correctly
+        code = dedent("""\
+            async def target():
+                pass
+
+            async def run():
+                await target()
+        """)
+        call_offset = code.rindex("target")
+        result = find_definition(self.project, code, call_offset)
+        def_offset = code.index("target")
+        self.assertIsNotNone(result)
+        self.assertEqual(def_offset, result.offset)


### PR DESCRIPTION
# Description

`worder`'s `is_a_class_or_function_name_in_header` only recognised the `def` and
`class` header prefixes, so an `async def` method header was not treated as a
definition. As a result `find_definition` for an `async def` method called via
`self` resolved to the **call site** instead of the def, and `Rename` from the
call did not reach the def.

```python
class C:
    async def target(self):
        pass
    async def run(self):
        await self.target()   # find_definition here -> the call site, not `def target`
```

Module-level `async def` already resolved correctly (different path); only method
resolution via `self` was affected.

### Fix

Add `"async def"` to the recognised headers and normalise internal whitespace so
`async  def` / `async\tdef` / line-continued forms also match:

```python
return " ".join(prev_word.split()) in ["def", "class", "async def"]
```

The predicate reads the blanked `real_code`, so string/comment text can't spoof
it, and only those three exact strings match — no false-positive surface. The fix
is version-independent (`async def` has been valid since Python 3.5).

Tests cover `find_definition` on an async method (canonical and tab/extra-space
spellings), an end-to-end `Rename`, and two regression controls (sync methods and
module-level async defs still resolve).

---

# Checklist

- [x] I have added tests that prove my fix is effective
- [x] I have updated CHANGELOG.md
