### PR TITLE
patchedast: raise MismatchedTokenError instead of AttributeError

### DIFF
--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -983,6 +983,18 @@ class _Source:
             if end is None:
                 end = len(self.source)
             match = repattern.search(self.source, self.offset, end)
+            if match is None:
+                # `re.search` returns None when nothing matches in the
+                # requested range, and calling `.group()` on it raised a
+                # bare AttributeError that says nothing about where the
+                # walker lost track.
+                #
+                # `consume()` already reports this situation as a
+                # MismatchedTokenError with a source location; do the
+                # same here so callers see one failure mode, not two.
+                raise MismatchedTokenError(
+                    f"Pattern at {self._get_location()} cannot be matched"
+                )
             if self._good_token(match.group(), match.start()):
                 break
             else:

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1921,6 +1921,40 @@ class PatchedASTTest(unittest.TestCase):
             "Tuple",
         ])
 
+    def test_unparsable_string_region_raises_rope_error(self):
+        """Parentheses inside a triple-quoted string can desynchronise the
+        source walker; when that happens `_consume_pattern` used to call
+        `.group()` on a None match and raise a bare AttributeError.
+
+        Reduced from a real module (a SQL schema kept in a module-level
+        string). Removing the parentheses from the string makes it pass,
+        which is why they are part of the fixture.
+
+        This test does not claim the source becomes patchable — only that
+        the failure is reported as rope's own error, with a location,
+        instead of an AttributeError from deep inside the walker.
+        """
+        source = dedent("""\
+            def check_transition(src: str, dst: str) -> None:
+                    raise Refused(
+                        f"{src} - {dst} isn't a declared transition. "
+                        f"passing silently (#1848).")
+            SCHEMA = \"\"\"
+                -- called `move()
+                PRIMARY KEY (source_site, item_id)
+            \"\"\"
+            class Store:
+                def __init__(self, path: str | Path) -> None:
+                    self._conn.executescript(SCHEMA)
+                    entry["identified_at"] = p
+                def get(self, source_site: str, item_id: str) -> Optional[dict]:
+                        r
+        """)
+
+        with self.assertRaises(patchedast.MismatchedTokenError):
+            patchedast.get_patched_ast(source, True)
+
+
 
 class _ResultChecker:
     def __init__(self, test_case, ast):

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1938,7 +1938,7 @@ class PatchedASTTest(unittest.TestCase):
             def check_transition(src: str, dst: str) -> None:
                     raise Refused(
                         f"{src} - {dst} isn't a declared transition. "
-                        f"passing silently (#1848).")
+                        f"passing silently (#123).")
             SCHEMA = \"\"\"
                 -- called `move()
                 PRIMARY KEY (source_site, item_id)


### PR DESCRIPTION
## What happens today

`_Source._consume_pattern` calls `match.group()` without checking that `re.search` found anything:

```python
match = repattern.search(self.source, self.offset, end)
if self._good_token(match.group(), match.start()):
```

When it finds nothing, the failure surfaces as:

```
AttributeError: 'NoneType' object has no attribute 'group'
```

raised from inside the source walker, with nothing to say where in the file it lost track. I hit this while evaluating rope for bulk renames on a ~300-file codebase: one module out of eight failed this way, and the message gave me no starting point.

## What this changes

`consume()` already handles the same situation — no match for a token — by raising `MismatchedTokenError` with a source location. This makes `_consume_pattern` do the same, so callers see one failure mode instead of two, and the message points at the offending position.

## What it does *not* change

**It does not make the attached fixture patchable.** It only replaces an opaque crash with rope's own error.

The underlying desynchronisation is triggered by **parentheses inside a triple-quoted string** — removing `PRIMARY KEY (source_site, item_id)` from the fixture's string makes it parse fine, keeping everything else identical. That looks related to #499 ("patched_ast will set region[0] to None when unmatched parenthesis inside string"), though here the parentheses are balanced. I did not try to fix that part.

## The fixture

Reduced automatically from a real module (a SQL schema kept in a module-level string), then translated and re-checked at every step. Ingredients verified one at a time — non-ASCII characters, the apostrophe inside the f-string and the backtick in the SQL comment are all irrelevant; only the parentheses matter.

## Tests

- The new test fails on `master` with the original `AttributeError`, and passes with this change.
- Full suite: **2121 passed, 7 skipped, 5 xfailed** on Python 3.12.