### PR TITLE
Handle parentheses around MatchSequence more correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - #852 Implement patchedast handlers for TypeAlias 
 - #853 Implement patchedast handlers TypeVar
 - #847 Avoid printing autoimport syntax errors (@yangfan-yf-yf)
-- #819 supports MatchOr, MatchSequence, MatchStar (@jheld)
+- #623, #819, #863 Support MatchOr, MatchSequence, MatchStar (@jheld, @lieryan)
 
 # Release 1.14.0
 

--- a/rope/base/codeanalyze.py
+++ b/rope/base/codeanalyze.py
@@ -78,7 +78,11 @@ class SourceLinesAdapter:
     def _calculate_offset(self, coord: tuple[int, int]) -> int:
         lineno, col_offset = coord
         lineno = self._clamp(0, self.length(), lineno)
-        col_offset = self._clamp(0, self.get_line_end(lineno) - self.get_line_start(lineno), col_offset)
+        col_offset = self._clamp(
+            0,
+            self.get_line_end(lineno) - self.get_line_start(lineno),
+            col_offset,
+        )
 
         return self.get_line_start(lineno) + col_offset
 

--- a/rope/base/codeanalyze.py
+++ b/rope/base/codeanalyze.py
@@ -70,6 +70,21 @@ class SourceLinesAdapter:
     def get_line_end(self, lineno):
         return self.starts[lineno] - 1
 
+    def __getitem__(self, subscript):
+        start_offset = self._calculate_offset(subscript.start)
+        stop_offset = self._calculate_offset(subscript.stop)
+        return self.code[start_offset:stop_offset]
+
+    def _calculate_offset(self, coord: tuple[int, int]) -> int:
+        lineno, col_offset = coord
+        lineno = self._clamp(0, self.length(), lineno)
+        col_offset = self._clamp(0, self.get_line_end(lineno) - self.get_line_start(lineno), col_offset)
+
+        return self.get_line_start(lineno) + col_offset
+
+    def _clamp(self, min_value, max_value, value):
+        return max(min_value, min(max_value, value))
+
 
 class ArrayLinesAdapter:
     def __init__(self, lines):

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -805,33 +805,41 @@ class _PatchingASTWalker:
 
     def _MatchSequence(self, node):
         if node.patterns:
-            opening_paren = self.lines[
-                (node.lineno, node.col_offset) : (
-                    node.patterns[0].lineno,
-                    node.patterns[0].col_offset,
-                )
-            ].strip()
-            closing_paren = self.lines[
-                (node.patterns[-1].end_lineno, node.patterns[-1].end_col_offset) : (
-                    node.end_lineno,
-                    node.end_col_offset,
-                )
-            ].strip()
+            opening_paren, closing_paren = self._get_surrounding_parens(node)
+
             children = [
                 *opening_paren,
                 *self._child_nodes(node.patterns, ","),
                 *closing_paren,
             ]
         else:
-            children = [
-                self.lines[
-                    (node.lineno, node.col_offset) : (
-                        node.end_lineno,
-                        node.end_col_offset,
-                    )
-                ]
-            ]
+            node_start = (node.lineno, node.col_offset)
+            node_end = (node.end_lineno, node.end_col_offset)
+            children = [self.lines[node_start:node_end]]
         self._handle(node, children)
+
+    def _get_surrounding_parens(self, node: ast.MatchSequence):
+        node_start = (node.lineno, node.col_offset)
+        first_pattern_start = (node.patterns[0].lineno, node.patterns[0].col_offset)
+        opening_paren = self.lines[node_start:first_pattern_start].strip()
+        if opening_paren not in ["[", "(", ""]:
+            warnings.warn(
+                f"Unexpected character in MatchSequence's opening_paren <{opening_paren}>; please report!",
+                RuntimeWarning,
+            )
+
+        last_pattern_end = (
+            node.patterns[-1].end_lineno,
+            node.patterns[-1].end_col_offset,
+        )
+        node_end = (node.end_lineno, node.end_col_offset)
+        closing_paren = self.lines[last_pattern_end:node_end].strip()
+        if closing_paren not in ["]", ")", ""]:
+            warnings.warn(
+                f"Unexpected character in MatchSequence's closing_paren <{closing_paren}>; please report!",
+                RuntimeWarning,
+            )
+        return opening_paren, closing_paren
 
     def _MatchStar(self, node):
         self._handle(node, ["*", node.name or "_"])

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -805,11 +805,32 @@ class _PatchingASTWalker:
 
     def _MatchSequence(self, node):
         if node.patterns:
-            opening_paren = self.lines[(node.lineno, node.col_offset):(node.patterns[0].lineno, node.patterns[0].col_offset)]
-            closing_paren = self.lines[(node.patterns[-1].end_lineno, node.patterns[-1].end_col_offset):(node.end_lineno, node.end_col_offset)]
-            children = [*opening_paren, *self._child_nodes(node.patterns, ","), *closing_paren]
+            opening_paren = self.lines[
+                (node.lineno, node.col_offset) : (
+                    node.patterns[0].lineno,
+                    node.patterns[0].col_offset,
+                )
+            ]
+            closing_paren = self.lines[
+                (node.patterns[-1].end_lineno, node.patterns[-1].end_col_offset) : (
+                    node.end_lineno,
+                    node.end_col_offset,
+                )
+            ]
+            children = [
+                *opening_paren,
+                *self._child_nodes(node.patterns, ","),
+                *closing_paren,
+            ]
         else:
-            children = [self.lines[(node.lineno, node.col_offset):(node.end_lineno, node.end_col_offset)]]
+            children = [
+                self.lines[
+                    (node.lineno, node.col_offset) : (
+                        node.end_lineno,
+                        node.end_col_offset,
+                    )
+                ]
+            ]
         self._handle(node, children)
 
     def _MatchStar(self, node):

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -804,7 +804,12 @@ class _PatchingASTWalker:
         self._handle(node, children)
 
     def _MatchSequence(self, node):
-        children = ["[", *self._child_nodes(node.patterns, ","), "]"]
+        if node.patterns:
+            opening_paren = self.lines[(node.lineno, node.col_offset):(node.patterns[0].lineno, node.patterns[0].col_offset)]
+            closing_paren = self.lines[(node.patterns[-1].end_lineno, node.patterns[-1].end_col_offset):(node.end_lineno, node.end_col_offset)]
+            children = [*opening_paren, *self._child_nodes(node.patterns, ","), *closing_paren]
+        else:
+            children = [self.lines[(node.lineno, node.col_offset):(node.end_lineno, node.end_col_offset)]]
         self._handle(node, children)
 
     def _MatchStar(self, node):

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -810,13 +810,13 @@ class _PatchingASTWalker:
                     node.patterns[0].lineno,
                     node.patterns[0].col_offset,
                 )
-            ]
+            ].strip()
             closing_paren = self.lines[
                 (node.patterns[-1].end_lineno, node.patterns[-1].end_col_offset) : (
                     node.end_lineno,
                     node.end_col_offset,
                 )
-            ]
+            ].strip()
             children = [
                 *opening_paren,
                 *self._child_nodes(node.patterns, ","),

--- a/ropetest/codeanalyzetest.py
+++ b/ropetest/codeanalyzetest.py
@@ -38,6 +38,26 @@ class SourceLinesAdapterTest(unittest.TestCase):
         to_lines = SourceLinesAdapter("line1")
         self.assertEqual(1, to_lines.get_line_number(5))
 
+    def test_source_lines_getitem_range(self):
+        to_lines = SourceLinesAdapter("line1\nline2\nline3\nline4\n")
+        self.assertEqual('ne2\nli', to_lines[(2, 2):(3, 2)])
+
+    def test_source_lines_getitem_start_lineno_out_of_range(self):
+        to_lines = SourceLinesAdapter("line1\nline2\nline3\nline4\n")
+        self.assertEqual("", to_lines[(100, 2):(3, 2)])
+
+    def test_source_lines_getitem_start_col_offset_out_of_range(self):
+        to_lines = SourceLinesAdapter("line1\nline2\nline3\nline4\n")
+        self.assertEqual('\nli', to_lines[(2, 100):(3, 2)])
+
+    def test_source_lines_getitem_end_lineno_out_of_range(self):
+        to_lines = SourceLinesAdapter("line1\nline2\nline3\nline4\n")
+        self.assertEqual("ne2\nline3\nline4\n", to_lines[(2, 2):(100, 2)])
+
+    def test_source_lines_getitem_end_col_offset_out_of_range(self):
+        to_lines = SourceLinesAdapter("line1\nline2\nline3\nline4\n")
+        self.assertEqual('ne2\nline3', to_lines[(2, 2):(3, 100)])
+
 
 class WordRangeFinderTest(unittest.TestCase):
     def _find_primary(self, code, offset):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1487,6 +1487,86 @@ class PatchedASTTest(unittest.TestCase):
         ])
 
     @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_sequence_with_no_parens(self):
+        source = dedent("""\
+            match x:
+                case 1, 2:
+                    print(rest)
+        """)
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSequence")
+        checker.check_children("MatchSequence", [
+            "MatchValue", "", ",", " ", "MatchValue",
+        ])
+
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_sequence_with_square_parens(self):
+        source = dedent("""\
+            match x:
+                case [1, 2]:
+                    print(rest)
+        """)
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSequence")
+        checker.check_children("MatchSequence", [
+            "[", "", "MatchValue", "", ",", " ", "MatchValue", "", "]",
+        ])
+
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_sequence_with_round_parens(self):
+        source = dedent("""\
+            match x:
+                case (1, 2):
+                    print(rest)
+        """)
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSequence")
+        checker.check_children("MatchSequence", [
+            "(", "", "MatchValue", "", ",", " ", "MatchValue", "", ")",
+        ])
+
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_sequence_with_internal_parens(self):
+        source = dedent("""\
+            match x:
+                case [1], [2]:
+                    print(rest)
+        """)
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSequence")
+        checker.check_children("MatchSequence", [
+            "MatchSequence", "", ",", " ", "MatchSequence"
+        ])
+
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_sequence_empty_round_parens(self):
+        source = dedent("""\
+            match x:
+                case ( ):
+                    print(x)
+        """)
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSequence")
+        checker.check_children("MatchSequence", ["( )"])
+
+    @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_sequence_empty_square_parens(self):
+        source = dedent("""\
+            match x:
+                case []:
+                    print(x)
+        """)
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSequence")
+        checker.check_children("MatchSequence", ["[]"])
+
+    @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_sequence_with_star_and_value(self):
         source = dedent("""\
             match x:

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1426,13 +1426,11 @@ class PatchedASTTest(unittest.TestCase):
 
     @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_or(self):
-        source = dedent(
-            """\
+        source = dedent("""\
             match x:
                 case 'v'|'z':
                     print(x)
-        """
-        )
+        """)
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         self.assert_single_case_match_block(checker, "MatchOr")
@@ -1440,13 +1438,11 @@ class PatchedASTTest(unittest.TestCase):
 
     @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_singleton_true(self):
-        source = dedent(
-            """\
+        source = dedent("""\
             match x:
                 case True:
                     print(x)
-        """
-        )
+        """)
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         self.assert_single_case_match_block(checker, "MatchSingleton")
@@ -1454,13 +1450,11 @@ class PatchedASTTest(unittest.TestCase):
 
     @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_singleton_none(self):
-        source = dedent(
-            """\
+        source = dedent("""\
             match x:
                 case None:
                     print(x)
-        """
-        )
+        """)
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         self.assert_single_case_match_block(checker, "MatchSingleton")
@@ -1468,13 +1462,11 @@ class PatchedASTTest(unittest.TestCase):
 
     @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_sequence_with_star_wildcard(self):
-        source = dedent(
-            """\
+        source = dedent("""\
             match x:
                 case [*_]:
                     print(x)
-        """
-        )
+        """)
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         self.assert_single_case_match_block(checker, "MatchSequence")
@@ -1482,13 +1474,11 @@ class PatchedASTTest(unittest.TestCase):
 
     @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_sequence_with_tail_capture(self):
-        source = dedent(
-            """\
+        source = dedent("""\
             match x:
                 case [1, 2, *rest]:
                     print(rest)
-        """
-        )
+        """)
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         self.assert_single_case_match_block(checker, "MatchSequence")
@@ -1498,13 +1488,11 @@ class PatchedASTTest(unittest.TestCase):
 
     @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_sequence_with_star_and_value(self):
-        source = dedent(
-            """\
+        source = dedent("""\
             match x:
                 case [*_, "something"]:
                     print(x)
-        """
-        )
+        """)
         ast_frag = patchedast.get_patched_ast(source, True)
         checker = _ResultChecker(self, ast_frag)
         self.assert_single_case_match_block(checker, "MatchSequence")

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1529,6 +1529,21 @@ class PatchedASTTest(unittest.TestCase):
         ])
 
     @testutils.only_for_versions_higher("3.10")
+    def test_match_node_with_match_sequence_with_spaces_around_parens(self):
+        source = dedent("""\
+            match x:
+                case (  1, 2
+            ):
+                    print(rest)
+        """)
+        ast_frag = patchedast.get_patched_ast(source, True)
+        checker = _ResultChecker(self, ast_frag)
+        self.assert_single_case_match_block(checker, "MatchSequence")
+        checker.check_children("MatchSequence", [
+            "(", "  ", "MatchValue", "", ",", " ", "MatchValue", "\n", ")",
+        ])
+
+    @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_sequence_with_internal_parens(self):
         source = dedent("""\
             match x:


### PR DESCRIPTION
# Description

Handle various corner cases around MatchSequence. It's complicated by the fact that the MatchSequence syntax allows multiple kinds of parentheses and even no parentheses and the ast doesn't give us any clue which is being used.

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
