### PR TITLE
Fix UTF-8 offsets in sequence patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # **Upcoming release**
 
+- Fix patched-AST sequence patterns containing non-ASCII text
 - #850 Update and pin black version in pre-commit and Github Actions
 - #851 Bump supported python version to up to Python 3.14
-- #852 Implement patchedast handlers for TypeAlias 
+- #852 Implement patchedast handlers for TypeAlias
 - #853 Implement patchedast handlers TypeVar
 - #847 Avoid printing autoimport syntax errors (@yangfan-yf-yf)
 - #623, #819, #863 Support MatchOr, MatchSequence, MatchStar (@jheld, @lieryan)

--- a/rope/refactor/patchedast.py
+++ b/rope/refactor/patchedast.py
@@ -813,27 +813,35 @@ class _PatchingASTWalker:
                 *closing_paren,
             ]
         else:
-            node_start = (node.lineno, node.col_offset)
-            node_end = (node.end_lineno, node.end_col_offset)
-            children = [self.lines[node_start:node_end]]
+            node_start = self._get_ast_offset(node.lineno, node.col_offset)
+            node_end = self._get_ast_offset(node.end_lineno, node.end_col_offset)
+            children = [self.source.source[node_start:node_end]]
         self._handle(node, children)
 
+    def _get_ast_offset(self, lineno, col_offset):
+        # AST columns count UTF-8 bytes; source slices count Unicode characters.
+        line = self.lines.get_line(lineno)
+        prefix = line.encode("utf-8")[:col_offset].decode("utf-8")
+        return self.lines.get_line_start(lineno) + len(prefix)
+
     def _get_surrounding_parens(self, node: ast.MatchSequence):
-        node_start = (node.lineno, node.col_offset)
-        first_pattern_start = (node.patterns[0].lineno, node.patterns[0].col_offset)
-        opening_paren = self.lines[node_start:first_pattern_start].strip()
+        node_start = self._get_ast_offset(node.lineno, node.col_offset)
+        first_pattern_start = self._get_ast_offset(
+            node.patterns[0].lineno, node.patterns[0].col_offset
+        )
+        opening_paren = self.source.source[node_start:first_pattern_start].strip()
         if opening_paren not in ["[", "(", ""]:
             warnings.warn(
                 f"Unexpected character in MatchSequence's opening_paren <{opening_paren}>; please report!",
                 RuntimeWarning,
             )
 
-        last_pattern_end = (
+        last_pattern_end = self._get_ast_offset(
             node.patterns[-1].end_lineno,
             node.patterns[-1].end_col_offset,
         )
-        node_end = (node.end_lineno, node.end_col_offset)
-        closing_paren = self.lines[last_pattern_end:node_end].strip()
+        node_end = self._get_ast_offset(node.end_lineno, node.end_col_offset)
+        closing_paren = self.source.source[last_pattern_end:node_end].strip()
         if closing_paren not in ["]", ")", ""]:
             warnings.warn(
                 f"Unexpected character in MatchSequence's closing_paren <{closing_paren}>; please report!",

--- a/ropetest/refactor/patchedasttest.py
+++ b/ropetest/refactor/patchedasttest.py
@@ -1558,6 +1558,29 @@ class PatchedASTTest(unittest.TestCase):
         ])
 
     @testutils.only_for_versions_higher("3.10")
+    def test_match_sequence_with_non_ascii_text(self):
+        patterns = [
+            "[é, y]",
+            "('你好', y)",
+            "['é', [x, y]]",
+            "['é', []]",
+            "['é', ()]",
+            "'é', [x, y]",
+            "[\n        'é', [x, y]\n    ]",
+        ]
+        for pattern in patterns:
+            with self.subTest(pattern=pattern):
+                source = f"match value:\n    case {pattern}:\n        pass\n"
+                ast_frag = patchedast.get_patched_ast(source, True)
+                self.assertEqual(source, patchedast.write_ast(ast_frag))
+                for node in ast.walk(ast_frag):
+                    if isinstance(node, ast.MatchSequence):
+                        self.assertEqual(
+                            ast.get_source_segment(source, node),
+                            source[node.region[0]:node.region[1]],
+                        )
+
+    @testutils.only_for_versions_higher("3.10")
     def test_match_node_with_match_sequence_empty_round_parens(self):
         source = dedent("""\
             match x:


### PR DESCRIPTION
# Description

I reproduced a crash on `master` (`f005ac786da7d556fdf5733e9b9ddae1eaf27242`) when patching a sequence pattern containing non-ASCII text:

```python
from rope.refactor import patchedast

source = "match value:\n    case [é, y]:\n        pass\n"
patchedast.get_patched_ast(source, True)
```

The walker reads `:` as the closing delimiter and raises `MismatchedTokenError`. Nested and empty sequence patterns after non-ASCII text are also affected, and some inputs produce incorrect source regions without raising.

AST columns are UTF-8 byte offsets, while the walker slices a Python string using character offsets. I convert the AST coordinates at the sequence-pattern slicing sites, including the empty-pattern path. The generic `SourceLinesAdapter` coordinate behavior is preserved.

The regression test covers seven patterns, including non-ASCII captures and literals, nested and empty sequences, bare sequences, and multiline input. It checks both source round-tripping and each sequence node's source region against `ast.get_source_segment`.

Related to #623; follows the sequence delimiter handling introduced in #863. Delimiter warnings for adjacent comments remain outside this change.

Validation on Windows / Python 3.12.14:

- All seven new regression scenarios fail before the fix and pass after it.
- Related modules: 311 passed, 10 skipped; seven subtests passed.
- Full suite: 2117 passed, 12 skipped, 5 xfailed; seven subtests passed.
- Target-file pre-commit checks and `git diff --check` pass.

# Checklist

- [x] I have added tests that prove my fix is effective.
- [x] I have updated CHANGELOG.md.

