### PR TITLE
pycore: don't stop source folder detection at the first package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - #853 Implement patchedast handlers TypeVar
 - #847 Avoid printing autoimport syntax errors (@yangfan-yf-yf)
 - #623, #819, #863 Support MatchOr, MatchSequence, MatchStar (@jheld, @lieryan)
+- #869 Fix source folder detection stopping at the first package
 - #870 Add default implementation for is_dir() (@lieryan)
 
 # Release 1.14.0

--- a/rope/base/pycore.py
+++ b/rope/base/pycore.py
@@ -146,16 +146,21 @@ class PyCore:
         )
 
     def _find_source_folders(self, folder):
-        for resource in folder.get_folders():
-            if self._is_package(resource):
-                return [folder]
         result = []
-        for resource in folder.get_files():
-            if resource.name.endswith(".py"):
-                result.append(folder)
-                break
-        for resource in folder.get_folders():
-            result.extend(self._find_source_folders(resource))
+        subfolders = folder.get_folders()
+        if any(self._is_package(resource) for resource in subfolders):
+            result.append(folder)
+        else:
+            for resource in folder.get_files():
+                if resource.name.endswith(".py"):
+                    result.append(folder)
+                    break
+        for resource in subfolders:
+            # Inside a package the subfolders are subpackages, not roots
+            # of their own -- descending would make `pkg.sub` importable
+            # as plain `sub`.
+            if not self._is_package(resource):
+                result.extend(self._find_source_folders(resource))
         return result
 
     def run_module(self, resource, args=None, stdin=None, stdout=None):

--- a/ropetest/projecttest.py
+++ b/ropetest/projecttest.py
@@ -618,6 +618,26 @@ class ProjectTest(unittest.TestCase):
         self.assertEqual(2, len(source_folders))
         self.assertTrue(self.project.root in source_folders and src in source_folders)
 
+    def test_multi_source_folders_with_a_package_at_the_root(self):
+        # A package sitting directly at the root used to end the search
+        # there, leaving every sibling folder unscanned -- so `src` was
+        # never a source folder and nothing under it could be resolved.
+        testutils.create_package(self.project, "rootpkg")
+        src = self.project.root.create_folder("src")
+        testutils.create_package(self.project, "package", src)
+        source_folders = self.project.get_source_folders()
+        self.assertEqual(2, len(source_folders))
+        self.assertTrue(self.project.root in source_folders and src in source_folders)
+
+    def test_a_subpackage_is_not_a_source_folder(self):
+        # Descending into a package would make `package.sub` importable
+        # as plain `sub`.
+        src = self.project.root.create_folder("src")
+        package = testutils.create_package(self.project, "package", src)
+        testutils.create_package(self.project, "sub", package)
+        source_folders = self.project.get_source_folders()
+        self.assertEqual([src], source_folders)
+
     def test_folder_is_pathlike(self):
         resource = self.project.root.create_folder("src")
         self.assertIsInstance(resource, Folder)


### PR DESCRIPTION
## The defect

`_find_source_folders` returns as soon as a folder has a package among its children:

```python
def _find_source_folders(self, folder):
    for resource in folder.get_folders():
        if self._is_package(resource):
            return [folder]          # every sibling folder goes unscanned
```

So on a project whose **root** holds a package, detection stops at the root and no other source folder is ever found.

## Why this looks like a defect rather than a design choice

Two existing tests already describe side-by-side roots:

| test | expects |
|---|---|
| `test_multi_source_folders` | `src` **and** `test` |
| `test_multi_source_folders2` | root **and** `src` |

Both pass today only because in their layouts no package sits *directly at the root*, so the early return never fires. Multi-root detection is clearly intended; the early return silently disables it for any repository that grew a package at its top level.

## Why it matters

The consequence is silent, which is the worst part. Imports that would resolve through the unscanned folders simply do not resolve, so `Rename` skips those occurrences rather than reporting them — a repository-wide rename comes back having quietly renamed a subset. There is no error and no `unsure` occurrence to review.

## The change

Apply the same rule at every level instead of stopping at the first match, and skip package subfolders when recursing — descending into a package would make `package.sub` importable as plain `sub`.

Two tests added. The first fails on `master`; the second guards the subpackage boundary and passes either way.

## Measurements

On a real project whose root holds two packages with further code under `src/`:

| | before | after |
|---|---|---|
| source folders detected | 1 | 15 |
| `from pkg import mod` | unresolved | `src/pkg/mod.py` |
| a rename that was already correct | 3.2s | 17.0s |

`ropetest/`: 2122 passed, 7 skipped, 5 xfailed.

**On the cost, plainly:** this spends time where detection previously skipped work, so a project that gains source folders pays for analysing code that was invisible before. It is not overhead, but it is real, and on a project where the old single root was the right answer there is nothing to gain and time to lose. `source_folders` in the prefs still overrides detection for anyone who wants to narrow it back.

I measured a second case where the coverage actually changes — an occurrence resolving 0 of 2 references before and 2 of 2 after — but that rename needs #868 to run at all on this codebase, so I am not claiming it for this PR alone.

## Relation to #868

Independent, and based on `master`. #868 fixes the walker matching tokens inside string literals; this one fixes which folders are searched. Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5GqJKaXZzFzmFEYgo4pPR
