### PR TITLE
Add default implementation for is_dir()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - #853 Implement patchedast handlers TypeVar
 - #847 Avoid printing autoimport syntax errors (@yangfan-yf-yf)
 - #623, #819, #863 Support MatchOr, MatchSequence, MatchStar (@jheld, @lieryan)
+- #870 Add default implementation for is_dir() (@lieryan)
 
 # Release 1.14.0
 

--- a/rope/base/resources.py
+++ b/rope/base/resources.py
@@ -66,6 +66,7 @@ class Resource(os.PathLike):
 
     def is_dir(self):
         """Alias for `is_folder()`"""
+        return self.is_folder()
 
     def is_folder(self):
         """Return True if the resource is a Folder"""

--- a/ropetest/projecttest.py
+++ b/ropetest/projecttest.py
@@ -2,6 +2,7 @@ import os.path
 import pathlib
 import tempfile
 import unittest
+from unittest.mock import patch
 from textwrap import dedent
 
 from rope.base.exceptions import ResourceNotFoundError, RopeError
@@ -195,6 +196,12 @@ class ProjectTest(unittest.TestCase):
     def test_is_folder(self):
         self.assertTrue(self.project.get_resource(self.sample_folder).is_folder())
         self.assertTrue(not self.project.get_resource(self.sample_file).is_folder())
+
+    def test_is_dir(self):
+        with patch('rope.base.resources.Folder.is_folder') as is_folder1:
+            assert self.project.get_resource(self.sample_folder).is_dir() == is_folder1.return_value
+        with patch('rope.base.resources.File.is_folder') as is_folder2:
+            assert self.project.get_resource(self.sample_file).is_dir() == is_folder2.return_value
 
     def testget_children(self):
         children = self.project.get_resource(self.sample_folder).get_children()


### PR DESCRIPTION
# Description

is_dir() is the name used by os.PathLike interface, while is_folder() was the original name used by rope's Resource.

At some point, Resource became an implementor of os.PathLike but it never provided an implementation for is_dir().

# Checklist (delete if not relevant):

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated CHANGELOG.md
